### PR TITLE
[codex] Refactor DuckLake attach option builder

### DIFF
--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -43,6 +43,16 @@ export interface DuckLakePoolResolution {
 }
 
 const DEFAULT_ALIAS = 'ducklake';
+const DUCKLAKE_ATTACH_OPTION_NAMES = {
+  createIfNotExists: 'CREATE_IF_NOT_EXISTS',
+  dataInliningRowLimit: 'DATA_INLINING_ROW_LIMIT',
+  dataPath: 'DATA_PATH',
+  encrypted: 'ENCRYPTED',
+  metaParameterName: 'META_PARAMETER_NAME',
+  metadataCatalog: 'METADATA_CATALOG',
+  overrideDataPath: 'OVERRIDE_DATA_PATH',
+  readOnly: 'READ_ONLY',
+} as const satisfies Record<keyof DuckLakeAttachOptions, string>;
 
 function escapeSqlString(value: string): string {
   return value.replace(/'/g, "''");
@@ -91,53 +101,34 @@ function optionValueToSql(value: string | number | boolean): string {
   return quoteString(value);
 }
 
+function buildDuckLakeAttachOptionsSql(
+  attachOptions?: DuckLakeAttachOptions
+): string[] {
+  if (!attachOptions) {
+    return [];
+  }
+
+  const options: string[] = [];
+
+  for (const [key, optionName] of Object.entries(
+    DUCKLAKE_ATTACH_OPTION_NAMES
+  ) as [keyof DuckLakeAttachOptions, string][]) {
+    const value = attachOptions[key];
+    if (value === undefined) {
+      continue;
+    }
+    if (typeof value === 'string' && value.length === 0) {
+      continue;
+    }
+    options.push(`${optionName}=${optionValueToSql(value)}`);
+  }
+
+  return options;
+}
+
 export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
   const normalized = normalizeDuckLakeConfig(config);
-  const options: string[] = [];
-  const attachOptions = normalized.attachOptions;
-
-  if (attachOptions) {
-    if (attachOptions.createIfNotExists !== undefined) {
-      options.push(
-        `CREATE_IF_NOT_EXISTS=${optionValueToSql(
-          attachOptions.createIfNotExists
-        )}`
-      );
-    }
-    if (attachOptions.dataInliningRowLimit !== undefined) {
-      options.push(
-        `DATA_INLINING_ROW_LIMIT=${optionValueToSql(
-          attachOptions.dataInliningRowLimit
-        )}`
-      );
-    }
-    if (attachOptions.dataPath) {
-      options.push(`DATA_PATH=${optionValueToSql(attachOptions.dataPath)}`);
-    }
-    if (attachOptions.encrypted !== undefined) {
-      options.push(`ENCRYPTED=${optionValueToSql(attachOptions.encrypted)}`);
-    }
-    if (attachOptions.metaParameterName) {
-      options.push(
-        `META_PARAMETER_NAME=${optionValueToSql(
-          attachOptions.metaParameterName
-        )}`
-      );
-    }
-    if (attachOptions.metadataCatalog) {
-      options.push(
-        `METADATA_CATALOG=${optionValueToSql(attachOptions.metadataCatalog)}`
-      );
-    }
-    if (attachOptions.overrideDataPath !== undefined) {
-      options.push(
-        `OVERRIDE_DATA_PATH=${optionValueToSql(attachOptions.overrideDataPath)}`
-      );
-    }
-    if (attachOptions.readOnly !== undefined) {
-      options.push(`READ_ONLY=${optionValueToSql(attachOptions.readOnly)}`);
-    }
-  }
+  const options = buildDuckLakeAttachOptionsSql(normalized.attachOptions);
 
   const attachSql = [
     `ATTACH ${quoteString(normalized.catalog)} AS ${quoteIdentifier(

--- a/test/ducklake.helpers.test.ts
+++ b/test/ducklake.helpers.test.ts
@@ -30,6 +30,22 @@ describe('DuckLake helpers', () => {
     );
   });
 
+  test('buildDuckLakeAttachSql escapes identifiers and skips blank strings', () => {
+    const sql = buildDuckLakeAttachSql({
+      catalog: "md:meta'db",
+      alias: 'lake"name',
+      attachOptions: {
+        dataPath: '',
+        metadataCatalog: "cat'alog",
+        readOnly: false,
+      },
+    });
+
+    expect(sql).toBe(
+      `ATTACH 'ducklake:md:meta''db' AS "lake""name" (METADATA_CATALOG='cat''alog', READ_ONLY=false)`
+    );
+  });
+
   test('isDuckDbFileCatalog detects local file catalogs', () => {
     expect(isDuckDbFileCatalog('./ducklake.duckdb')).toBe(true);
     expect(isDuckDbFileCatalog('ducklake:./ducklake.duckdb')).toBe(true);


### PR DESCRIPTION
## Summary
This PR applies a small targeted refactor to the DuckLake attach SQL builder. The builder previously expanded every supported attach option with a separate hand-written conditional block, which made the code longer than necessary and easy to drift when adding or renaming options.

## User impact
There is no intended behavior change for consumers. DuckLake attach SQL should continue to render exactly as before for existing options. The added regression coverage protects two user-facing edge cases: escaping quoted catalog and alias values correctly, and skipping blank string options instead of emitting empty SQL literals.

## Root cause
`buildDuckLakeAttachSql()` encoded option names and inclusion rules inline, repeating the same pattern for each attach option. That duplication increased maintenance cost and made it harder to verify that each option followed the same quoting and omission rules.

## Fix
The refactor introduces a single keyed map of DuckLake attach option names and a helper that converts the provided `attachOptions` object into SQL fragments. The public behavior stays the same while the option formatting logic is now centralized in one loop. The test suite now also covers identifier escaping plus blank-string filtering so future edits have a tighter safety net.

## Validation
- `bun test test/ducklake.helpers.test.ts`
- `bun run build`
