### PR TITLE
chore: update documentation and jekyll config to reflect repository name change

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build with Jekyll
         run: |
           cd docs
-          bundle exec jekyll build --baseurl "/drizzle-neo-duckdb"
+          bundle exec jekyll build --baseurl "/drizzle-duckdb"
         env:
           JEKYLL_ENV: production
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@leonardovida-md/drizzle-neo-duckdb)](https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-[Documentation](https://leonardovida.github.io/drizzle-neo-duckdb/) • [LLM Context](https://leonardovida.github.io/drizzle-neo-duckdb/llms.txt) • [Examples](./example) • [Contributing](#contributing)
+[Documentation](https://leonardovida.github.io/drizzle-duckdb/) • [LLM Context](https://leonardovida.github.io/drizzle-duckdb/llms.txt) • [Examples](./example) • [Contributing](#contributing)
 
 </div>
 
@@ -155,7 +155,7 @@ const db = drizzle(pool);
 - DuckDB-specific helpers: `duckDbList`, `duckDbArray`, `duckDbStruct`, `duckDbMap`, `duckDbJson`, `duckDbBlob`, `duckDbInet`, `duckDbInterval`, `duckDbTimestamp`, `duckDbDate`, `duckDbTime`.
 - Browser-safe imports live under `@leonardovida-md/drizzle-neo-duckdb/helpers` (introspection emits this path).
 
-See the [column types](https://leonardovida.github.io/drizzle-neo-duckdb/api/columns) docs for full API.
+See the [column types](https://leonardovida.github.io/drizzle-duckdb/api/columns) docs for full API.
 
 ## Postgres Schema Compatibility
 
@@ -246,7 +246,7 @@ import { migrate } from '@leonardovida-md/drizzle-neo-duckdb';
 await migrate(db, { migrationsFolder: './drizzle' });
 ```
 
-Migration metadata is stored in `drizzle.__drizzle_migrations` by default. See [Migrations Documentation](https://leonardovida.github.io/drizzle-neo-duckdb/guide/migrations) for configuration options.
+Migration metadata is stored in `drizzle.__drizzle_migrations` by default. See [Migrations Documentation](https://leonardovida.github.io/drizzle-duckdb/guide/migrations) for configuration options.
 
 ## Schema Introspection
 
@@ -271,7 +271,7 @@ const result = await introspect(db, {
 console.log(result.files.schemaTs);
 ```
 
-See [Introspection Documentation](https://leonardovida.github.io/drizzle-neo-duckdb/guide/introspection) for all options.
+See [Introspection Documentation](https://leonardovida.github.io/drizzle-duckdb/guide/introspection) for all options.
 
 ## Configuration Options
 
@@ -307,7 +307,7 @@ This connector aims for compatibility with Drizzle's Postgres driver but has som
 | Streaming results     | Chunked reads via `executeBatches()` / `executeArrow()`; no cursor streaming |
 | Concurrent queries    | One query per connection; use pooling for parallelism                        |
 
-See [Limitations Documentation](https://leonardovida.github.io/drizzle-neo-duckdb/reference/limitations) for details.
+See [Limitations Documentation](https://leonardovida.github.io/drizzle-duckdb/reference/limitations) for details.
 
 ## Examples
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 title: Drizzle DuckDB
 description: DuckDB dialect for Drizzle ORM
 url: https://leonardovida.github.io
-baseurl: /drizzle-neo-duckdb
+baseurl: /drizzle-duckdb
 
 theme: just-the-docs
 remote_theme: just-the-docs/just-the-docs@v0.10.0
@@ -40,7 +40,7 @@ footer_content: 'Released under the Apache 2.0 License. Copyright 2025-present.'
 
 # External links
 aux_links:
-  GitHub: https://github.com/leonardovida/drizzle-neo-duckdb
+  GitHub: https://github.com/leonardovida/drizzle-duckdb
   npm: https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb
 aux_links_new_tab: true
 

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -23,7 +23,7 @@
 
     const link = document.createElement('a');
     link.href =
-      'https://raw.githubusercontent.com/leonardovida/drizzle-neo-duckdb/main/docs/' +
+      'https://raw.githubusercontent.com/leonardovida/drizzle-duckdb/main/docs/' +
       pagePath;
     link.target = '_blank';
     link.rel = 'noopener';

--- a/docs/examples/analytics-dashboard.md
+++ b/docs/examples/analytics-dashboard.md
@@ -9,7 +9,7 @@ nav_order: 1
 
 This example shows an analytics dashboard with multi-table schemas, DuckDB-specific types, transactions, and analytical queries.
 
-**Source**: [example/analytics-dashboard.ts](https://github.com/leonardovida-md/drizzle-neo-duckdb/blob/main/example/analytics-dashboard.ts)
+**Source**: [example/analytics-dashboard.ts](https://github.com/leonardovida/drizzle-duckdb/blob/main/example/analytics-dashboard.ts)
 
 ## Features Demonstrated
 
@@ -335,8 +335,8 @@ const preferencesAnalysis = await db.execute(sql`
 
 ```bash
 # Clone and install
-git clone https://github.com/leonardovida-md/drizzle-neo-duckdb.git
-cd drizzle-neo-duckdb
+git clone https://github.com/leonardovida/drizzle-duckdb.git
+cd drizzle-duckdb
 bun install
 
 # Run the example

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -60,8 +60,8 @@ All examples are located in the `/example` directory of the repository.
 1. Clone the repository:
 
    ```bash
-   git clone https://github.com/leonardovida-md/drizzle-neo-duckdb.git
-   cd drizzle-neo-duckdb
+   git clone https://github.com/leonardovida/drizzle-duckdb.git
+   cd drizzle-duckdb
    ```
 
 2. Install dependencies:

--- a/docs/examples/motherduck-nyc-taxi.md
+++ b/docs/examples/motherduck-nyc-taxi.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 This example demonstrates Drizzle DuckDB with MotherDuck cloud database, querying NYC taxi sample data.
 
-**Source**: [example/motherduck-nyc-taxi.ts](https://github.com/leonardovida-md/drizzle-neo-duckdb/blob/main/example/motherduck-nyc-taxi.ts)
+**Source**: [example/motherduck-nyc-taxi.ts](https://github.com/leonardovida/drizzle-duckdb/blob/main/example/motherduck-nyc-taxi.ts)
 
 ## Features Demonstrated
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -73,7 +73,7 @@ const allUsers = await db.select().from(users);
 
 ## Resources
 
-- [GitHub Repository](https://github.com/leonardovida-md/drizzle-neo-duckdb)
+- [GitHub Repository](https://github.com/leonardovida/drizzle-duckdb)
 - [npm Package](https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb)
 - [DuckDB Documentation](https://duckdb.org/docs/)
 - [Drizzle ORM Documentation](https://orm.drizzle.team/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ nav_exclude: true
 DuckDB dialect for Drizzle ORM with full TypeScript inference, DuckDB-native types, and Postgres-compatible schema definitions.
 
 [Get Started]({{ '/getting-started/' | relative_url }}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
-[View on GitHub](https://github.com/leonardovida/drizzle-neo-duckdb){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
+[View on GitHub](https://github.com/leonardovida/drizzle-duckdb){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [LLM Context (llms.txt)]({{ '/llms.txt' | relative_url }}){: .btn .fs-5 .mb-4 .mb-md-0 }
 
 ---

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -47,10 +47,10 @@ const allUsers = await db.select().from(users);
 
 ## Documentation
 
-- Getting Started: /drizzle-neo-duckdb/getting-started/
-- Core Concepts: /drizzle-neo-duckdb/core/
-- API Reference: /drizzle-neo-duckdb/api/
-- Examples: /drizzle-neo-duckdb/examples/
+- Getting Started: /drizzle-duckdb/getting-started/
+- Core Concepts: /drizzle-duckdb/core/
+- API Reference: /drizzle-duckdb/api/
+- Examples: /drizzle-duckdb/examples/
 
 ## DuckDB-Specific Column Types
 
@@ -110,8 +110,8 @@ const db = drizzle(connection);
 
 ## Links
 
-- GitHub: https://github.com/leonardovida/drizzle-neo-duckdb
+- GitHub: https://github.com/leonardovida/drizzle-duckdb
 - npm: https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb
-- Documentation: https://leonardovida.github.io/drizzle-neo-duckdb/
+- Documentation: https://leonardovida.github.io/drizzle-duckdb/
 - DuckDB: https://duckdb.org/
 - Drizzle ORM: https://orm.drizzle.team/

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/leonardovida-md/drizzle-neo-duckdb.git"
+    "url": "git+https://github.com/leonardovida/drizzle-duckdb.git"
   },
   "exports": {
     ".": {
@@ -72,9 +72,9 @@
   "author": "M L",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/leonardovida-md/drizzle-neo-duckdb/issues"
+    "url": "https://github.com/leonardovida/drizzle-duckdb/issues"
   },
-  "homepage": "https://github.com/leonardovida-md/drizzle-neo-duckdb#readme",
+  "homepage": "https://github.com/leonardovida/drizzle-duckdb#readme",
   "files": [
     "src/**/*.ts",
     "dist/*.mjs",


### PR DESCRIPTION
Docs website is currently broken. This should fix it, although you may have to re-configure the environment/GH pages settings first if you haven't already.