### PR TITLE
[codex] tighten SQL heuristics and refresh Bun types

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
       },
       "devDependencies": {
         "@duckdb/node-api": "1.4.4-r.1",
-        "@types/bun": "^1.3.10",
+        "@types/bun": "^1.3.11",
         "@types/uuid": "^10.0.0",
         "@vitest/ui": "^1.6.0",
         "drizzle-orm": "0.40.1",
@@ -162,7 +162,7 @@
 
     "@sinclair/typebox": ["@sinclair/typebox@0.27.8", "", {}, "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -196,7 +196,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@duckdb/node-api": "1.4.4-r.1",
-    "@types/bun": "^1.3.10",
+    "@types/bun": "^1.3.11",
     "@types/uuid": "^10.0.0",
     "@vitest/ui": "^1.6.0",
     "drizzle-orm": "0.40.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -86,29 +86,19 @@ export function prepareParams(
 ): unknown[] {
   return params.map((param) => {
     if (typeof param === 'string' && param.length > 0) {
-      const firstChar = param[0];
-      const maybeArrayLiteral =
-        firstChar === '{' ||
-        firstChar === '[' ||
-        firstChar === ' ' ||
-        firstChar === '\t';
+      const trimmed = param.trim();
 
-      if (maybeArrayLiteral) {
-        const trimmed =
-          firstChar === '{' || firstChar === '[' ? param : param.trim();
-
-        if (trimmed && isPgArrayLiteral(trimmed)) {
-          if (options.rejectStringArrayLiterals) {
-            throw new Error(
-              'Stringified array literals are not supported. Use duckDbList()/duckDbArray() or pass native arrays.'
-            );
-          }
-
-          if (options.warnOnStringArrayLiteral) {
-            options.warnOnStringArrayLiteral();
-          }
-          return parsePgArrayLiteral(trimmed);
+      if (trimmed && isPgArrayLiteral(trimmed)) {
+        if (options.rejectStringArrayLiterals) {
+          throw new Error(
+            'Stringified array literals are not supported. Use duckDbList()/duckDbArray() or pass native arrays.'
+          );
         }
+
+        if (options.warnOnStringArrayLiteral) {
+          options.warnOnStringArrayLiteral();
+        }
+        return parsePgArrayLiteral(trimmed);
       }
     }
     return param;

--- a/src/sql/ast-transformer.ts
+++ b/src/sql/ast-transformer.ts
@@ -82,8 +82,7 @@ function debugLog(message: string, payload?: unknown): void {
 }
 
 export function transformSQL(query: string): TransformResult {
-  const needsArrayTransform =
-    ARRAY_OPERATOR_PATTERN.test(query);
+  const needsArrayTransform = ARRAY_OPERATOR_PATTERN.test(query);
   const needsJoinTransform =
     hasJoin(query) || UPDATE_PATTERN.test(query) || DELETE_PATTERN.test(query);
   const needsUnionTransform =

--- a/src/sql/ast-transformer.ts
+++ b/src/sql/ast-transformer.ts
@@ -61,8 +61,17 @@ function getCachedOrTransform(
 
 const DEBUG_ENV = 'DRIZZLE_DUCKDB_DEBUG_AST';
 
+const ARRAY_OPERATOR_PATTERN = /@>|<@|&&/;
+const JOIN_PATTERN = /\bjoin\b/i;
+const UNION_PATTERN = /\bunion\b/i;
+const INTERSECT_PATTERN = /\bintersect\b/i;
+const EXCEPT_PATTERN = /\bexcept\b/i;
+const GENERATE_SERIES_PATTERN = /\bgenerate_series\b/i;
+const UPDATE_PATTERN = /\bupdate\b/i;
+const DELETE_PATTERN = /\bdelete\b/i;
+
 function hasJoin(query: string): boolean {
-  return /\bjoin\b/i.test(query);
+  return JOIN_PATTERN.test(query);
 }
 
 function debugLog(message: string, payload?: unknown): void {
@@ -74,14 +83,14 @@ function debugLog(message: string, payload?: unknown): void {
 
 export function transformSQL(query: string): TransformResult {
   const needsArrayTransform =
-    query.includes('@>') || query.includes('<@') || query.includes('&&');
+    ARRAY_OPERATOR_PATTERN.test(query);
   const needsJoinTransform =
-    hasJoin(query) || /\bupdate\b/i.test(query) || /\bdelete\b/i.test(query);
+    hasJoin(query) || UPDATE_PATTERN.test(query) || DELETE_PATTERN.test(query);
   const needsUnionTransform =
-    /\bunion\b/i.test(query) ||
-    /\bintersect\b/i.test(query) ||
-    /\bexcept\b/i.test(query);
-  const needsGenerateSeriesTransform = /\bgenerate_series\b/i.test(query);
+    UNION_PATTERN.test(query) ||
+    INTERSECT_PATTERN.test(query) ||
+    EXCEPT_PATTERN.test(query);
+  const needsGenerateSeriesTransform = GENERATE_SERIES_PATTERN.test(query);
 
   if (
     !needsArrayTransform &&
@@ -149,18 +158,15 @@ export function getTransformCacheStats(): { size: number; maxSize: number } {
 }
 
 export function needsTransformation(query: string): boolean {
-  const lower = query.toLowerCase();
   return (
-    query.includes('@>') ||
-    query.includes('<@') ||
-    query.includes('&&') ||
-    lower.includes('join') ||
-    lower.includes('union') ||
-    lower.includes('intersect') ||
-    lower.includes('except') ||
-    lower.includes('generate_series') ||
-    lower.includes('update') ||
-    lower.includes('delete')
+    ARRAY_OPERATOR_PATTERN.test(query) ||
+    JOIN_PATTERN.test(query) ||
+    UNION_PATTERN.test(query) ||
+    INTERSECT_PATTERN.test(query) ||
+    EXCEPT_PATTERN.test(query) ||
+    GENERATE_SERIES_PATTERN.test(query) ||
+    UPDATE_PATTERN.test(query) ||
+    DELETE_PATTERN.test(query)
   );
 }
 

--- a/test/ast-transformer.test.ts
+++ b/test/ast-transformer.test.ts
@@ -264,7 +264,9 @@ describe('needsTransformation', () => {
 
   it('returns false for identifiers that only contain keywords as substrings', () => {
     expect(
-      needsTransformation('SELECT updated_at FROM users WHERE deleted_at IS NULL')
+      needsTransformation(
+        'SELECT updated_at FROM users WHERE deleted_at IS NULL'
+      )
     ).toBe(false);
   });
 });

--- a/test/ast-transformer.test.ts
+++ b/test/ast-transformer.test.ts
@@ -261,6 +261,12 @@ describe('needsTransformation', () => {
       false
     );
   });
+
+  it('returns false for identifiers that only contain keywords as substrings', () => {
+    expect(
+      needsTransformation('SELECT updated_at FROM users WHERE deleted_at IS NULL')
+    ).toBe(false);
+  });
 });
 
 describe('transformation cache', () => {

--- a/test/prepare-params.test.ts
+++ b/test/prepare-params.test.ts
@@ -12,6 +12,16 @@ test('prepareParams coerces Postgres array literals', () => {
   expect(warn).toHaveBeenCalledTimes(1);
 });
 
+test('prepareParams coerces Postgres array literals with leading newlines', () => {
+  const warn = vi.fn();
+  const result = prepareParams(['\n{1,2,3}'], {
+    warnOnStringArrayLiteral: warn,
+  });
+
+  expect(result[0]).toEqual([1, 2, 3]);
+  expect(warn).toHaveBeenCalledTimes(1);
+});
+
 test('prepareParams rejects string literals when configured', () => {
   expect(() =>
     prepareParams(['{hello,world}'], { rejectStringArrayLiterals: true })


### PR DESCRIPTION
This change tightens two hot paths and refreshes a low-risk dev dependency.

The SQL transformer now uses word-boundary checks for transformation keywords instead of broad substring matches. That avoids unnecessary parsing for identifiers such as `updated_at` and `deleted_at`, which previously triggered the transformation pipeline even when no rewrite was possible. The behavior of real statements is unchanged, but the false positives are gone.

The parameter preparer now trims both ends before checking for Postgres-style array literals. That keeps the existing array coercion working for values with surrounding whitespace while also handling literals that arrive with leading newlines or other whitespace characters.

I also refreshed `@types/bun` to the current patch release in the dev dependency set.

Validation:
- `bun test`
- `bun run build`
- targeted regression tests for `prepareParams` and `needsTransformation`
