### PR TITLE
[codex] Refactor shutdown helpers

### DIFF
--- a/src/bin/duckdb-introspect.ts
+++ b/src/bin/duckdb-introspect.ts
@@ -3,6 +3,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { mkdir, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
+import { closeClientConnection, closeDuckDbInstance } from '../client.ts';
 import { drizzle } from '../index.ts';
 import { configureDuckLake, type DuckLakeConfig } from '../ducklake.ts';
 import { introspect } from '../introspect.ts';
@@ -252,17 +253,8 @@ async function main() {
       console.log(`Wrote metadata to ${options.outMeta}`);
     }
   } finally {
-    if (
-      'closeSync' in connection &&
-      typeof connection.closeSync === 'function'
-    ) {
-      connection.closeSync();
-    }
-    if ('closeSync' in instance && typeof instance.closeSync === 'function') {
-      instance.closeSync();
-    } else if ('close' in instance && typeof instance.close === 'function') {
-      await instance.close();
-    }
+    await closeClientConnection(connection);
+    await closeDuckDbInstance(instance);
   }
 }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,6 +2,7 @@ import {
   listValue,
   timestampValue,
   type DuckDBConnection,
+  type DuckDBInstance,
   type DuckDBPreparedStatement,
   type DuckDBValue,
 } from '@duckdb/node-api';
@@ -47,6 +48,15 @@ type PreparedStatementCache = {
 type ResultColumnsLike = {
   columnNames: () => string[];
   deduplicatedColumnNames?: () => string[];
+};
+
+type ClosableResource = {
+  close?: () => Promise<void> | void;
+  closeSync?: () => void;
+};
+
+type DisconnectableResource = ClosableResource & {
+  disconnectSync?: () => void;
 };
 
 const PREPARED_CACHE = Symbol.for('drizzle-duckdb:prepared-cache');
@@ -352,21 +362,31 @@ export async function closeClientConnection(
 ): Promise<void> {
   clearPreparedCache(connection);
 
-  if ('close' in connection && typeof connection.close === 'function') {
-    await connection.close();
+  await closeDuckDbResource(connection as DisconnectableResource, true);
+}
+
+export async function closeDuckDbInstance(
+  instance: DuckDBInstance
+): Promise<void> {
+  await closeDuckDbResource(instance as ClosableResource);
+}
+
+async function closeDuckDbResource(
+  resource: DisconnectableResource,
+  allowDisconnectSync = false
+): Promise<void> {
+  if (typeof resource.close === 'function') {
+    await resource.close();
     return;
   }
 
-  if ('closeSync' in connection && typeof connection.closeSync === 'function') {
-    connection.closeSync();
+  if (typeof resource.closeSync === 'function') {
+    resource.closeSync();
     return;
   }
 
-  if (
-    'disconnectSync' in connection &&
-    typeof connection.disconnectSync === 'function'
-  ) {
-    connection.disconnectSync();
+  if (allowDisconnectSync && typeof resource.disconnectSync === 'function') {
+    resource.disconnectSync();
   }
 }
 

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -28,7 +28,11 @@ import type {
   ExecuteInBatchesOptions,
   RowData,
 } from './client.ts';
-import { closeClientConnection, isPool } from './client.ts';
+import {
+  closeClientConnection,
+  closeDuckDbInstance,
+  isPool,
+} from './client.ts';
 import {
   createDuckDBConnectionPool,
   type DuckDBPoolConfig,
@@ -376,15 +380,7 @@ export class DuckDBDatabase<
 
     try {
       if (this.$instance) {
-        const maybeClosable = this.$instance as unknown as {
-          close?: () => Promise<void> | void;
-          closeSync?: () => void;
-        };
-        if (typeof maybeClosable.close === 'function') {
-          await maybeClosable.close();
-        } else if (typeof maybeClosable.closeSync === 'function') {
-          maybeClosable.closeSync();
-        }
+        await closeDuckDbInstance(this.$instance);
       }
     } catch (error) {
       if (!firstError) {

--- a/test/client-close.test.ts
+++ b/test/client-close.test.ts
@@ -1,0 +1,42 @@
+import type { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
+import { expect, test, vi } from 'vitest';
+import { closeClientConnection, closeDuckDbInstance } from '../src/client.ts';
+
+test('closeClientConnection prefers async close when available', async () => {
+  const close = vi.fn(async () => undefined);
+  const closeSync = vi.fn();
+  const disconnectSync = vi.fn();
+
+  await closeClientConnection({
+    close,
+    closeSync,
+    disconnectSync,
+  } as unknown as DuckDBConnection);
+
+  expect(close).toHaveBeenCalledTimes(1);
+  expect(closeSync).not.toHaveBeenCalled();
+  expect(disconnectSync).not.toHaveBeenCalled();
+});
+
+test('closeClientConnection falls back to disconnectSync', async () => {
+  const disconnectSync = vi.fn();
+
+  await closeClientConnection({
+    disconnectSync,
+  } as unknown as DuckDBConnection);
+
+  expect(disconnectSync).toHaveBeenCalledTimes(1);
+});
+
+test('closeDuckDbInstance prefers async close when available', async () => {
+  const close = vi.fn(async () => undefined);
+  const closeSync = vi.fn();
+
+  await closeDuckDbInstance({
+    close,
+    closeSync,
+  } as unknown as DuckDBInstance);
+
+  expect(close).toHaveBeenCalledTimes(1);
+  expect(closeSync).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
This PR does a small targeted refactor around DuckDB resource shutdown.

The codebase had slightly different close-path logic in three places: connection shutdown in `src/client.ts`, instance shutdown in `src/driver.ts`, and CLI cleanup in `src/bin/duckdb-introspect.ts`. That duplication made it easier for shutdown behavior to drift over time, especially around the async `close()` path versus sync fallbacks.

The user-facing effect of that drift would be inconsistent cleanup depending on which code path created the connection or instance. That is not a large feature bug today, but it is exactly the kind of maintenance edge that becomes expensive once more entry points are added.

## Root cause
The project already had a connection-specific cleanup helper, but instance cleanup remained open-coded in separate places. The CLI also repeated connection cleanup instead of reusing the shared logic.

## Fix
I extracted the shared probing logic into one internal helper in `src/client.ts`, then exposed two narrow wrappers:

- `closeClientConnection()` for connection cleanup, including prepared statement cache clearing and the `disconnectSync()` fallback
- `closeDuckDbInstance()` for instance cleanup, preferring async `close()` and falling back to `closeSync()`

With those helpers in place:

- `src/driver.ts` now reuses the shared instance close path
- `src/bin/duckdb-introspect.ts` now reuses both shared close helpers
- `test/client-close.test.ts` locks down the close-order behavior with focused unit coverage

## Validation
I verified the change locally with:

- `bun run build`
- `bun run test -- --run`

Both completed successfully.
