### PR TITLE
[codex] Ignore local codex rules files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ coverage
 *.log
 test/.tmp
 .cursor
+.codex/rules/


### PR DESCRIPTION
## Summary
This change adds `.codex/rules/` to the repository ignore list.

## Problem
A repo-local Codex rules file was created to control sandbox execution behavior for this workspace. Without an ignore entry, these local policy files can appear as untracked changes and may be accidentally committed.

## User Impact
If local rules are committed, repository history can include workstation-specific policy configuration that is not part of the project source. This creates noise in pull requests and can propagate personal execution policy settings to collaborators.

## Root Cause
The existing `.gitignore` did not include the `.codex/rules/` directory.

## Fix
Added a single ignore rule:

- `.codex/rules/`

This keeps local rules files out of commits while preserving repo behavior.

## Validation
- Ran `pre-commit run --files .gitignore`
- Confirmed git status no longer shows `.codex/rules/` as untracked
