### PR TITLE
[codex] Refactor client execution helpers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -152,6 +152,12 @@ function toNodeApiValue(value: unknown): DuckDBValue {
   return value as DuckDBValue;
 }
 
+function toNodeApiValues(params: unknown[]): DuckDBValue[] | undefined {
+  return params.length > 0
+    ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
+    : undefined;
+}
+
 function deduplicateColumns(columns: string[]): string[] {
   const counts = new Map<string, number>();
   let hasDuplicates = false;
@@ -300,10 +306,7 @@ async function materializeRows(
     }
   }
 
-  const values =
-    params.length > 0
-      ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
-      : undefined;
+  const values = toNodeApiValues(params);
 
   const connection = client as DuckDBConnection;
 
@@ -428,6 +431,14 @@ export interface ExecuteBatchesRawChunk {
   rows: unknown[][];
 }
 
+function resolveRowsPerChunk(
+  options: ExecuteInBatchesOptions | undefined
+): number {
+  return options?.rowsPerChunk && options.rowsPerChunk > 0
+    ? options.rowsPerChunk
+    : 100_000;
+}
+
 /**
  * Stream results from DuckDB in batches to avoid fully materializing rows in JS.
  */
@@ -447,14 +458,8 @@ export async function* executeInBatches(
     }
   }
 
-  const rowsPerChunk =
-    options.rowsPerChunk && options.rowsPerChunk > 0
-      ? options.rowsPerChunk
-      : 100_000;
-  const values =
-    params.length > 0
-      ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
-      : undefined;
+  const rowsPerChunk = resolveRowsPerChunk(options);
+  const values = toNodeApiValues(params);
 
   const result = (await client.stream(query, values)) as StreamResultLike;
   const columns = resolveResultColumns(result);
@@ -497,15 +502,8 @@ export async function* executeInBatchesRaw(
     }
   }
 
-  const rowsPerChunk =
-    options.rowsPerChunk && options.rowsPerChunk > 0
-      ? options.rowsPerChunk
-      : 100_000;
-
-  const values =
-    params.length > 0
-      ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
-      : undefined;
+  const rowsPerChunk = resolveRowsPerChunk(options);
+  const values = toNodeApiValues(params);
 
   const result = (await client.stream(query, values)) as StreamResultLike;
   const columns = resolveResultColumns(result);
@@ -549,10 +547,7 @@ export async function executeArrowOnClient(
     }
   }
 
-  const values =
-    params.length > 0
-      ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
-      : undefined;
+  const values = toNodeApiValues(params);
   const result = await client.run(query, values);
 
   // Runtime detection for Arrow API support (optional method, not in base type)

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -88,6 +88,21 @@ describe('executeInBatches', () => {
     expect(chunks).toEqual([[{ id: 1 }, { id: 2 }], [{ id: 3 }]]);
   });
 
+  test('falls back to the default chunk size for non-positive rowsPerChunk', async () => {
+    const client = makeClient({
+      rows: [[1], [2], [3]],
+    });
+    const chunks: Array<Array<{ id: number }>> = [];
+
+    for await (const chunk of executeInBatches(client, 'select', [], {
+      rowsPerChunk: 0,
+    })) {
+      chunks.push(chunk as Array<{ id: number }>);
+    }
+
+    expect(chunks).toEqual([[{ id: 1 }, { id: 2 }, { id: 3 }]]);
+  });
+
   test('closes stream when consumer exits early', async () => {
     let closeCalls = 0;
     const client = makeClient({


### PR DESCRIPTION
## Summary
This change is a small targeted refactor in the DuckDB client execution path. The user-facing issue was not incorrect results, but avoidable duplication in the logic that prepares Node API values and normalizes batch sizes across the execution helpers. That duplication made the file harder to maintain and increased the chance of drifting behavior between the array, streaming, and Arrow execution paths.

The root cause was that `src/client.ts` repeated the same `params` conversion and `rowsPerChunk` fallback logic in multiple functions. The effect on users would show up later as inconsistent behavior or higher maintenance cost when one call path changed and the others did not.

The fix extracts two small local helpers: one for converting query params into DuckDB Node API values, and one for resolving the effective batch size. The behavior remains the same, but the shared logic now lives in one place and the streaming paths use the same normalization code as the rest of the execution helpers.

## Validation
I added a focused regression test that locks in the existing fallback behavior for non-positive `rowsPerChunk` values. I also ran the local verification loop end to end:

- `bun test test/client-execute.test.ts`
- `bun run build`
- `bun test`
