### PR TITLE
Add DuckLake support

### DIFF
--- a/docs/core/connection.md
+++ b/docs/core/connection.md
@@ -29,6 +29,14 @@ const db = await drizzle({
     options: { motherduck_token: process.env.MOTHERDUCK_TOKEN },
   },
 });
+
+// DuckLake catalog attach
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    attachOptions: { dataPath: './ducklake-data' },
+  },
+});
 ```
 
 This creates a connection pool automatically, which is critical for MotherDuck performance (see [Connection Pooling](#connection-pooling)).
@@ -77,6 +85,38 @@ const db = await drizzle({
 ```
 
 See the [MotherDuck guide](/integrations/motherduck) for more details.
+
+## DuckLake
+
+Attach a DuckLake catalog during connection setup:
+
+```typescript
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    attachOptions: {
+      dataPath: './ducklake-data',
+      createIfNotExists: true,
+    },
+  },
+});
+```
+
+For MotherDuck, use the DuckLake metadata catalog created by `CREATE DATABASE ... TYPE DUCKLAKE`:
+
+```typescript
+const db = await drizzle({
+  connection: {
+    path: 'md:',
+    options: { motherduck_token: process.env.MOTHERDUCK_TOKEN },
+  },
+  ducklake: {
+    catalog: 'md:__ducklake_metadata_my_lake',
+  },
+});
+```
+
+See the [DuckLake guide](/integrations/ducklake) for details.
 
 ## With Logging
 

--- a/docs/examples/ducklake-local.md
+++ b/docs/examples/ducklake-local.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: DuckLake Local Catalog
+parent: Examples
+nav_order: 3
+---
+
+# DuckLake Local Catalog Example
+
+This example attaches a local DuckLake catalog backed by a DuckDB file and writes a small table.
+
+**Source**: [example/ducklake-local.ts](https://github.com/leonardovida/drizzle-duckdb/blob/main/example/ducklake-local.ts)
+
+## Run the Example
+
+```bash
+bun run example/ducklake-local.ts
+```
+
+## What It Demonstrates
+
+- DuckLake catalog attach via the `ducklake` config
+- Data path configuration for DuckLake tables
+- Basic insert and select workflow
+
+## Key Snippet
+
+```typescript
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    install: true,
+    load: true,
+    attachOptions: {
+      dataPath: './ducklake-data',
+      createIfNotExists: true,
+    },
+  },
+});
+```

--- a/docs/examples/ducklake-motherduck.md
+++ b/docs/examples/ducklake-motherduck.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: DuckLake MotherDuck
+parent: Examples
+nav_order: 4
+---
+
+# DuckLake MotherDuck Example
+
+This example attaches a DuckLake catalog hosted on MotherDuck and writes a small table.
+
+**Source**: [example/ducklake-motherduck.ts](https://github.com/leonardovida/drizzle-duckdb/blob/main/example/ducklake-motherduck.ts)
+
+## Prerequisites
+
+- A MotherDuck account and service token
+- A DuckLake database created in MotherDuck, for example `CREATE DATABASE my_lake TYPE DUCKLAKE;`
+
+## Run the Example
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+export DUCKLAKE_MOTHERDUCK_DB=my_lake
+bun run example/ducklake-motherduck.ts
+```
+
+## What It Demonstrates
+
+- DuckLake catalog attach using MotherDuck metadata
+- Basic insert and select workflow
+
+## Key Snippet
+
+```typescript
+const db = await drizzle({
+  connection: {
+    path: 'md:',
+    options: { motherduck_token: process.env.MOTHERDUCK_TOKEN },
+  },
+  ducklake: {
+    catalog: 'md:__ducklake_metadata_my_lake',
+  },
+});
+```

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -51,6 +51,39 @@ export MOTHERDUCK_TOKEN=your_token_here
 bun example/motherduck-nyc-taxi.ts
 ```
 
+### [DuckLake Local Catalog]({{ '/examples/ducklake-local' | relative_url }})
+
+Local DuckLake example featuring:
+
+- DuckLake catalog attach
+- Data path configuration
+- Basic table creation and inserts
+
+**Best for**: Getting started with DuckLake on local storage.
+
+Run locally:
+
+```bash
+bun example/ducklake-local.ts
+```
+
+### [DuckLake MotherDuck]({{ '/examples/ducklake-motherduck' | relative_url }})
+
+DuckLake on MotherDuck example featuring:
+
+- DuckLake catalog attach using MotherDuck metadata
+- Basic table creation and inserts
+
+**Best for**: DuckLake on MotherDuck catalogs.
+
+Run with MotherDuck:
+
+```bash
+export MOTHERDUCK_TOKEN=your_token_here
+export DUCKLAKE_MOTHERDUCK_DB=my_lake
+bun example/ducklake-motherduck.ts
+```
+
 ## Running Examples
 
 All examples are located in the `/example` directory of the repository.
@@ -74,6 +107,9 @@ All examples are located in the `/example` directory of the repository.
 ```bash
 # Run the analytics dashboard example
 bun run example/analytics-dashboard.ts
+
+# Run the DuckLake local example
+bun run example/ducklake-local.ts
 ```
 
 ### MotherDuck Examples
@@ -84,6 +120,10 @@ export MOTHERDUCK_TOKEN=your_token_here
 
 # Run the NYC taxi example
 bun run example/motherduck-nyc-taxi.ts
+
+# Run the DuckLake MotherDuck example
+export DUCKLAKE_MOTHERDUCK_DB=my_lake
+bun run example/ducklake-motherduck.ts
 ```
 
 ## Example Structure

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,7 @@ DuckDB dialect for Drizzle ORM with full TypeScript inference, DuckDB-native typ
 | **DuckDB Native**       | Native support for DuckDB types like STRUCT, MAP, LIST, and JSON. Works with local files and MotherDuck. |
 | **Fast Analytics**      | Leverage DuckDB's analytical engine for blazing fast queries on large datasets.                          |
 | **Postgres Compatible** | Built on Drizzle's Postgres driver. Use familiar schema definitions and query patterns.                  |
+| **DuckLake Ready**      | Attach DuckLake catalogs for lakehouse storage with local files or MotherDuck.                           |
 
 ---
 

--- a/docs/integrations/ducklake.md
+++ b/docs/integrations/ducklake.md
@@ -60,7 +60,10 @@ If you have a direct connection, call `configureDuckLake` before using Drizzle:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { configureDuckLake, drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import {
+  configureDuckLake,
+  drizzle,
+} from '@leonardovida-md/drizzle-neo-duckdb';
 
 const instance = await DuckDBInstance.create(':memory:');
 const connection = await instance.connect();

--- a/docs/integrations/ducklake.md
+++ b/docs/integrations/ducklake.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: DuckLake
+parent: Integrations
+nav_order: 4
+---
+
+# DuckLake
+
+DuckLake stores DuckDB tables on object storage while keeping metadata in a catalog. Drizzle DuckDB can attach a DuckLake catalog during connection setup.
+
+## Local DuckLake Catalog
+
+Create a DuckLake catalog backed by a local DuckDB file and point data to a directory:
+
+```typescript
+import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    attachOptions: {
+      dataPath: './ducklake-data',
+      createIfNotExists: true,
+    },
+  },
+});
+```
+
+## MotherDuck DuckLake
+
+Create a DuckLake database in MotherDuck, then attach its metadata catalog:
+
+```sql
+CREATE DATABASE my_lake TYPE DUCKLAKE;
+```
+
+```typescript
+import { DuckDBInstance } from '@duckdb/node-api';
+import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+
+const db = await drizzle({
+  connection: {
+    path: 'md:',
+    options: { motherduck_token: process.env.MOTHERDUCK_TOKEN },
+  },
+  ducklake: {
+    catalog: 'md:__ducklake_metadata_my_lake',
+  },
+});
+```
+
+## Pooling Guidance
+
+DuckLake catalogs stored in a DuckDB file are single client only. When a local catalog is detected, `drizzle()` defaults to a single connection pool size of 1. You can override this with `pool`, but it can cause write conflicts.
+
+## Manual Setup
+
+If you have a direct connection, call `configureDuckLake` before using Drizzle:
+
+```typescript
+import { DuckDBInstance } from '@duckdb/node-api';
+import { configureDuckLake, drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+
+const instance = await DuckDBInstance.create(':memory:');
+const connection = await instance.connect();
+
+await configureDuckLake(connection, {
+  catalog: './ducklake.duckdb',
+  attachOptions: { dataPath: './ducklake-data' },
+});
+
+const db = drizzle(connection);
+```
+
+## Limitations
+
+DuckLake only supports `NOT NULL` constraints. Primary keys, foreign keys, unique constraints, and indexes are not supported. Avoid relying on those features in migrations or schema design.

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -14,4 +14,5 @@ Framework and platform-specific guides for using Drizzle DuckDB.
 
 - [Next.js]({{ '/integrations/nextjs' | relative_url }}) - Server Components, API Routes, and Server Actions
 - [MotherDuck]({{ '/integrations/motherduck' | relative_url }}) - Cloud-hosted DuckDB
+- [DuckLake]({{ '/integrations/ducklake' | relative_url }}) - DuckLake catalog setup
 - [Bun]({{ '/integrations/bun' | relative_url }}) - Recommended runtime for Drizzle DuckDB

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -38,6 +38,7 @@ const allUsers = await db.select().from(users);
 - Array query helpers: duckDbArrayContains, duckDbArrayContained, duckDbArrayOverlaps
 - Migrations and schema introspection
 - MotherDuck cloud support
+- DuckLake catalog attach support
 
 ## Important Notes
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -210,6 +210,33 @@ const pool = createDuckDBConnectionPool(instance, {
 const db = drizzle(pool);
 ```
 
+### ducklake
+
+Attach a DuckLake catalog when creating a connection with `drizzle()`.
+
+```typescript
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    attachOptions: {
+      dataPath: './ducklake-data',
+      createIfNotExists: true,
+    },
+  },
+});
+```
+
+Options:
+
+- `catalog` string. Required. The catalog value after the `ducklake:` prefix.
+- `alias` string. Optional. Defaults to `ducklake`.
+- `use` boolean. Optional. Defaults to `true`.
+- `install` boolean. Optional. Defaults to `false`.
+- `load` boolean. Optional. Defaults to `false`.
+- `attachOptions` object with fields `createIfNotExists`, `dataInliningRowLimit`, `dataPath`, `encrypted`, `metaParameterName`, `metadataCatalog`, `overrideDataPath`, and `readOnly`.
+
+When the DuckLake catalog is a local DuckDB file, `drizzle()` defaults to a single connection pool size of 1. You can override this with `pool`, but it can cause write conflicts.
+
 ## migrate() Options
 
 The `migrate()` function accepts either a string path or configuration object:

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -50,6 +50,21 @@ const instance = await DuckDBInstance.create('md:', {
 
 See the [MotherDuck guide]({{ '/integrations/motherduck' | relative_url }}) for details.
 
+### Does it work with DuckLake?
+
+Yes. Use the `ducklake` config to attach a DuckLake catalog:
+
+```typescript
+const db = await drizzle(':memory:', {
+  ducklake: {
+    catalog: './ducklake.duckdb',
+    attachOptions: { dataPath: './ducklake-data' },
+  },
+});
+```
+
+DuckLake supports `NOT NULL` constraints only. Primary keys, foreign keys, unique constraints, check constraints, and indexes are not supported.
+
 ### What about DuckDB WASM (browser)?
 
 Currently, this package only supports `@duckdb/node-api` (Node.js). Browser support via DuckDB WASM is not available.

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -114,6 +114,10 @@ If your runtime exposes an Arrow/columnar API, `db.executeArrow()` will return i
 
 DuckDB executes a single query at a time per connection. Without pooling, concurrent requests will serialize. The async `drizzle()` entrypoints auto-create a pool (default size: 4); configure size/presets with the `pool` option or use `createDuckDBConnectionPool` for timeouts, queue limits, and recycling.
 
+## DuckLake Limitations
+
+DuckLake supports `NOT NULL` constraints only. Primary keys, foreign keys, unique constraints, check constraints, and indexes are not supported. Avoid relying on those features when using DuckLake catalogs.
+
 ### Column Alias Deduplication
 
 When selecting the same column multiple times (e.g., in multi-join queries), duplicate aliases are automatically suffixed to avoid collisions:

--- a/example/ducklake-local.ts
+++ b/example/ducklake-local.ts
@@ -1,0 +1,54 @@
+/**
+ * DuckLake Local Catalog Example
+ *
+ * This example shows how to attach a local DuckLake catalog and write data.
+ *
+ * Run with:
+ *   bun run example/ducklake-local.ts
+ */
+
+import { sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from '../src/index.ts';
+
+const users = pgTable('ducklake_users', {
+  id: integer('id'),
+  name: text('name').notNull(),
+});
+
+async function main() {
+  const db = await drizzle(':memory:', {
+    ducklake: {
+      catalog: './ducklake.duckdb',
+      install: true,
+      load: true,
+      attachOptions: {
+        dataPath: './ducklake-data',
+        createIfNotExists: true,
+      },
+    },
+  });
+
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS ducklake_users (
+        id INTEGER,
+        name TEXT NOT NULL
+      )
+    `);
+
+    await db
+      .insert(users)
+      .values([{ id: 1, name: 'Ada' }, { id: 2, name: 'Grace' }]);
+
+    const rows = await db.select().from(users).orderBy(users.id);
+    console.table(rows);
+  } finally {
+    await db.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/example/ducklake-local.ts
+++ b/example/ducklake-local.ts
@@ -37,9 +37,10 @@ async function main() {
       )
     `);
 
-    await db
-      .insert(users)
-      .values([{ id: 1, name: 'Ada' }, { id: 2, name: 'Grace' }]);
+    await db.insert(users).values([
+      { id: 1, name: 'Ada' },
+      { id: 2, name: 'Grace' },
+    ]);
 
     const rows = await db.select().from(users).orderBy(users.id);
     console.table(rows);

--- a/example/ducklake-motherduck.ts
+++ b/example/ducklake-motherduck.ts
@@ -1,0 +1,68 @@
+/**
+ * DuckLake MotherDuck Example
+ *
+ * This example attaches a DuckLake catalog hosted on MotherDuck.
+ *
+ * Prerequisites:
+ * - Set MOTHERDUCK_TOKEN
+ * - Create a DuckLake database in MotherDuck, for example:
+ *   CREATE DATABASE my_lake TYPE DUCKLAKE;
+ * - Set DUCKLAKE_MOTHERDUCK_DB to the database name (for example: my_lake)
+ *
+ * Run with:
+ *   MOTHERDUCK_TOKEN=token DUCKLAKE_MOTHERDUCK_DB=my_lake bun run example/ducklake-motherduck.ts
+ */
+
+import { sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { drizzle } from '../src/index.ts';
+
+const users = pgTable('ducklake_users', {
+  id: integer('id'),
+  name: text('name').notNull(),
+});
+
+async function main() {
+  const motherduckToken = process.env.MOTHERDUCK_TOKEN;
+  const ducklakeDb = process.env.DUCKLAKE_MOTHERDUCK_DB;
+
+  if (!motherduckToken || !ducklakeDb) {
+    console.error(
+      'Set MOTHERDUCK_TOKEN and DUCKLAKE_MOTHERDUCK_DB before running this example.'
+    );
+    process.exit(1);
+  }
+
+  const db = await drizzle({
+    connection: {
+      path: 'md:',
+      options: { motherduck_token: motherduckToken },
+    },
+    ducklake: {
+      catalog: `md:__ducklake_metadata_${ducklakeDb}`,
+    },
+  });
+
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS ducklake_users (
+        id INTEGER,
+        name TEXT NOT NULL
+      )
+    `);
+
+    await db
+      .insert(users)
+      .values([{ id: 1, name: 'Quinn' }, { id: 2, name: 'Riley' }]);
+
+    const rows = await db.select().from(users).orderBy(users.id);
+    console.table(rows);
+  } finally {
+    await db.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/example/ducklake-motherduck.ts
+++ b/example/ducklake-motherduck.ts
@@ -51,9 +51,10 @@ async function main() {
       )
     `);
 
-    await db
-      .insert(users)
-      .values([{ id: 1, name: 'Quinn' }, { id: 2, name: 'Riley' }]);
+    await db.insert(users).values([
+      { id: 1, name: 'Quinn' },
+      { id: 2, name: 'Riley' },
+    ]);
 
     const rows = await db.select().from(users).orderBy(users.id);
     console.table(rows);

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -165,7 +165,13 @@ function createFromClient<
   });
   const session = driver.createSession(schema);
 
-  const db = new DuckDBDatabase(dialect, session, schema, finalClient, instance);
+  const db = new DuckDBDatabase(
+    dialect,
+    session,
+    schema,
+    finalClient,
+    instance
+  );
   return db as DuckDBDatabase<TSchema, ExtractTablesWithRelations<TSchema>>;
 }
 

--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -179,10 +179,9 @@ export function wrapDuckLakePool(
   config: DuckLakeConfig
 ): DuckDBConnectionPool {
   const configuredConnections = new WeakSet<DuckDBConnection>();
+  const poolWithSize = pool as unknown as { size?: number };
   const size =
-    'size' in (pool as Record<string, unknown>)
-      ? (pool as unknown as { size: number }).size
-      : undefined;
+    typeof poolWithSize.size === 'number' ? poolWithSize.size : undefined;
 
   const wrapped: DuckDBConnectionPool & { size?: number } = {
     async acquire() {

--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -1,6 +1,10 @@
 import type { DuckDBConnection } from '@duckdb/node-api';
 import type { DuckDBConnectionPool } from './client.ts';
-import { resolvePoolSize, type DuckDBPoolConfig, type PoolPreset } from './pool.ts';
+import {
+  resolvePoolSize,
+  type DuckDBPoolConfig,
+  type PoolPreset,
+} from './pool.ts';
 
 export interface DuckLakeAttachOptions {
   createIfNotExists?: boolean;
@@ -111,9 +115,7 @@ export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
       options.push(`DATA_PATH=${optionValueToSql(attachOptions.dataPath)}`);
     }
     if (attachOptions.encrypted !== undefined) {
-      options.push(
-        `ENCRYPTED=${optionValueToSql(attachOptions.encrypted)}`
-      );
+      options.push(`ENCRYPTED=${optionValueToSql(attachOptions.encrypted)}`);
     }
     if (attachOptions.metaParameterName) {
       options.push(
@@ -124,16 +126,12 @@ export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
     }
     if (attachOptions.metadataCatalog) {
       options.push(
-        `METADATA_CATALOG=${optionValueToSql(
-          attachOptions.metadataCatalog
-        )}`
+        `METADATA_CATALOG=${optionValueToSql(attachOptions.metadataCatalog)}`
       );
     }
     if (attachOptions.overrideDataPath !== undefined) {
       options.push(
-        `OVERRIDE_DATA_PATH=${optionValueToSql(
-          attachOptions.overrideDataPath
-        )}`
+        `OVERRIDE_DATA_PATH=${optionValueToSql(attachOptions.overrideDataPath)}`
       );
     }
     if (attachOptions.readOnly !== undefined) {
@@ -219,7 +217,11 @@ export function isDuckDbFileCatalog(catalog: string): boolean {
   if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return true;
   if (trimmed.startsWith('md:')) return false;
   if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) return false;
-  if (/^(postgres|postgresql|mysql|mariadb|sqlite|snowflake|bigquery):/i.test(trimmed)) {
+  if (
+    /^(postgres|postgresql|mysql|mariadb|sqlite|snowflake|bigquery):/i.test(
+      trimmed
+    )
+  ) {
     return false;
   }
 
@@ -244,8 +246,7 @@ export function resolveDuckLakePoolSize(
     ducklakeConfig !== undefined
       ? isDuckDbFileCatalog(normalizeDuckLakeConfig(ducklakeConfig).catalog)
       : false;
-  const poolSize =
-    !hasPoolSetting && isLocalCatalog ? 1 : resolvedPoolSize;
+  const poolSize = !hasPoolSetting && isLocalCatalog ? 1 : resolvedPoolSize;
 
   return {
     poolSize,

--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -1,0 +1,256 @@
+import type { DuckDBConnection } from '@duckdb/node-api';
+import type { DuckDBConnectionPool } from './client.ts';
+import { resolvePoolSize, type DuckDBPoolConfig, type PoolPreset } from './pool.ts';
+
+export interface DuckLakeAttachOptions {
+  createIfNotExists?: boolean;
+  dataInliningRowLimit?: number;
+  dataPath?: string;
+  encrypted?: boolean;
+  metaParameterName?: string;
+  metadataCatalog?: string;
+  overrideDataPath?: boolean;
+  readOnly?: boolean;
+}
+
+export interface DuckLakeConfig {
+  catalog: string;
+  alias?: string;
+  use?: boolean;
+  install?: boolean;
+  load?: boolean;
+  attachOptions?: DuckLakeAttachOptions;
+}
+
+export interface NormalizedDuckLakeConfig {
+  catalog: string;
+  alias: string;
+  use: boolean;
+  install: boolean;
+  load: boolean;
+  attachOptions?: DuckLakeAttachOptions;
+}
+
+export interface DuckLakePoolResolution {
+  poolSize: number | false;
+  resolvedPoolSize: number | false;
+  isLocalCatalog: boolean;
+  hasPoolSetting: boolean;
+}
+
+const DEFAULT_ALIAS = 'ducklake';
+
+function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function quoteString(value: string): string {
+  return `'${escapeSqlString(value)}'`;
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function isDuckLakeUri(catalog: string): boolean {
+  return catalog.startsWith('ducklake:');
+}
+
+export function normalizeDuckLakeConfig(
+  config: DuckLakeConfig
+): NormalizedDuckLakeConfig {
+  if (!config.catalog) {
+    throw new Error('DuckLake config requires a catalog');
+  }
+
+  const catalog = isDuckLakeUri(config.catalog)
+    ? config.catalog
+    : `ducklake:${config.catalog}`;
+
+  return {
+    catalog,
+    alias: config.alias?.trim() || DEFAULT_ALIAS,
+    use: config.use ?? true,
+    install: config.install ?? false,
+    load: config.load ?? false,
+    attachOptions: config.attachOptions,
+  };
+}
+
+function optionValueToSql(value: string | number | boolean): string {
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false';
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? String(value) : '0';
+  }
+  return quoteString(value);
+}
+
+export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
+  const normalized = normalizeDuckLakeConfig(config);
+  const options: string[] = [];
+  const attachOptions = normalized.attachOptions;
+
+  if (attachOptions) {
+    if (attachOptions.createIfNotExists !== undefined) {
+      options.push(
+        `CREATE_IF_NOT_EXISTS=${optionValueToSql(
+          attachOptions.createIfNotExists
+        )}`
+      );
+    }
+    if (attachOptions.dataInliningRowLimit !== undefined) {
+      options.push(
+        `DATA_INLINING_ROW_LIMIT=${optionValueToSql(
+          attachOptions.dataInliningRowLimit
+        )}`
+      );
+    }
+    if (attachOptions.dataPath) {
+      options.push(`DATA_PATH=${optionValueToSql(attachOptions.dataPath)}`);
+    }
+    if (attachOptions.encrypted !== undefined) {
+      options.push(
+        `ENCRYPTED=${optionValueToSql(attachOptions.encrypted)}`
+      );
+    }
+    if (attachOptions.metaParameterName) {
+      options.push(
+        `META_PARAMETER_NAME=${optionValueToSql(
+          attachOptions.metaParameterName
+        )}`
+      );
+    }
+    if (attachOptions.metadataCatalog) {
+      options.push(
+        `METADATA_CATALOG=${optionValueToSql(
+          attachOptions.metadataCatalog
+        )}`
+      );
+    }
+    if (attachOptions.overrideDataPath !== undefined) {
+      options.push(
+        `OVERRIDE_DATA_PATH=${optionValueToSql(
+          attachOptions.overrideDataPath
+        )}`
+      );
+    }
+    if (attachOptions.readOnly !== undefined) {
+      options.push(`READ_ONLY=${optionValueToSql(attachOptions.readOnly)}`);
+    }
+  }
+
+  const attachSql = [
+    `ATTACH ${quoteString(normalized.catalog)} AS ${quoteIdentifier(
+      normalized.alias
+    )}`,
+  ];
+
+  if (options.length > 0) {
+    attachSql.push(`(${options.join(', ')})`);
+  }
+
+  return attachSql.join(' ');
+}
+
+export async function configureDuckLake(
+  connection: DuckDBConnection,
+  config: DuckLakeConfig
+): Promise<void> {
+  const normalized = normalizeDuckLakeConfig(config);
+
+  if (normalized.install) {
+    await connection.run('INSTALL ducklake');
+  }
+
+  if (normalized.load) {
+    await connection.run('LOAD ducklake');
+  }
+
+  const attachSql = buildDuckLakeAttachSql(normalized);
+  await connection.run(attachSql);
+
+  if (normalized.use) {
+    await connection.run(`USE ${quoteIdentifier(normalized.alias)}`);
+  }
+}
+
+export function wrapDuckLakePool(
+  pool: DuckDBConnectionPool,
+  config: DuckLakeConfig
+): DuckDBConnectionPool {
+  const configuredConnections = new WeakSet<DuckDBConnection>();
+  const size =
+    'size' in (pool as Record<string, unknown>)
+      ? (pool as unknown as { size: number }).size
+      : undefined;
+
+  const wrapped: DuckDBConnectionPool & { size?: number } = {
+    async acquire() {
+      const connection = await pool.acquire();
+      if (!configuredConnections.has(connection)) {
+        await configureDuckLake(connection, config);
+        configuredConnections.add(connection);
+      }
+      return connection;
+    },
+    release(connection) {
+      return pool.release(connection);
+    },
+    close: pool.close?.bind(pool),
+  };
+
+  if (size !== undefined) {
+    wrapped.size = size;
+  }
+
+  return wrapped;
+}
+
+export function isDuckDbFileCatalog(catalog: string): boolean {
+  const trimmed = catalog.trim();
+  if (!trimmed) return false;
+
+  if (trimmed === ':memory:') return true;
+  if (isDuckLakeUri(trimmed)) {
+    return isDuckDbFileCatalog(trimmed.slice('ducklake:'.length));
+  }
+  if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return true;
+  if (trimmed.startsWith('md:')) return false;
+  if (/^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//.test(trimmed)) return false;
+  if (/^(postgres|postgresql|mysql|mariadb|sqlite|snowflake|bigquery):/i.test(trimmed)) {
+    return false;
+  }
+
+  return (
+    trimmed.endsWith('.duckdb') ||
+    trimmed.endsWith('.ddb') ||
+    trimmed.includes('/') ||
+    trimmed.includes('\\') ||
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('~')
+  );
+}
+
+export function resolveDuckLakePoolSize(
+  poolSetting: DuckDBPoolConfig | PoolPreset | false | undefined,
+  ducklakeConfig: DuckLakeConfig | undefined
+): DuckLakePoolResolution {
+  const hasPoolSetting = poolSetting !== undefined;
+  const resolvedPoolSize = resolvePoolSize(poolSetting);
+  const isLocalCatalog =
+    ducklakeConfig !== undefined
+      ? isDuckDbFileCatalog(normalizeDuckLakeConfig(ducklakeConfig).catalog)
+      : false;
+  const poolSize =
+    !hasPoolSetting && isLocalCatalog ? 1 : resolvedPoolSize;
+
+  return {
+    poolSize,
+    resolvedPoolSize,
+    isLocalCatalog,
+    hasPoolSetting,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,9 @@ export * from './olap.ts';
 export * from './value-wrappers.ts';
 export * from './options.ts';
 export * from './operators.ts';
+export {
+  configureDuckLake,
+  wrapDuckLakePool,
+  type DuckLakeAttachOptions,
+  type DuckLakeConfig,
+} from './ducklake.ts';

--- a/test/ducklake.helpers.test.ts
+++ b/test/ducklake.helpers.test.ts
@@ -35,7 +35,9 @@ describe('DuckLake helpers', () => {
     expect(isDuckDbFileCatalog('ducklake:./ducklake.duckdb')).toBe(true);
     expect(isDuckDbFileCatalog(':memory:')).toBe(true);
     expect(isDuckDbFileCatalog('md:__ducklake_metadata_db')).toBe(false);
-    expect(isDuckDbFileCatalog('ducklake:md:__ducklake_metadata_db')).toBe(false);
+    expect(isDuckDbFileCatalog('ducklake:md:__ducklake_metadata_db')).toBe(
+      false
+    );
     expect(isDuckDbFileCatalog('postgres://localhost/db')).toBe(false);
   });
 

--- a/test/ducklake.helpers.test.ts
+++ b/test/ducklake.helpers.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildDuckLakeAttachSql,
+  isDuckDbFileCatalog,
+  normalizeDuckLakeConfig,
+  resolveDuckLakePoolSize,
+} from '../src/ducklake.ts';
+
+describe('DuckLake helpers', () => {
+  test('normalizeDuckLakeConfig defaults alias and use', () => {
+    const normalized = normalizeDuckLakeConfig({ catalog: 'md:meta_db' });
+    expect(normalized.catalog).toBe('ducklake:md:meta_db');
+    expect(normalized.alias).toBe('ducklake');
+    expect(normalized.use).toBe(true);
+  });
+
+  test('buildDuckLakeAttachSql emits attach with options', () => {
+    const sql = buildDuckLakeAttachSql({
+      catalog: 'md:meta_db',
+      alias: 'lake',
+      attachOptions: {
+        dataPath: './data',
+        readOnly: true,
+        createIfNotExists: true,
+      },
+    });
+
+    expect(sql).toBe(
+      `ATTACH 'ducklake:md:meta_db' AS "lake" (CREATE_IF_NOT_EXISTS=true, DATA_PATH='./data', READ_ONLY=true)`
+    );
+  });
+
+  test('isDuckDbFileCatalog detects local file catalogs', () => {
+    expect(isDuckDbFileCatalog('./ducklake.duckdb')).toBe(true);
+    expect(isDuckDbFileCatalog('ducklake:./ducklake.duckdb')).toBe(true);
+    expect(isDuckDbFileCatalog(':memory:')).toBe(true);
+    expect(isDuckDbFileCatalog('md:__ducklake_metadata_db')).toBe(false);
+    expect(isDuckDbFileCatalog('ducklake:md:__ducklake_metadata_db')).toBe(false);
+    expect(isDuckDbFileCatalog('postgres://localhost/db')).toBe(false);
+  });
+
+  test('resolveDuckLakePoolSize defaults to 1 for local catalogs', () => {
+    const resolution = resolveDuckLakePoolSize(undefined, {
+      catalog: './ducklake.duckdb',
+    });
+    expect(resolution.poolSize).toBe(1);
+    expect(resolution.isLocalCatalog).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add DuckLake helpers and  config for drizzle
- add CLI support for DuckLake attach in duckdb-introspect
- add DuckLake docs and examples
- add DuckLake helper unit tests

## Testing
- bun test test/ducklake.helpers.test.ts