### PR TITLE
Refresh docs for package rename and APIs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -41,7 +41,7 @@ footer_content: 'Released under the Apache 2.0 License. Copyright 2025-present.'
 # External links
 aux_links:
   GitHub: https://github.com/leonardovida/drizzle-duckdb
-  npm: https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb
+  npm: https://www.npmjs.com/package/@duckdbfan/drizzle-duckdb
 aux_links_new_tab: true
 
 # Features

--- a/docs/api/array-helpers.md
+++ b/docs/api/array-helpers.md
@@ -33,7 +33,7 @@ function duckDbArrayContains(
 ### Usage
 
 ```typescript
-import { duckDbArrayContains } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArrayContains } from '@duckdbfan/drizzle-duckdb';
 
 const products = pgTable('products', {
   id: integer('id').primaryKey(),
@@ -70,7 +70,7 @@ function duckDbArrayContained(
 ### Usage
 
 ```typescript
-import { duckDbArrayContained } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArrayContained } from '@duckdbfan/drizzle-duckdb';
 
 // Find products whose tags are ALL within the allowed set
 const allowedTags = ['electronics', 'sale', 'featured', 'new'];
@@ -104,7 +104,7 @@ function duckDbArrayOverlaps(
 ### Usage
 
 ```typescript
-import { duckDbArrayOverlaps } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArrayOverlaps } from '@duckdbfan/drizzle-duckdb';
 
 // Find products with at least ONE of these tags
 const results = await db
@@ -173,7 +173,7 @@ import {
   duckDbList,
   duckDbArrayContains,
   duckDbArrayOverlaps,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 import { pgTable, integer, text } from 'drizzle-orm/pg-core';
 import { and } from 'drizzle-orm';
 

--- a/docs/api/columns.md
+++ b/docs/api/columns.md
@@ -81,7 +81,7 @@ const table = pgTable('example', {
 
 ## DuckDB-Specific Types
 
-Import these from `@leonardovida-md/drizzle-neo-duckdb`. When the generated schema will be used in a browser bundle (drizzle-zod, tRPC inputs, React props), import from the client-safe helpers subpath instead to avoid bundling the native DuckDB node bindings:
+Import these from `@duckdbfan/drizzle-duckdb`. When the generated schema will be used in a browser bundle (drizzle-zod, tRPC inputs, React props), import from the client-safe helpers subpath instead to avoid bundling the native DuckDB node bindings:
 
 ```typescript
 import {
@@ -96,7 +96,7 @@ import {
   duckDbBlob,
   duckDbInet,
   duckDbInterval,
-} from '@leonardovida-md/drizzle-neo-duckdb/helpers';
+} from '@duckdbfan/drizzle-duckdb/helpers';
 ```
 
 ### Lists and Arrays
@@ -355,7 +355,7 @@ import {
   duckDbArrayContains,
   duckDbArrayContained,
   duckDbArrayOverlaps,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 ```
 
 ### duckDbArrayContains

--- a/docs/api/drizzle.md
+++ b/docs/api/drizzle.md
@@ -63,7 +63,7 @@ Returns a `DuckDBDatabase` instance that provides the full Drizzle query builder
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 // Create connection
 const instance = await DuckDBInstance.create(':memory:');

--- a/docs/api/introspect.md
+++ b/docs/api/introspect.md
@@ -40,7 +40,7 @@ interface IntrospectOptions {
   // Map JSON columns to duckDbJson (default: true)
   mapJsonAsDuckDbJson?: boolean;
 
-  // Base import path for local types (default: '@leonardovida-md/drizzle-neo-duckdb/helpers')
+  // Base import path for local types (default: '@duckdbfan/drizzle-duckdb/helpers')
   importBasePath?: string;
 }
 ```
@@ -75,7 +75,7 @@ interface IntrospectedTable {
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, introspect } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, introspect } from '@duckdbfan/drizzle-duckdb';
 import { writeFileSync } from 'fs';
 
 const instance = await DuckDBInstance.create('./my-database.duckdb');
@@ -148,7 +148,7 @@ import {
   duckDbList,
   duckDbJson,
   duckDbTimestamp,
-} from '@leonardovida-md/drizzle-neo-duckdb/helpers';
+} from '@duckdbfan/drizzle-duckdb/helpers';
 
 export const mainSchema = pgSchema('main');
 
@@ -220,7 +220,7 @@ bunx duckdb-introspect \
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, introspect } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, introspect } from '@duckdbfan/drizzle-duckdb';
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 

--- a/docs/api/migrate.md
+++ b/docs/api/migrate.md
@@ -46,7 +46,7 @@ Either a string path to the migrations folder, or a configuration object:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, migrate } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('./my-database.duckdb');
 const connection = await instance.connect();
@@ -153,7 +153,7 @@ try {
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, migrate } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 async function main() {

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -14,12 +14,7 @@ Utilities to keep aggregates and window logic inside DuckDB while returning JS-f
 DuckDB returns DECIMAL aggregates as strings. Use the numeric helpers to coerce to `number` when that's acceptable:
 
 ```typescript
-import {
-  sumN,
-  avgN,
-  countN,
-  sumDistinctN,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { sumN, avgN, countN, sumDistinctN } from '@duckdbfan/drizzle-duckdb';
 
 await db
   .select({
@@ -34,7 +29,7 @@ await db
 ## Percentiles and median
 
 ```typescript
-import { percentileCont, median } from '@leonardovida-md/drizzle-neo-duckdb';
+import { percentileCont, median } from '@duckdbfan/drizzle-duckdb';
 
 await db
   .select({
@@ -53,7 +48,7 @@ import {
   denseRank,
   lag,
   lead,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 await db
   .select({
@@ -70,7 +65,7 @@ await db
 ## any_value for non-aggregated selections
 
 ```typescript
-import { anyValue, sumN } from '@leonardovida-md/drizzle-neo-duckdb';
+import { anyValue, sumN } from '@duckdbfan/drizzle-duckdb';
 
 await db
   .select({
@@ -85,7 +80,7 @@ await db
 ## OLAP builder (grouped measures)
 
 ```typescript
-import { olap, sumN } from '@leonardovida-md/drizzle-neo-duckdb';
+import { olap, sumN } from '@duckdbfan/drizzle-duckdb';
 
 const query = olap(db)
   .from(orders)

--- a/docs/core/arrays.md
+++ b/docs/core/arrays.md
@@ -16,7 +16,7 @@ DuckDB has two array-like types:
 ### LIST (Variable Length)
 
 ```typescript
-import { duckDbList } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbList } from '@duckdbfan/drizzle-duckdb';
 
 const users = pgTable('users', {
   tags: duckDbList<string>('tags', 'TEXT'),
@@ -27,7 +27,7 @@ const users = pgTable('users', {
 ### ARRAY (Fixed Length)
 
 ```typescript
-import { duckDbArray } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArray } from '@duckdbfan/drizzle-duckdb';
 
 const users = pgTable('users', {
   rgb: duckDbArray<number>('rgb', 'INTEGER', 3),
@@ -60,7 +60,7 @@ import {
   duckDbArrayContains,
   duckDbArrayContained,
   duckDbArrayOverlaps,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 ```
 
 #### duckDbArrayContains

--- a/docs/core/connection.md
+++ b/docs/core/connection.md
@@ -14,7 +14,7 @@ Learn how to connect to DuckDB databases in different scenarios.
 The simplest way to connect uses a connection string with automatic pooling:
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 // In-memory with auto-pooling (4 connections)
 const db = await drizzle(':memory:');
@@ -46,7 +46,7 @@ This creates a connection pool automatically, which is critical for MotherDuck p
 Perfect for testing and temporary data processing:
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const db = await drizzle(':memory:');
 ```
@@ -190,7 +190,7 @@ const usersWithPosts = await db.query.users.findMany({
 ```typescript
 // db.ts
 import { DuckDBInstance, DuckDBConnection } from '@duckdb/node-api';
-import { drizzle, DuckDBDatabase } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, DuckDBDatabase } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 let instance: DuckDBInstance | null = null;
@@ -272,10 +272,7 @@ For more control, create the pool manually:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import {
-  drizzle,
-  createDuckDBConnectionPool,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, createDuckDBConnectionPool } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('./app.duckdb');
 const pool = createDuckDBConnectionPool(instance, { size: 4 });

--- a/docs/core/queries.md
+++ b/docs/core/queries.md
@@ -113,12 +113,7 @@ const results = await db
 
 ```typescript
 import { count, sum, avg, min, max, countDistinct } from 'drizzle-orm';
-import {
-  countN,
-  sumN,
-  avgN,
-  sumDistinctN,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { countN, sumN, avgN, sumDistinctN } from '@duckdbfan/drizzle-duckdb';
 
 // Basic aggregates
 const stats = await db
@@ -184,7 +179,7 @@ import {
   median,
   rowNumber,
   lag,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 const [stats] = await db
   .select({
@@ -201,7 +196,7 @@ const [stats] = await db
 ### Grouped measures with the OLAP builder
 
 ```typescript
-import { olap, sumN } from '@leonardovida-md/drizzle-neo-duckdb';
+import { olap, sumN } from '@duckdbfan/drizzle-duckdb';
 
 const rows = await olap(db)
   .from(orders)

--- a/docs/core/schema.md
+++ b/docs/core/schema.md
@@ -67,7 +67,7 @@ import {
   duckDbBlob,
   duckDbInet,
   duckDbInterval,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 ```
 
 See [DuckDB Types]({{ '/features/duckdb-types' | relative_url }}) for detailed usage.
@@ -261,7 +261,7 @@ import {
   duckDbList,
   duckDbStruct,
   duckDbTimestamp,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 // Users table
 export const users = pgTable('users', {

--- a/docs/examples/analytics-dashboard.md
+++ b/docs/examples/analytics-dashboard.md
@@ -39,7 +39,7 @@ import {
   duckDbMap,
   duckDbJson,
   duckDbTimestamp,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 // Users with JSON metadata and list of tags
 const users = pgTable('users', {
@@ -118,7 +118,7 @@ Create tables with sequences for auto-increment. Pick a connection style:
 ```typescript
 // Single connection (matches the checked-in script)
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create(':memory:');
 const connection = await instance.connect();
@@ -127,7 +127,7 @@ const db = drizzle(connection);
 
 ```typescript
 // Auto-pooling for concurrent workloads (default pool size: 4, memory preset)
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const db = await drizzle(':memory:', { pool: 'memory' });
 ```
@@ -214,7 +214,7 @@ Find users by tags using DuckDB array helpers:
 import {
   duckDbArrayContains,
   duckDbArrayOverlaps,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 // Find users with BOTH 'premium' AND 'newsletter' tags
 const premiumNewsletterUsers = await db

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -132,7 +132,7 @@ Each example follows a similar pattern:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 // 1. Define schema
 const users = pgTable('users', { ... });

--- a/docs/examples/motherduck-nyc-taxi.md
+++ b/docs/examples/motherduck-nyc-taxi.md
@@ -34,7 +34,7 @@ This example demonstrates Drizzle DuckDB with MotherDuck cloud database, queryin
 Use the async `drizzle()` entrypoint for automatic pooling (default pool size: 4). This avoids serializing concurrent requests when hitting MotherDuck from an API or script.
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const motherDuckToken = process.env.MOTHERDUCK_TOKEN;
 if (!motherDuckToken) {
@@ -55,10 +55,7 @@ Want fine-grained pool control (timeouts, queue limits, recycling)? Build the po
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import {
-  createDuckDBConnectionPool,
-  drizzle,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { createDuckDBConnectionPool, drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('md:', {
   motherduck_token: motherDuckToken,

--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -24,7 +24,7 @@ import {
   duckDbBlob,
   duckDbInet,
   duckDbInterval,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 ```
 
 ## LIST (Variable Length Array)

--- a/docs/features/introspection.md
+++ b/docs/features/introspection.md
@@ -91,7 +91,7 @@ bunx duckdb-introspect --url md: --all-databases --out ./schema.ts
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, introspect } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, introspect } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('./my-database.duckdb');
 const connection = await instance.connect();
@@ -129,7 +129,7 @@ interface IntrospectOptions {
   // Use duckDbJson for JSON columns (default: true)
   mapJsonAsDuckDbJson?: boolean;
 
-  // Custom import path for helpers (default: '@leonardovida-md/drizzle-neo-duckdb/helpers')
+  // Custom import path for helpers (default: '@duckdbfan/drizzle-duckdb/helpers')
   importBasePath?: string;
 }
 ```
@@ -188,7 +188,7 @@ import {
   duckDbList,
   duckDbStruct,
   duckDbTimestamp,
-} from '@leonardovida-md/drizzle-neo-duckdb/helpers';
+} from '@duckdbfan/drizzle-duckdb/helpers';
 
 export const analyticsSchema = pgSchema('analytics');
 
@@ -281,7 +281,7 @@ bunx duckdb-introspect --url ./app.duckdb --out ./src/db/schema.ts
 ```typescript
 // src/db/index.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema.ts';
 
 const instance = await DuckDBInstance.create('./app.duckdb');

--- a/docs/features/migrations.md
+++ b/docs/features/migrations.md
@@ -13,7 +13,7 @@ Drizzle DuckDB supports running SQL migration files against your DuckDB database
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, migrate } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('./my-database.duckdb');
 const connection = await instance.connect();
@@ -167,7 +167,7 @@ await migrate(db, './drizzle');
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, migrate } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 
 async function runMigrations() {

--- a/docs/getting-started/coming-from-postgres.md
+++ b/docs/getting-started/coming-from-postgres.md
@@ -34,7 +34,7 @@ const users = pgTable('users', {
 });
 
 // After (DuckDB)
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 
 const users = pgTable('users', {
   settings: duckDbJson<{ theme: string }>('settings'),
@@ -54,7 +54,7 @@ const events = pgTable('events', {
 });
 
 // After (DuckDB) - recommended
-import { duckDbTimestamp } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbTimestamp } from '@duckdbfan/drizzle-duckdb';
 
 const events = pgTable('events', {
   createdAt: duckDbTimestamp('created_at', { withTimezone: true }),
@@ -91,7 +91,7 @@ import { arrayContains } from 'drizzle-orm/pg-core';
 .where(arrayContains(products.tags, ['sale']))
 
 // After (DuckDB) - explicit
-import { duckDbArrayContains } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArrayContains } from '@duckdbfan/drizzle-duckdb';
 
 .where(duckDbArrayContains(products.tags, ['sale']))
 ```
@@ -128,7 +128,7 @@ const users = pgTable('users', {
 
 ```typescript
 // Replace json/jsonb imports
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 
 const users = pgTable('users', {
   // Change this
@@ -182,7 +182,7 @@ const db = drizzle(pool);
 
 // After (DuckDB)
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('./my-database.duckdb');
 const connection = await instance.connect();

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -10,6 +10,11 @@ permalink: /getting-started/
 
 Drizzle DuckDB brings [Drizzle ORM](https://orm.drizzle.team/) to [DuckDB](https://duckdb.org/) - the fast in-process analytical database.
 
+{: .warning }
+
+> Install `@duckdbfan/drizzle-duckdb`.
+> The older package `@leonardovida-md/drizzle-neo-duckdb` is being deprecated and stops receiving updates after May 2, 2026.
+
 ## What is Drizzle DuckDB?
 
 This package is a DuckDB dialect adapter for Drizzle ORM. It provides:
@@ -37,7 +42,7 @@ DuckDB is less suited for:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { pgTable, integer, text } from 'drizzle-orm/pg-core';
 
 // Define your schema
@@ -74,6 +79,6 @@ const allUsers = await db.select().from(users);
 ## Resources
 
 - [GitHub Repository](https://github.com/leonardovida/drizzle-duckdb)
-- [npm Package](https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb)
+- [npm Package](https://www.npmjs.com/package/@duckdbfan/drizzle-duckdb)
 - [DuckDB Documentation](https://duckdb.org/docs/)
 - [Drizzle ORM Documentation](https://orm.drizzle.team/)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -9,30 +9,35 @@ nav_order: 1
 
 Install Drizzle DuckDB and its peer dependency.
 
+{: .warning }
+
+> Install `@duckdbfan/drizzle-duckdb`.
+> The previous package `@leonardovida-md/drizzle-neo-duckdb` is in deprecation and receives updates only through May 2, 2026.
+
 ## Package Installation
 
 **Using bun:**
 
 ```bash
-bun add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+bun add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 **Using npm:**
 
 ```bash
-npm install @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 **Using pnpm:**
 
 ```bash
-pnpm add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 **Using yarn:**
 
 ```bash
-yarn add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 Recommended client version is `@duckdb/node-api@1.4.4-r.1`, which bundles DuckDB 1.4.4.
@@ -64,7 +69,7 @@ Create a test file to verify everything works:
 ```typescript
 // test.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 
 async function test() {

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -37,7 +37,7 @@ export const posts = pgTable('posts', {
 ```typescript
 // db.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 // In-memory database
@@ -167,7 +167,7 @@ const [deleted] = await db.delete(users).where(eq(users.id, 1)).returning();
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { pgTable, integer, text } from 'drizzle-orm/pg-core';
 import { eq, sql } from 'drizzle-orm';
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,11 @@ nav_exclude: true
 
 DuckDB dialect for Drizzle ORM with full TypeScript inference, DuckDB-native types, and Postgres-compatible schema definitions.
 
+{: .warning }
+
+> Install `@duckdbfan/drizzle-duckdb`.
+> The previous package `@leonardovida-md/drizzle-neo-duckdb` is in deprecation and receives updates only through May 2, 2026.
+
 [Get Started]({{ '/getting-started/' | relative_url }}){: .btn .btn-primary .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [View on GitHub](https://github.com/leonardovida/drizzle-duckdb){: .btn .fs-5 .mb-4 .mb-md-0 .mr-2 }
 [LLM Context (llms.txt)]({{ '/llms.txt' | relative_url }}){: .btn .fs-5 .mb-4 .mb-md-0 }
@@ -32,7 +37,7 @@ DuckDB dialect for Drizzle ORM with full TypeScript inference, DuckDB-native typ
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { integer, text, pgTable } from 'drizzle-orm/pg-core';
 
 // Connect to DuckDB

--- a/docs/integrations/bun.md
+++ b/docs/integrations/bun.md
@@ -12,7 +12,7 @@ Bun is the recommended runtime for Drizzle DuckDB. It provides excellent perform
 ## Installation
 
 ```bash
-bun add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+bun add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 ## Basic Usage
@@ -20,7 +20,7 @@ bun add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
 ```typescript
 // db.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 const instance = await DuckDBInstance.create('./app.duckdb');
@@ -77,7 +77,7 @@ bun run scripts/introspect.ts
   },
   "dependencies": {
     "@duckdb/node-api": "^1.0.0",
-    "@leonardovida-md/drizzle-neo-duckdb": "^1.0.0",
+    "@duckdbfan/drizzle-duckdb": "^1.0.0",
     "drizzle-orm": "^0.30.0"
   },
   "devDependencies": {
@@ -109,7 +109,7 @@ bun run scripts/introspect.ts
 ```typescript
 // scripts/migrate.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, migrate } from '@duckdbfan/drizzle-duckdb';
 
 async function main() {
   const instance = await DuckDBInstance.create('./app.duckdb');
@@ -131,7 +131,7 @@ main().catch(console.error);
 ```typescript
 // scripts/introspect.ts
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle, introspect } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, introspect } from '@duckdbfan/drizzle-duckdb';
 import { writeFileSync } from 'fs';
 
 async function main() {
@@ -158,7 +158,7 @@ Bun has a built-in test runner:
 // tests/db.test.ts
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 
 let instance: DuckDBInstance;

--- a/docs/integrations/ducklake.md
+++ b/docs/integrations/ducklake.md
@@ -14,7 +14,7 @@ DuckLake stores DuckDB tables on object storage while keeping metadata in a cata
 Create a DuckLake catalog backed by a local DuckDB file and point data to a directory:
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const db = await drizzle(':memory:', {
   ducklake: {
@@ -37,7 +37,7 @@ CREATE DATABASE my_lake TYPE DUCKLAKE;
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const db = await drizzle({
   connection: {
@@ -60,10 +60,7 @@ If you have a direct connection, call `configureDuckLake` before using Drizzle:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import {
-  configureDuckLake,
-  drizzle,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { configureDuckLake, drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create(':memory:');
 const connection = await instance.connect();

--- a/docs/integrations/motherduck.md
+++ b/docs/integrations/motherduck.md
@@ -22,7 +22,7 @@ nav_order: 2
 The async `drizzle()` entrypoint creates a pool automatically and exposes `db.close()` to clean up:
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const db = await drizzle({
   connection: {
@@ -44,7 +44,7 @@ If you need to manage the instance and connection directly, use the lower level 
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('md:', {
   motherduck_token: process.env.MOTHERDUCK_TOKEN,
@@ -84,7 +84,7 @@ MotherDuck provides sample datasets. Here's an example querying the NYC taxi dat
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 
 const instance = await DuckDBInstance.create('md:', {
@@ -214,7 +214,7 @@ await db.execute(sql`
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 
 async function getAnalytics() {

--- a/docs/integrations/nextjs.md
+++ b/docs/integrations/nextjs.md
@@ -7,7 +7,7 @@ nav_order: 1
 
 # Next.js Integration
 
-This guide covers how to use `@leonardovida-md/drizzle-neo-duckdb` with Next.js applications.
+This guide covers how to use `@duckdbfan/drizzle-duckdb` with Next.js applications.
 
 ## Configuration
 
@@ -62,7 +62,7 @@ The simplest approach uses connection strings with automatic pooling:
 
 ```typescript
 // lib/db.ts
-import { drizzle, DuckDBDatabase } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, DuckDBDatabase } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 let db: Awaited<ReturnType<typeof drizzle<typeof schema>>> | null = null;
@@ -115,10 +115,7 @@ For more control, create the pool manually:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import {
-  drizzle,
-  createDuckDBConnectionPool,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle, createDuckDBConnectionPool } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 let db: ReturnType<typeof drizzle<typeof schema>> | null = null;
@@ -294,7 +291,7 @@ In serverless environments, connections may not be properly cleaned up between i
 ```typescript
 // lib/db.ts
 import { DuckDBInstance, DuckDBConnection } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 
 export async function withDb<T>(
   callback: (db: ReturnType<typeof drizzle>) => Promise<T>
@@ -340,7 +337,7 @@ export const users = pgTable('users', {
 **`lib/db.ts`**:
 
 ```typescript
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import * as schema from './schema';
 
 let db: Awaited<ReturnType<typeof drizzle<typeof schema>>> | null = null;

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -9,14 +9,16 @@ Drizzle DuckDB is a DuckDB dialect adapter for Drizzle ORM. It provides type-saf
 ## Installation
 
 ```bash
-npm install @leonardovida-md/drizzle-neo-duckdb drizzle-orm @duckdb/node-api
+npm install @duckdbfan/drizzle-duckdb drizzle-orm @duckdb/node-api
 ```
+
+Package note: use `@duckdbfan/drizzle-duckdb` for new installs. `@leonardovida-md/drizzle-neo-duckdb` is deprecated and receives updates only through May 2, 2026.
 
 ## Quick Start
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { pgTable, integer, text } from 'drizzle-orm/pg-core';
 
 const users = pgTable('users', {
@@ -43,7 +45,7 @@ const allUsers = await db.select().from(users);
 ## Important Notes
 
 - Do NOT use Postgres json or jsonb columns - use duckDbJson() instead
-- DuckDB doesn't support SAVEPOINT for nested transactions
+- Current DuckDB 1.4.x builds do not support `SAVEPOINT`. Nested transactions reuse the outer transaction and mark it for rollback on nested errors.
 - Array operators are automatically rewritten to DuckDB functions
 
 ## Documentation
@@ -55,7 +57,7 @@ const allUsers = await db.select().from(users);
 
 ## DuckDB-Specific Column Types
 
-Import from '@leonardovida-md/drizzle-neo-duckdb':
+Import from '@duckdbfan/drizzle-duckdb':
 
 - duckDbList - Variable length arrays (LIST)
 - duckDbArray - Fixed length arrays (ARRAY)
@@ -78,7 +80,7 @@ Import from '@leonardovida-md/drizzle-neo-duckdb':
 ## Migrations
 
 ```typescript
-import { migrate } from '@leonardovida-md/drizzle-neo-duckdb';
+import { migrate } from '@duckdbfan/drizzle-duckdb';
 
 await migrate(db, {
   migrationsFolder: './drizzle',
@@ -89,7 +91,7 @@ await migrate(db, {
 ## Schema Introspection
 
 ```typescript
-import { introspect } from '@leonardovida-md/drizzle-neo-duckdb';
+import { introspect } from '@duckdbfan/drizzle-duckdb';
 
 const result = await introspect(db, {
   schemas: ['main'],
@@ -112,7 +114,7 @@ const db = drizzle(connection);
 ## Links
 
 - GitHub: https://github.com/leonardovida/drizzle-duckdb
-- npm: https://www.npmjs.com/package/@leonardovida-md/drizzle-neo-duckdb
+- npm: https://www.npmjs.com/package/@duckdbfan/drizzle-duckdb
 - Documentation: https://leonardovida.github.io/drizzle-duckdb/
 - DuckDB: https://duckdb.org/
 - Drizzle ORM: https://orm.drizzle.team/

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -192,10 +192,7 @@ For timeouts, queue limits, and connection recycling, build the pool manually:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import {
-  createDuckDBConnectionPool,
-  drizzle,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { createDuckDBConnectionPool, drizzle } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create('md:', {
   motherduck_token: process.env.MOTHERDUCK_TOKEN,
@@ -288,7 +285,7 @@ const result = await introspect(db, {
   includeViews: true,
   useCustomTimeTypes: true,
   mapJsonAsDuckDbJson: true,
-  importBasePath: '@leonardovida-md/drizzle-neo-duckdb/helpers',
+  importBasePath: '@duckdbfan/drizzle-duckdb/helpers',
 });
 ```
 
@@ -356,9 +353,9 @@ Map JSON columns to `duckDbJson`.
 
 Base path for local type imports.
 
-| Type     | Default                                         | Description           |
-| -------- | ----------------------------------------------- | --------------------- |
-| `string` | `'@leonardovida-md/drizzle-neo-duckdb/helpers'` | Import path for types |
+| Type     | Default                               | Description           |
+| -------- | ------------------------------------- | --------------------- |
+| `string` | `'@duckdbfan/drizzle-duckdb/helpers'` | Import path for types |
 
 ## Environment Variables
 

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -117,7 +117,7 @@ DuckDB is optimized for OLAP (analytical) workloads, not OLTP (transactional).
 ### How do I use DuckDB's STRUCT type?
 
 ```typescript
-import { duckDbStruct } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbStruct } from '@duckdbfan/drizzle-duckdb';
 
 const users = pgTable('users', {
   address: duckDbStruct<{
@@ -205,7 +205,7 @@ while (true) {
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { createDuckDBConnectionPool } from '@leonardovida-md/drizzle-neo-duckdb';
+import { createDuckDBConnectionPool } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create(':memory:');
 const pool = createDuckDBConnectionPool(instance, {
@@ -250,7 +250,7 @@ See the [Next.js guide]({{ '/integrations/nextjs' | relative_url }}) for full se
 Yes! Bun is the recommended runtime:
 
 ```bash
-bun add @leonardovida-md/drizzle-neo-duckdb @duckdb/node-api
+bun add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
 See the [Bun guide]({{ '/integrations/bun' | relative_url }}) for details.
@@ -280,7 +280,7 @@ DuckDB has its own JSON type. Replace:
 import { json } from 'drizzle-orm/pg-core';
 
 // After
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 ```
 
 ### Why doesn't my transaction rollback work as expected?

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -67,7 +67,7 @@ const table = pgTable('example', {
 **Solution:** Use `duckDbJson()` instead:
 
 ```typescript
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 
 const table = pgTable('example', {
   data: duckDbJson('data'), // Works!
@@ -197,7 +197,7 @@ This transformation happens automatically for all queries.
 **Recommendation:** Use the explicit DuckDB-native helpers for clarity:
 
 ```typescript
-import { arrayHasAll, arrayHasAny, duckDbArrayContains } from '@leonardovida-md/drizzle-neo-duckdb';
+import { arrayHasAll, arrayHasAny, duckDbArrayContains } from '@duckdbfan/drizzle-duckdb';
 
 // DuckDB-native (recommended)
 .where(arrayHasAll(products.tags, ['a', 'b']))

--- a/docs/reference/performance.md
+++ b/docs/reference/performance.md
@@ -15,20 +15,20 @@ These settings provide immediate performance improvements for most workloads:
 
 ```typescript
 import { DuckDBInstance } from '@duckdb/node-api';
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
-import { createDuckDBConnectionPool } from '@leonardovida-md/drizzle-neo-duckdb/pool';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
+import { createDuckDBConnectionPool } from '@duckdbfan/drizzle-duckdb';
 
 const instance = await DuckDBInstance.create(':memory:');
 
 // Option 1: Single connection with prepared statement cache
 const connection = await instance.connect();
-const db = drizzle(connection, {
+const dbSingle = drizzle(connection, {
   prepareCache: { size: 64 },
 });
 
 // Option 2: Connection pool for concurrent workloads
 const pool = createDuckDBConnectionPool(instance, { size: 8 });
-const db = drizzle({ client: pool, prepareCache: { size: 64 } });
+const dbPooled = drizzle({ client: pool, prepareCache: { size: 64 } });
 ```
 
 ## Prepared Statement Caching
@@ -77,12 +77,12 @@ Use connection pooling for applications with concurrent database access.
 ### Basic Pool Setup
 
 ```typescript
-import { createDuckDBConnectionPool } from '@leonardovida-md/drizzle-neo-duckdb/pool';
+import { createDuckDBConnectionPool } from '@duckdbfan/drizzle-duckdb';
 
 const pool = createDuckDBConnectionPool(instance, {
   size: 8, // Number of connections
   acquireTimeout: 30000, // Max wait time (ms)
-  maxWaiters: 100, // Max queued requests
+  maxWaitingRequests: 100, // Max queued requests
 });
 
 const db = drizzle({ client: pool, prepareCache: { size: 64 } });
@@ -92,7 +92,7 @@ const db = drizzle({ client: pool, prepareCache: { size: 64 } });
 
 ```typescript
 // Optimized presets for MotherDuck instance types
-const pool = createDuckDBConnectionPool(instance, { preset: 'standard' });
+const db = await drizzle('md:', { pool: 'standard' });
 ```
 
 | Preset     | Pool Size | Use Case             |
@@ -134,12 +134,14 @@ For queries returning many rows, use streaming to avoid memory pressure.
 ### Batch Streaming
 
 ```typescript
+import { sql } from 'drizzle-orm';
+
 // Stream 100,000 rows per batch
-for await (const batch of db.$client.executeInBatches(query, params, {
+for await (const rows of db.executeBatches(sql`SELECT * FROM large_table`, {
   rowsPerChunk: 100000,
 })) {
-  // Process batch.rows (array of objects)
-  for (const row of batch.rows) {
+  // Process each chunk of mapped rows
+  for (const row of rows) {
     processRow(row);
   }
 }
@@ -151,10 +153,12 @@ For maximum performance with large datasets:
 
 ```typescript
 // Stream raw arrays (no object mapping overhead)
-for await (const batch of db.$client.executeInBatchesRaw(query, params)) {
-  // batch.columns: string[]
-  // batch.rows: unknown[][]
-  for (const row of batch.rows) {
+for await (const chunk of db.executeBatchesRaw(
+  sql`SELECT id, name FROM users`
+)) {
+  // chunk.columns: string[]
+  // chunk.rows: unknown[][]
+  for (const row of chunk.rows) {
     const id = row[0];
     const name = row[1];
   }
@@ -166,7 +170,7 @@ for await (const batch of db.$client.executeInBatchesRaw(query, params)) {
 For interop with analytical tools:
 
 ```typescript
-const arrow = await db.$client.executeArrow(query, params);
+const arrow = await db.executeArrow(sql`SELECT * FROM large_table`);
 // Returns Arrow table for zero-copy analytics
 ```
 
@@ -209,7 +213,7 @@ import {
   duckDbArray,
   duckDbJson,
   duckDbStruct,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+} from '@duckdbfan/drizzle-duckdb';
 
 // Faster: pre-wrapped DuckDB value
 await db.insert(table).values({
@@ -265,10 +269,7 @@ When migrating from PostgreSQL, consider these performance differences:
 PostgreSQL array operators (`@>`, `<@`, `&&`) are automatically rewritten to DuckDB functions. For best performance, use DuckDB-native array functions directly:
 
 ```typescript
-import {
-  arrayContains,
-  arrayOverlaps,
-} from '@leonardovida-md/drizzle-neo-duckdb';
+import { arrayHasAll, arrayHasAny } from '@duckdbfan/drizzle-duckdb';
 
 // Automatic rewrite (works but has parsing overhead on first execution)
 const result = await db
@@ -280,7 +281,13 @@ const result = await db
 const result = await db
   .select()
   .from(posts)
-  .where(arrayContains(posts.tags, ['featured']));
+  .where(arrayHasAll(posts.tags, ['featured']));
+
+// Overlap check with native helper
+const overlapping = await db
+  .select()
+  .from(posts)
+  .where(arrayHasAny(posts.tags, ['featured', 'trending']));
 ```
 
 ### JSON Columns
@@ -288,7 +295,7 @@ const result = await db
 Use `duckDbJson()` instead of Postgres `json`/`jsonb`:
 
 ```typescript
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 
 const table = pgTable('events', {
   id: integer('id').primaryKey(),
@@ -324,15 +331,15 @@ const result = await db
 
 ## Monitoring Performance
 
-### Query Transformation Cache
+### Query Timing
 
-The SQL transformer caches query rewrites. Monitor cache effectiveness:
+Track representative query latency in your runtime environment:
 
 ```typescript
-import { getTransformCacheStats } from '@leonardovida-md/drizzle-neo-duckdb';
-
-const stats = getTransformCacheStats();
-console.log(`Transform cache: ${stats.size}/${stats.maxSize} entries`);
+const startedAt = Date.now();
+await db.select().from(users).limit(1000);
+const elapsedMs = Date.now() - startedAt;
+console.log(`Query took ${elapsedMs}ms`);
 ```
 
 ### Warm-Up Critical Queries
@@ -361,7 +368,7 @@ await warmUp(db);
 - [ ] Create indexes for frequently-queried columns
 - [ ] Use `duckDbJson()` instead of Postgres `json`/`jsonb`
 - [ ] Warm up caches at application startup
-- [ ] Monitor cache hit rates in production
+- [ ] Track query latency and pool queue behavior in production
 
 ## Troubleshooting Slow Queries
 

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -25,7 +25,7 @@ import { json, jsonb } from 'drizzle-orm/pg-core';
 const table = pgTable('t', { data: json('data') }); // Error!
 
 // Correct
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb';
 const table = pgTable('t', { data: duckDbJson('data') });
 ```
 
@@ -40,7 +40,7 @@ const table = pgTable('t', { data: duckDbJson('data') });
 **Solution**: Array operators are automatically rewritten via AST transformation. For clarity, you can also use explicit helpers:
 
 ```typescript
-import { duckDbArrayContains } from '@leonardovida-md/drizzle-neo-duckdb';
+import { duckDbArrayContains } from '@duckdbfan/drizzle-duckdb';
 
 // Explicit and clear
 .where(duckDbArrayContains(products.tags, ['a', 'b']))
@@ -132,7 +132,7 @@ const nextConfig = {
 When sharing generated schemas with client components (e.g., drizzle-zod or tRPC inputs), import column helpers from the browser-safe subpath to avoid bundling the native binding:
 
 ```ts
-import { duckDbJson } from '@leonardovida-md/drizzle-neo-duckdb/helpers';
+import { duckDbJson } from '@duckdbfan/drizzle-duckdb/helpers';
 ```
 
 ### "Native Node.js APIs not supported" Error


### PR DESCRIPTION
## Summary
This PR refreshes repository documentation to align with the current package naming and supported API surface.

It updates docs content to consistently reference `@duckdbfan/drizzle-duckdb`, replaces stale install/import examples, and corrects performance-guide snippets that no longer matched the implementation.

## Problem
The docs had drift in two places:
1. Package and helper import references still pointed at the legacy package name in many pages
2. Some performance examples referenced outdated options or symbols (`maxWaiters`, `createDuckDBConnectionPool(...preset...)`, direct `$client` usage patterns, and a cache stats helper that is not publicly exported)

This created onboarding friction and copy-paste failures for users following docs verbatim.

## Fix
- Replaced docs references from `@leonardovida-md/drizzle-neo-duckdb` to `@duckdbfan/drizzle-duckdb` across docs pages
- Updated helper path references to `@duckdbfan/drizzle-duckdb/helpers`
- Updated docs npm link in site config and landing pages
- Added explicit migration/deprecation notes in key entrypoints:
  - docs home page
  - getting started index
  - installation page
  - llms.txt
- Corrected performance examples to match current APIs:
  - `maxWaitingRequests` option
  - pool preset guidance via `await drizzle('md:', { pool: 'standard' })`
  - `db.executeBatches`, `db.executeBatchesRaw`, `db.executeArrow`
  - `arrayHasAll` / `arrayHasAny`
  - replaced non-exported transform-cache stats snippet with practical query timing guidance

## User Impact
Users now get consistent package/install guidance and runnable examples that match the current connector APIs, reducing setup and migration confusion.

## Validation
- `pre-commit run --all-files`
  - trim trailing whitespace: passed
  - fix end of files: passed
  - check yaml/json/merge conflicts/large files: passed
  - secret scan: passed
  - prettier formatting: passed
  - typecheck: passed
