### PR TITLE
fix: add default export entries in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs"
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.mjs"
     },
     "./helpers": {
       "types": "./dist/helpers.d.ts",
-      "import": "./dist/helpers.mjs"
+      "import": "./dist/helpers.mjs",
+      "default": "./dist/helpers.mjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Adding default export conditions solves some strange issues that can occur in some cases when using certain bundlers, probably having something to do with how they handle mixing commonjs/ESM modules.