### PR TITLE
[codex] Refactor introspect catalog filters

### DIFF
--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { sql, type SQL } from 'drizzle-orm';
 import type { RowData } from './client.ts';
 import type { DuckDBDatabase } from './driver.ts';
 
@@ -180,23 +180,37 @@ async function resolveSchemas(
     .filter((name) => !SYSTEM_SCHEMAS.has(name));
 }
 
+function buildOptionalEqualityFilter(
+  columnName: string,
+  value: string | null
+): SQL {
+  return value ? sql`${sql.raw(columnName)} = ${value}` : sql`1 = 1`;
+}
+
+function buildSchemaFilter(columnName: string, schemas: string[]): SQL {
+  if (schemas.length === 0) {
+    return sql`1 = 0`;
+  }
+
+  const schemaFragments = schemas.map((schema) => sql`${schema}`);
+  return sql`${sql.raw(columnName)} IN (${sql.join(
+    schemaFragments,
+    sql.raw(', ')
+  )})`;
+}
+
 async function loadTables(
   db: DuckDBDatabase,
   database: string | null,
   schemas: string[],
   includeViews: boolean
 ): Promise<DuckDbTableRow[]> {
-  const schemaFragments = schemas.map((schema) => sql`${schema}`);
-  const databaseFilter = database
-    ? sql`table_catalog = ${database}`
-    : sql`1 = 1`;
-
   return await db.execute<DuckDbTableRow>(
     sql`
       SELECT table_schema as schema_name, table_name, table_type
       FROM information_schema.tables
-      WHERE ${databaseFilter}
-      AND table_schema IN (${sql.join(schemaFragments, sql.raw(', '))})
+      WHERE ${buildOptionalEqualityFilter('table_catalog', database)}
+      AND ${buildSchemaFilter('table_schema', schemas)}
       AND ${includeViews ? sql`1 = 1` : sql`table_type = 'BASE TABLE'`}
       ORDER BY table_schema, table_name
     `
@@ -208,11 +222,6 @@ async function loadColumns(
   database: string | null,
   schemas: string[]
 ): Promise<DuckDbColumnRow[]> {
-  const schemaFragments = schemas.map((schema) => sql`${schema}`);
-  const databaseFilter = database
-    ? sql`database_name = ${database}`
-    : sql`1 = 1`;
-
   return await db.execute<DuckDbColumnRow>(
     sql`
       SELECT
@@ -228,8 +237,8 @@ async function loadColumns(
         numeric_scale,
         internal
       FROM duckdb_columns()
-      WHERE ${databaseFilter}
-      AND schema_name IN (${sql.join(schemaFragments, sql.raw(', '))})
+      WHERE ${buildOptionalEqualityFilter('database_name', database)}
+      AND ${buildSchemaFilter('schema_name', schemas)}
       ORDER BY schema_name, table_name, column_index
     `
   );
@@ -240,11 +249,6 @@ async function loadConstraints(
   database: string | null,
   schemas: string[]
 ): Promise<DuckDbConstraintRow[]> {
-  const schemaFragments = schemas.map((schema) => sql`${schema}`);
-  const databaseFilter = database
-    ? sql`database_name = ${database}`
-    : sql`1 = 1`;
-
   return await db.execute<DuckDbConstraintRow>(
     sql`
       SELECT
@@ -257,8 +261,8 @@ async function loadConstraints(
         referenced_table,
         referenced_column_names
       FROM duckdb_constraints()
-      WHERE ${databaseFilter}
-      AND schema_name IN (${sql.join(schemaFragments, sql.raw(', '))})
+      WHERE ${buildOptionalEqualityFilter('database_name', database)}
+      AND ${buildSchemaFilter('schema_name', schemas)}
       ORDER BY schema_name, table_name, constraint_index
     `
   );
@@ -269,11 +273,6 @@ async function loadIndexes(
   database: string | null,
   schemas: string[]
 ): Promise<DuckDbIndexRow[]> {
-  const schemaFragments = schemas.map((schema) => sql`${schema}`);
-  const databaseFilter = database
-    ? sql`database_name = ${database}`
-    : sql`1 = 1`;
-
   return await db.execute<DuckDbIndexRow>(
     sql`
       SELECT
@@ -283,8 +282,8 @@ async function loadIndexes(
         is_unique,
         expressions
       FROM duckdb_indexes()
-      WHERE ${databaseFilter}
-      AND schema_name IN (${sql.join(schemaFragments, sql.raw(', '))})
+      WHERE ${buildOptionalEqualityFilter('database_name', database)}
+      AND ${buildSchemaFilter('schema_name', schemas)}
       ORDER BY schema_name, table_name, index_name
     `
   );

--- a/test/introspect.empty-database.test.ts
+++ b/test/introspect.empty-database.test.ts
@@ -1,0 +1,18 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import { drizzle } from '../src/index';
+import { introspect } from '../src/introspect';
+import { expect, test } from 'vitest';
+
+test('introspect returns empty results for an unknown database', async () => {
+  const instance = await DuckDBInstance.create(':memory:');
+  const connection = await instance.connect();
+
+  try {
+    const db = drizzle(connection);
+    const result = await introspect(db, { database: 'missing_catalog' });
+
+    expect(result.files.metaJson).toEqual([]);
+  } finally {
+    connection.closeSync();
+  }
+});


### PR DESCRIPTION
## Summary
This change tightens the introspection loader path in two ways. First, it extracts the repeated optional database filter and schema `IN (...)` clauses into shared helpers so the four catalog queries stay aligned. Second, it makes the empty-schema case explicit by returning a false filter instead of emitting an invalid `IN ()` clause.

## Problem
`src/introspect.ts` built nearly identical catalog filters in `loadTables`, `loadColumns`, `loadConstraints`, and `loadIndexes`. That duplication made the behavior harder to keep consistent and hid an edge case: when schema resolution returned no user schemas, the follow-up catalog queries attempted to build `IN ()`, which is invalid SQL.

For users, that meant introspection could fail before returning a clean empty result when they targeted a missing or otherwise empty catalog. The failure mode was a SQL parser error instead of an empty schema snapshot.

## Root Cause
The filter construction lived inline in each loader and assumed `schemas` was always non-empty. That assumption is usually true for normal databases, but it breaks for catalog selections that resolve to zero non-system schemas.

## Fix
The refactor introduces two small helpers:

- `buildOptionalEqualityFilter()` centralizes the repeated `column = value` or `1 = 1` logic.
- `buildSchemaFilter()` centralizes schema filtering and returns `1 = 0` when the schema list is empty.

All four catalog loaders now use the same filter construction path. A new regression test covers introspection against an unknown database and asserts that the result is empty instead of crashing.

## Validation
I validated the change with:

- `bun run build`
- `bun test`

Both passed locally before opening this PR.
