### PR TITLE
Small targeted refactor: centralize result column resolution

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -235,14 +235,7 @@ async function materializeResultRows(result: {
   deduplicatedColumnNames?: () => string[];
 }): Promise<MaterializedRows> {
   const rows = (await result.getRowsJS()) ?? [];
-  const baseColumns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? result.deduplicatedColumnNames()
-      : result.columnNames();
-  const columns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? baseColumns
-      : deduplicateColumns(baseColumns);
+  const columns = resolveResultColumns(result);
 
   return { columns, rows };
 }
@@ -254,6 +247,18 @@ type StreamResultLike = {
   close?: () => Promise<void> | void;
   cancel?: () => Promise<void> | void;
 };
+
+type ResultColumnsLike = {
+  columnNames: () => string[];
+  deduplicatedColumnNames?: () => string[];
+};
+
+function resolveResultColumns(result: ResultColumnsLike): string[] {
+  if (typeof result.deduplicatedColumnNames === 'function') {
+    return result.deduplicatedColumnNames();
+  }
+  return deduplicateColumns(result.columnNames());
+}
 
 async function closeStreamResult(result: StreamResultLike): Promise<void> {
   try {
@@ -431,14 +436,7 @@ export async function* executeInBatches(
       : undefined;
 
   const result = (await client.stream(query, values)) as StreamResultLike;
-  const rawColumns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? result.deduplicatedColumnNames()
-      : result.columnNames();
-  const columns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? rawColumns
-      : deduplicateColumns(rawColumns);
+  const columns = resolveResultColumns(result);
 
   let buffer: RowData[] = [];
 
@@ -489,14 +487,7 @@ export async function* executeInBatchesRaw(
       : undefined;
 
   const result = (await client.stream(query, values)) as StreamResultLike;
-  const rawColumns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? result.deduplicatedColumnNames()
-      : result.columnNames();
-  const columns =
-    typeof result.deduplicatedColumnNames === 'function'
-      ? rawColumns
-      : deduplicateColumns(rawColumns);
+  const columns = resolveResultColumns(result);
 
   let buffer: unknown[][] = [];
 

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -10,14 +10,23 @@ function makeClient(options: {
   arrowValue?: unknown;
   fallbackValue?: unknown;
   rows?: unknown[][];
+  columns?: string[];
+  deduplicatedColumns?: string[];
   onStreamClose?: () => void;
 }): DuckDBClientLike {
   const {
     arrowValue,
     fallbackValue = {},
     rows = [[1], [2], [3]],
+    columns = ['id'],
     onStreamClose,
   } = options;
+  const deduplicatedColumns = Object.prototype.hasOwnProperty.call(
+    options,
+    'deduplicatedColumns'
+  )
+    ? options.deduplicatedColumns
+    : ['id'];
 
   return {
     async run(_query: string, _values?: unknown[]) {
@@ -28,7 +37,11 @@ function makeClient(options: {
     },
     async stream(_query: string, _values?: unknown[]) {
       return {
-        deduplicatedColumnNames: () => ['id'],
+        columnNames: () => columns,
+        deduplicatedColumnNames:
+          deduplicatedColumns === undefined
+            ? undefined
+            : () => deduplicatedColumns,
         async *yieldRowsJs() {
           yield rows;
         },
@@ -111,5 +124,20 @@ describe('executeInBatchesRaw', () => {
     }
 
     expect(closeCalls).toBe(1);
+  });
+
+  test('deduplicates fallback column names when node-api does not provide them', async () => {
+    const client = makeClient({
+      rows: [[1, 2]],
+      columns: ['id', 'id'],
+      deduplicatedColumns: undefined,
+    });
+    const chunks: Array<{ columns: string[]; rows: unknown[][] }> = [];
+
+    for await (const chunk of executeInBatchesRaw(client, 'select', [])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks[0]?.columns).toEqual(['id', 'id_1']);
   });
 });


### PR DESCRIPTION
## Summary
- extract shared result-column resolution into `resolveResultColumns(...)` in `src/client.ts`
- replace duplicated logic in `materializeResultRows`, `executeInBatches`, and `executeInBatchesRaw`
- add regression test for fallback duplicate column deduplication in `test/client-execute.test.ts`

## Validation
- bun test test/client-execute.test.ts