### PR TITLE
[codex] Refactor array literal parsing

### DIFF
--- a/src/array-literals.ts
+++ b/src/array-literals.ts
@@ -1,0 +1,34 @@
+function parseArrayJson(value: string): unknown[] | undefined {
+  try {
+    const parsed = JSON.parse(value) as unknown;
+    return Array.isArray(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function isPgArrayLiteral(value: string): boolean {
+  return value.startsWith('{') && value.endsWith('}');
+}
+
+export function coerceArrayString(value: string): unknown[] | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  if (trimmed.startsWith('[')) {
+    return parseArrayJson(trimmed);
+  }
+
+  if (isPgArrayLiteral(trimmed)) {
+    const json = trimmed.replace(/{/g, '[').replace(/}/g, ']');
+    return parseArrayJson(json);
+  }
+
+  return undefined;
+}
+
+export function parsePgArrayLiteral(value: string): unknown {
+  return coerceArrayString(value) ?? value;
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,6 +12,7 @@ import {
   type AnyDuckDBValueWrapper,
 } from './value-wrappers.ts';
 import type { PreparedStatementCacheConfig } from './options.ts';
+import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
 
 export type DuckDBClientLike = DuckDBConnection | DuckDBConnectionPool;
 export type RowData = Record<string, unknown>;
@@ -64,20 +65,6 @@ const PREPARED_CACHE = Symbol.for('drizzle-duckdb:prepared-cache');
 export interface PrepareParamsOptions {
   rejectStringArrayLiterals?: boolean;
   warnOnStringArrayLiteral?: () => void;
-}
-
-function isPgArrayLiteral(value: string): boolean {
-  return value.startsWith('{') && value.endsWith('}');
-}
-
-function parsePgArrayLiteral(value: string): unknown {
-  const json = value.replace(/{/g, '[').replace(/}/g, ']');
-
-  try {
-    return JSON.parse(json);
-  } catch {
-    return value;
-  }
 }
 
 export function prepareParams(

--- a/src/columns.ts
+++ b/src/columns.ts
@@ -15,6 +15,9 @@ import {
   type JsonValueWrapper,
   type TimestampValueWrapper,
 } from './value-wrappers-core.ts';
+import { coerceArrayString as parseArrayString } from './array-literals.ts';
+
+export { coerceArrayString } from './array-literals.ts';
 
 type IntColType =
   | 'SMALLINT'
@@ -65,27 +68,25 @@ type StructColType = `STRUCT (${string})`;
 
 type Primitive = AnyColType | ListColType | ArrayColType | StructColType;
 
-export function coerceArrayString(value: string): unknown[] | undefined {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return [];
+type ArrayDriverValue =
+  | unknown[]
+  | string
+  | ListValueWrapper
+  | ArrayValueWrapper;
+
+function coerceArrayDriverValue<TData>(value: ArrayDriverValue): TData[] {
+  if (Array.isArray(value)) {
+    return value as TData[];
   }
-  if (trimmed.startsWith('[')) {
-    try {
-      return JSON.parse(trimmed) as unknown[];
-    } catch {
-      return undefined;
+
+  if (typeof value === 'string') {
+    const parsed = parseArrayString(value);
+    if (parsed !== undefined) {
+      return parsed as TData[];
     }
   }
-  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
-    try {
-      const json = trimmed.replace(/{/g, '[').replace(/}/g, ']');
-      return JSON.parse(json) as unknown[];
-    } catch {
-      return undefined;
-    }
-  }
-  return undefined;
+
+  return value as unknown as TData[];
 }
 
 export function formatLiteral(value: unknown, typeHint?: string): string {
@@ -185,16 +186,7 @@ export const duckDbList = <TData = unknown>(
       return wrapList(value, elementType);
     },
     fromDriver(value: unknown[] | string | ListValueWrapper): TData[] {
-      if (Array.isArray(value)) {
-        return value as TData[];
-      }
-      if (typeof value === 'string') {
-        const parsed = coerceArrayString(value);
-        if (parsed !== undefined) {
-          return parsed as TData[];
-        }
-      }
-      return value as unknown as TData[];
+      return coerceArrayDriverValue(value);
     },
   })(name);
 
@@ -216,16 +208,7 @@ export const duckDbArray = <TData = unknown>(
       return wrapArray(value, elementType, fixedLength);
     },
     fromDriver(value: unknown[] | string | ArrayValueWrapper): TData[] {
-      if (Array.isArray(value)) {
-        return value as TData[];
-      }
-      if (typeof value === 'string') {
-        const parsed = coerceArrayString(value);
-        if (parsed !== undefined) {
-          return parsed as TData[];
-        }
-      }
-      return value as unknown as TData[];
+      return coerceArrayDriverValue(value);
     },
   })(name);
 

--- a/test/prepare-params.test.ts
+++ b/test/prepare-params.test.ts
@@ -36,3 +36,12 @@ test('prepareParams leaves plain strings untouched', () => {
   expect(result).toEqual(input);
   expect(warn).not.toHaveBeenCalled();
 });
+
+test('prepareParams preserves unparsable Postgres array literals', () => {
+  const warn = vi.fn();
+  const input = ['{hello,world}'];
+  const result = prepareParams(input, { warnOnStringArrayLiteral: warn });
+
+  expect(result).toEqual(input);
+  expect(warn).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Summary
This PR applies a small targeted refactor to the array-literal parsing path used by Drizzle DuckDB. The user-facing behavior stays the same, but the parsing logic now lives in one shared helper instead of being copied in separate places.

## Issue
The codebase had two independent implementations for Postgres-style array literal parsing. `prepareParams()` in `src/client.ts` converted `{...}` strings before binding query params, while `coerceArrayString()` in `src/columns.ts` handled the same shape when reading string-backed array values from DuckDB.

That duplication created a maintenance risk. Any future fix to parsing semantics, whitespace handling, or fallback behavior would need to be updated in both places, and it was easy for the two paths to drift apart.

## Root cause
Array literal coercion grew in two nearby code paths for slightly different callers, but the normalization rules were effectively shared:
- detect Postgres-style `{...}` literals
- convert them to JSON-like syntax for parsing
- fall back safely when parsing is not possible

`duckDbList()` and `duckDbArray()` also repeated the same driver-value coercion logic on top of that.

## Fix
The refactor introduces `src/array-literals.ts` as the shared source of truth for:
- detecting Postgres-style array literals
- coercing string arrays into native arrays
- preserving the original string when a Postgres-style literal is syntactically detected but cannot be parsed

Then:
- `src/client.ts` now imports the shared helpers instead of keeping an inline copy
- `src/columns.ts` re-exports `coerceArrayString()` to preserve the existing API surface
- `src/columns.ts` uses one local `coerceArrayDriverValue()` helper so `duckDbList()` and `duckDbArray()` no longer duplicate the same `fromDriver()` logic
- `test/prepare-params.test.ts` adds a regression test for the fallback case where a Postgres-style array literal is detected but left unchanged because it cannot be parsed

## Validation
I validated this change with:
- `bun install`
- `bun run build`
- `bun test`
