### PR TITLE
[codex] align package name and publish flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is `@leonardovida-md/drizzle-neo-duckdb`, a DuckDB dialect adapter for drizzle-orm. It builds on Drizzle's Postgres driver surface but targets DuckDB, providing query building, migrations, and type inference for DuckDB's Node runtime (`@duckdb/node-api`).
+This is `@duckdbfan/drizzle-duckdb`, a DuckDB dialect adapter for drizzle-orm. It builds on Drizzle's Postgres driver surface but targets DuckDB, providing query building, migrations, and type inference for DuckDB's Node runtime (`@duckdb/node-api`). The legacy package name `@leonardovida-md/drizzle-neo-duckdb` remains published for backward compatibility.
 
 ## Commands
 

--- a/example/motherduck-nyc.ts
+++ b/example/motherduck-nyc.ts
@@ -3,7 +3,7 @@
  *
  * Demonstrates the simplest way to connect to MotherDuck with automatic pooling.
  */
-import { drizzle } from '@leonardovida-md/drizzle-neo-duckdb';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
 import { sql } from 'drizzle-orm';
 import {
   doublePrecision,

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@leonardovida-md/drizzle-neo-duckdb",
+  "name": "@duckdbfan/drizzle-duckdb",
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/scripts/publish-dual.ts
+++ b/scripts/publish-dual.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 /**
  * Publishes the package under both npm scopes:
- * - @leonardovida-md/drizzle-neo-duckdb (original)
- * - @duckdbfan/drizzle-duckdb (new)
+ * - @duckdbfan/drizzle-duckdb (canonical)
+ * - @leonardovida-md/drizzle-neo-duckdb (legacy)
  *
  * Usage: bun run publish:dual [--dry-run]
  */
@@ -11,8 +11,8 @@ import { $ } from 'bun';
 import { readFile, writeFile } from 'node:fs/promises';
 
 const PACKAGE_JSON_PATH = new URL('../package.json', import.meta.url).pathname;
-const ORIGINAL_NAME = '@leonardovida-md/drizzle-neo-duckdb';
-const NEW_NAME = '@duckdbfan/drizzle-duckdb';
+const CANONICAL_NAME = '@duckdbfan/drizzle-duckdb';
+const LEGACY_NAME = '@leonardovida-md/drizzle-neo-duckdb';
 
 const dryRun = process.argv.includes('--dry-run');
 
@@ -44,41 +44,46 @@ async function publish(name: string) {
 }
 
 async function main() {
+  let originalPkg: Record<string, unknown> | undefined;
+  let publishFailed = false;
+
   if (dryRun) {
     console.log('Running in dry-run mode (no actual publishing)\n');
   }
 
-  // Read original package.json
-  const originalPkg = await readPackageJson();
-  const version = originalPkg.version;
+  try {
+    originalPkg = await readPackageJson();
+    const version = originalPkg.version;
 
-  console.log(`Publishing version ${version} to both scopes...`);
+    console.log(`Publishing version ${version} to both scopes...`);
 
-  // Ensure we're built
-  console.log('\nBuilding...');
-  if (!dryRun) {
-    await $`bun run build`.quiet();
+    // Ensure we're built
+    console.log('\nBuilding...');
+    if (!dryRun) {
+      await $`bun run build`.quiet();
+    }
+
+    // Publish the canonical package first.
+    await writePackageJson({ ...originalPkg, name: CANONICAL_NAME });
+    const canonicalResult = await publish(CANONICAL_NAME);
+
+    // Publish the legacy package name for backwards compatibility.
+    await writePackageJson({ ...originalPkg, name: LEGACY_NAME });
+    const legacyResult = await publish(LEGACY_NAME);
+
+    console.log('\n--- Summary ---');
+    console.log(`${CANONICAL_NAME}: ${canonicalResult ? 'success' : 'failed'}`);
+    console.log(`${LEGACY_NAME}: ${legacyResult ? 'success' : 'failed'}`);
+
+    publishFailed = !canonicalResult || !legacyResult;
+  } finally {
+    if (originalPkg) {
+      await writePackageJson(originalPkg);
+    }
   }
 
-  // Publish under original name first
-  const pkg1 = { ...originalPkg, name: ORIGINAL_NAME };
-  await writePackageJson(pkg1);
-  const result1 = await publish(ORIGINAL_NAME);
-
-  // Publish under new name
-  const pkg2 = { ...originalPkg, name: NEW_NAME };
-  await writePackageJson(pkg2);
-  const result2 = await publish(NEW_NAME);
-
-  // Restore original package.json (keep original name as canonical)
-  await writePackageJson(originalPkg);
-
-  console.log('\n--- Summary ---');
-  console.log(`${ORIGINAL_NAME}: ${result1 ? 'success' : 'failed'}`);
-  console.log(`${NEW_NAME}: ${result2 ? 'success' : 'failed'}`);
-
-  if (!result1 || !result2) {
-    process.exit(1);
+  if (publishFailed) {
+    throw new Error('One or more publish steps failed');
   }
 }
 

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -109,7 +109,7 @@ type ImportBuckets = {
 };
 
 export const DEFAULT_IMPORT_BASE =
-  '@leonardovida-md/drizzle-neo-duckdb/helpers';
+  '@duckdbfan/drizzle-duckdb/helpers';
 
 export async function introspect(
   db: DuckDBDatabase,

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -108,8 +108,7 @@ type ImportBuckets = {
   local: Set<string>;
 };
 
-export const DEFAULT_IMPORT_BASE =
-  '@duckdbfan/drizzle-duckdb/helpers';
+export const DEFAULT_IMPORT_BASE = '@duckdbfan/drizzle-duckdb/helpers';
 
 export async function introspect(
   db: DuckDBDatabase,

--- a/test/helpers-import-path.test.ts
+++ b/test/helpers-import-path.test.ts
@@ -4,7 +4,7 @@ describe('client-safe helpers entry', () => {
   it('uses helpers import base for introspection', async () => {
     const { DEFAULT_IMPORT_BASE } = await import('../src/introspect.ts');
     expect(DEFAULT_IMPORT_BASE).toBe(
-      '@leonardovida-md/drizzle-neo-duckdb/helpers'
+      '@duckdbfan/drizzle-duckdb/helpers'
     );
   });
 

--- a/test/helpers-import-path.test.ts
+++ b/test/helpers-import-path.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 describe('client-safe helpers entry', () => {
   it('uses helpers import base for introspection', async () => {
     const { DEFAULT_IMPORT_BASE } = await import('../src/introspect.ts');
-    expect(DEFAULT_IMPORT_BASE).toBe(
-      '@duckdbfan/drizzle-duckdb/helpers'
-    );
+    expect(DEFAULT_IMPORT_BASE).toBe('@duckdbfan/drizzle-duckdb/helpers');
   });
 
   it('helpers entry stays free of native binding imports', async () => {

--- a/test/introspect.typecheck.test.ts
+++ b/test/introspect.typecheck.test.ts
@@ -37,7 +37,7 @@ test('generated schema type-checks with tsc', async () => {
   fs.mkdirSync(tmpDir, { recursive: true });
   const schemaPath = path.join(tmpDir, 'tc-schema.ts');
 
-  const importBasePath = '@leonardovida-md/drizzle-neo-duckdb';
+  const importBasePath = '@duckdbfan/drizzle-duckdb';
 
   const result = await introspect(db, {
     schemas: ['tc'],
@@ -59,7 +59,7 @@ test('generated schema type-checks with tsc', async () => {
       // baseUrl is required for TS to apply `paths` mappings below
       baseUrl: '.',
       paths: {
-        '@leonardovida-md/drizzle-neo-duckdb': [
+        '@duckdbfan/drizzle-duckdb': [
           path.relative(tmpDir, path.join(process.cwd(), 'src', 'index.ts')),
           path.relative(tmpDir, path.join(process.cwd(), 'dist', 'index.d.ts')),
         ],


### PR DESCRIPTION
This change makes `@duckdbfan/drizzle-duckdb` the canonical package name in the repo and aligns generated schema imports with the new package. The legacy package name remains available through the existing override path and the dual-publish script still handles both names for backward compatibility.

What changed:
- Switched `package.json` to the canonical package name and bumped the patch version.
- Updated the introspection default import base to the new package helper entry.
- Updated the introspection typecheck and helper-path tests to match the canonical name.
- Hardened `scripts/publish-dual.ts` so it always restores `package.json`, even if a publish step fails.

Why:
- The README and publish story already point at the new package, but generated output and default introspection still used the legacy scope.
- The publish script could leave `package.json` in a temporary state if a failure happened mid-run.

Validation:
- `bun run build`
- `bun test`
