### PR TITLE
Release v1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,7 @@ Works with local DuckDB files, in-memory databases, and [MotherDuck](https://mot
 
 > **Status:** Experimental. Core query building, migrations, and type inference work well. Some DuckDB-specific types and edge cases are still being refined.
 
-> **Note:** The main NPM package is now `@duckdbfan/drizzle-duckdb`.
-> The previous package `@leonardovida-md/drizzle-neo-duckdb` remains published but will be deprecated.
-> Updates will land in both packages through May 2, 2026.
-> After that date, only `@duckdbfan/drizzle-duckdb` will receive updates.
+> **Note:** The npm package is `@duckdbfan/drizzle-duckdb`.
 
 Docs tip: every docs page has a **Markdown (raw)** button for LLM-friendly source.
 
@@ -40,7 +37,7 @@ npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Recommended client version is `@duckdb/node-api@1.4.4-r.1`, which bundles DuckDB 1.4.4.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.1-r.1`. The repo now develops against `1.5.1-r.1`, and `1.4.4-r.1` remains supported.
 
 ## Quick Start
 

--- a/bun.lock
+++ b/bun.lock
@@ -3,12 +3,12 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@leonardovida-md/drizzle-neo-duckdb",
+      "name": "@duckdbfan/drizzle-duckdb",
       "dependencies": {
         "node-sql-parser": "^5.4.0",
       },
       "devDependencies": {
-        "@duckdb/node-api": "1.4.4-r.1",
+        "@duckdb/node-api": "1.5.1-r.1",
         "@types/bun": "^1.3.11",
         "@types/uuid": "^10.0.0",
         "@vitest/ui": "^1.6.1",
@@ -20,7 +20,7 @@
         "vitest": "^1.6.1",
       },
       "peerDependencies": {
-        "@duckdb/node-api": "1.4.4-r.1",
+        "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
         "drizzle-orm": "^0.40.1",
       },
       "optionalPeers": [
@@ -32,19 +32,21 @@
     "esbuild": "0.25.12",
   },
   "packages": {
-    "@duckdb/node-api": ["@duckdb/node-api@1.4.4-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.4.4-r.1" } }, "sha512-oqaH9DXTJNwyLkd2FgJwmSnWVqjB5irbESeTeNVMBnM03iRaNY545BhfBDumu1TnOV2koIdG1mNsmjgq/ZTIkA=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.1-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.1-r.1" } }, "sha512-8U8p44ZL4rJtUrgVaSLm2hOMk3XTwEgs5eJoxYiR6iQXKVEr8vi6z3Vrxhb61g9sgsEZIAmckD7e3zZ1lmPHYA=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.4.4-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.4.4-r.1", "@duckdb/node-bindings-darwin-x64": "1.4.4-r.1", "@duckdb/node-bindings-linux-arm64": "1.4.4-r.1", "@duckdb/node-bindings-linux-x64": "1.4.4-r.1", "@duckdb/node-bindings-win32-x64": "1.4.4-r.1" } }, "sha512-NFm0AMrK3kiVLQhgnGUEjX5c8Elm93dYePZ9BUCvvd0AVVTKEBeRhBp9afziuzP3Sl5+7XQ1TyaBLsZJKKBDBQ=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.1-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.1-r.1", "@duckdb/node-bindings-darwin-x64": "1.5.1-r.1", "@duckdb/node-bindings-linux-arm64": "1.5.1-r.1", "@duckdb/node-bindings-linux-x64": "1.5.1-r.1", "@duckdb/node-bindings-win32-arm64": "1.5.1-r.1", "@duckdb/node-bindings-win32-x64": "1.5.1-r.1" } }, "sha512-3vmIlY/ACTLutlMup4F+D2Gzo+kiUoMaIL4TvM4x34cMqnKfsZ+4lMjqfSKYmdcgNGXYXwPwIYaJlvMRhU3Tbg=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.4.4-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-/NtbkCgCAOJDxw41XvSGV/mxQAlsx+2xUvhIVUj6fxoOfTG4jTttRhuphwE3EXNoWzJOjZxCZ5LwhC/qb6ZwLg=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.1-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm0Q/P8/OB/ZDITNTUe80emlg0b7/EcqTPBRu4GmULbt/fFDtkEAjDHDblKZL1yazf7X6JFEabHBGuWL5jmjEw=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.4.4-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-lzFRDrZwc1EoV513vmKufasiAQ2WlhEb0O6guRBarbvOKKVhRb8tQ5H7LPVTrIewjTI3XDgHrnK+vfh9L+xQcA=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.1-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GOKWYbOP1v5jppGjlCaQzvyzVnY8/dGd7UJcnT213uiSMq/mtQk2yvzZCPhq7UdxmqR0TSd+TKttpozd8ANyOQ=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.4.4-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-wq92/EcTiOTRW1RSDOwjeLyMMXWwNVNwU21TQdfu3sgS86+Ih3raaK68leDgY5cWgf72We3J2W7HYz8GwxcMYw=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.1-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-b0tHCtC+GZnD6gJA+ldUwy8FhnugR1Uq0/LjLiusOQOoK5pRXyfiQjgIe/SiKSeE5iEr+FWUXEprSD81HOaaQg=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.4.4-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-fjYNc+t4/T7mhzZ57oJoIQaWvbYVvxhidcNNansQFiWnd6/JMLCULd4qnt8XI3Tt2BrZsraH690KSBIS3QPt0w=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.1-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-AczM4qyMuMXHIa7w1YacIu6FFPpwzUsQSkPUFKsAJzyuRcxAlGEwt+2GnVZSACGQFpKbL9nAkuu3Icq6ttxwag=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.4.4-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-+J+MUYGvYWfX0balWToDIy3CBYg7hHI0KQUQ39+SniinXlMF8+puRW6ebyQ+AXrcrKkwuj4wzJuEBD0AdhHGtw=="],
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.1-r.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-SrgAiFttkfFXCCAMrmMBWtnBMtEjVaC38XtG6zEdbvmp2RTEPo/dFcvRP75vS/Hm5Iq8Tgiuoq4tIdovwEw5yg=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.1-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-JkL9xvXx9i8ceU1fGJsb9gqgRn30RFi0HyfpuESK2AZInKx5mJn8fvYcj4AQg/Ip9SZ1S4a2Jh5DOFY81koubw=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 

--- a/docs/core/transactions.md
+++ b/docs/core/transactions.md
@@ -94,7 +94,7 @@ try {
 
 > **DuckDB Limitation**
 >
-> DuckDB 1.4.x does **not** support `SAVEPOINT`. The driver will try once per dialect instance; after the syntax error it marks savepoints unsupported and nested calls reuse the outer transaction.
+> DuckDB 1.4.x and 1.5.x currently do **not** support `SAVEPOINT`. The driver will try once per dialect instance. After the syntax error, it marks savepoints unsupported and nested calls reuse the outer transaction.
 
 ### What Happens with Nested Transactions
 

--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -9,6 +9,8 @@ nav_order: 3
 
 DuckDB provides several types not found in standard Postgres. This guide covers how to use them with Drizzle.
 
+DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.1-r.1` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
+
 ## Import
 
 ```typescript

--- a/docs/getting-started/coming-from-postgres.md
+++ b/docs/getting-started/coming-from-postgres.md
@@ -11,15 +11,15 @@ If you're already using Drizzle with Postgres, here's what you need to know to s
 
 ## Key Differences
 
-| Feature                  | Drizzle Postgres      | Drizzle DuckDB                                                         |
-| ------------------------ | --------------------- | ---------------------------------------------------------------------- |
-| JSON columns             | `json()`, `jsonb()`   | `duckDbJson()` only                                                    |
-| Nested transactions      | `SAVEPOINT` supported | DuckDB 1.4.x has no savepoints; driver probes once then reuses outer   |
-| Array operators          | `@>`, `<@`, `&&`      | Auto-rewritten or use helpers                                          |
-| Default schema           | `public`              | `main`                                                                 |
-| Serial columns           | `SERIAL` type         | Sequence + `nextval()`                                                 |
-| Result streaming         | Supported             | Chunked via `executeBatches()` / `executeArrow()`; no cursor streaming |
-| Prepared statement cache | Yes                   | No                                                                     |
+| Feature                  | Drizzle Postgres      | Drizzle DuckDB                                                                  |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------------- |
+| JSON columns             | `json()`, `jsonb()`   | `duckDbJson()` only                                                             |
+| Nested transactions      | `SAVEPOINT` supported | DuckDB 1.4.x and 1.5.x have no savepoints; driver probes once then reuses outer |
+| Array operators          | `@>`, `<@`, `&&`      | Auto-rewritten or use helpers                                                   |
+| Default schema           | `public`              | `main`                                                                          |
+| Serial columns           | `SERIAL` type         | Sequence + `nextval()`                                                          |
+| Result streaming         | Supported             | Chunked via `executeBatches()` / `executeArrow()`; no cursor streaming          |
+| Prepared statement cache | Yes                   | No                                                                              |
 
 ## Required Changes
 
@@ -140,7 +140,7 @@ const users = pgTable('users', {
 
 ### No Savepoints (driver auto-detects)
 
-DuckDB 1.4.x doesn't support `SAVEPOINT`. The driver will try once, mark it unsupported if the backend errors, and then reuse the outer transaction for all nested calls:
+DuckDB 1.4.x and 1.5.x currently reject `SAVEPOINT`. The driver will try once, mark it unsupported if the backend errors, and then reuse the outer transaction for all nested calls:
 
 ```typescript
 // This behaves DIFFERENTLY than Postgres!

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,7 +12,6 @@ Install Drizzle DuckDB and its peer dependency.
 {: .warning }
 
 > Install `@duckdbfan/drizzle-duckdb`.
-> The previous package `@leonardovida-md/drizzle-neo-duckdb` is in deprecation and receives updates only through May 2, 2026.
 
 ## Package Installation
 
@@ -40,7 +39,7 @@ pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Recommended client version is `@duckdb/node-api@1.4.4-r.1`, which bundles DuckDB 1.4.4.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.1-r.1`. The repo now develops against `1.5.1-r.1`, and `1.4.4-r.1` remains supported.
 
 ## Requirements
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,7 +12,7 @@ Drizzle DuckDB is a DuckDB dialect adapter for Drizzle ORM. It provides type-saf
 npm install @duckdbfan/drizzle-duckdb drizzle-orm @duckdb/node-api
 ```
 
-Package note: use `@duckdbfan/drizzle-duckdb` for new installs. `@leonardovida-md/drizzle-neo-duckdb` is deprecated and receives updates only through May 2, 2026.
+Package note: use `@duckdbfan/drizzle-duckdb`.
 
 ## Quick Start
 
@@ -45,7 +45,8 @@ const allUsers = await db.select().from(users);
 ## Important Notes
 
 - Do NOT use Postgres json or jsonb columns - use duckDbJson() instead
-- Current DuckDB 1.4.x builds do not support `SAVEPOINT`. Nested transactions reuse the outer transaction and mark it for rollback on nested errors.
+- Current DuckDB 1.4.x and 1.5.x builds do not support `SAVEPOINT`. Nested transactions reuse the outer transaction and mark it for rollback on nested errors.
+- DuckDB 1.5 adds `VARIANT` and built-in `GEOMETRY`, but raw JS materialization for those types is still limited by `@duckdb/node-api`. Cast them before selecting, for example with `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)`.
 - Array operators are automatically rewritten to DuckDB functions
 
 ## Documentation

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -11,26 +11,27 @@ This page documents known differences between Drizzle DuckDB and Drizzle's stand
 
 ## Feature Support Matrix
 
-| Feature              | Status  | Notes                                                                      |
-| -------------------- | ------- | -------------------------------------------------------------------------- |
-| Select queries       | Full    | All standard select operations work                                        |
-| Insert/Update/Delete | Full    | Including `.returning()`                                                   |
-| Joins                | Full    | All join types supported; same-name columns auto-qualified                 |
-| Subqueries           | Full    |                                                                            |
-| CTEs (WITH clauses)  | Full    | Join column ambiguity auto-resolved                                        |
-| Aggregations         | Full    |                                                                            |
-| Transactions         | Partial | No savepoints (driver probes once, then falls back)                        |
-| Concurrent queries   | Partial | One query per connection; use pooling for parallelism                      |
-| Prepared statements  | Partial | No statement caching; no named statements                                  |
-| JSON/JSONB columns   | None    | Use `duckDbJson()` instead                                                 |
-| Streaming results    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks |
-| Relational queries   | Full    | With schema configuration                                                  |
+| Feature                              | Status  | Notes                                                                                                               |
+| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| Select queries                       | Full    | All standard select operations work                                                                                 |
+| Insert/Update/Delete                 | Full    | Including `.returning()`                                                                                            |
+| Joins                                | Full    | All join types supported; same-name columns auto-qualified                                                          |
+| Subqueries                           | Full    |                                                                                                                     |
+| CTEs (WITH clauses)                  | Full    | Join column ambiguity auto-resolved                                                                                 |
+| Aggregations                         | Full    |                                                                                                                     |
+| Transactions                         | Partial | No savepoints in current 1.4.x/1.5.x builds (driver probes once, then falls back)                                   |
+| Concurrent queries                   | Partial | One query per connection; use pooling for parallelism                                                               |
+| Prepared statements                  | Partial | No statement caching; no named statements                                                                           |
+| JSON/JSONB columns                   | None    | Use `duckDbJson()` instead                                                                                          |
+| `VARIANT` / `GEOMETRY` raw JS values | Partial | DuckDB 1.5 types exist, but `@duckdb/node-api` cannot yet materialize raw values reliably. Cast in the query first. |
+| Streaming results                    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks                                          |
+| Relational queries                   | Full    | With schema configuration                                                                                           |
 
 ## Transactions
 
 ### No Savepoint Support
 
-DuckDB 1.4.x doesn't support `SAVEPOINT`, which means nested transactions behave differently. The driver attempts a savepoint once per dialect instance; after a syntax error it marks savepoints unsupported and reuses the outer transaction for nested calls.
+DuckDB 1.4.x and 1.5.x currently reject `SAVEPOINT`, which means nested transactions behave differently. The driver attempts a savepoint once per dialect instance. After a syntax error, it marks savepoints unsupported and reuses the outer transaction for nested calls.
 
 ```typescript
 // In Postgres: inner rollback only affects inner transaction
@@ -48,6 +49,24 @@ await db.transaction(async (tx) => {
 ```
 
 **Workaround:** Structure your code to avoid nested transactions, or handle rollback logic at the outer level. The driver will attempt a savepoint once per dialect instance; current DuckDB builds reject the syntax, so nested calls fall back to the outer transaction and mark it for rollback on errors.
+
+## DuckDB 1.5 Core Types
+
+DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.1-r.1` still throws a low-level conversion error when those raw values are materialized into JavaScript.
+
+Use explicit projections when querying those columns:
+
+```typescript
+await db.execute(sql`
+  select
+    cast(data as varchar) as data_text,
+    variant_extract(data, 'name') as name,
+    ST_AsText(geom) as geom_wkt
+  from my_table
+`);
+```
+
+Until the Node API exposes JS conversions for those types, this driver does not provide first-class column helpers for raw `VARIANT` or `GEOMETRY` values.
 
 ## JSON Columns
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.4.0",
+  "version": "1.5.1",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {
@@ -13,15 +13,13 @@
     "t": "vitest --watch --ui",
     "bench": "vitest bench --run test/perf --pool=threads --poolOptions.threads.singleThread=true --no-file-parallelism",
     "perf:run": "bun run scripts/run-perf.ts",
-    "perf:compare": "bun run scripts/compare-perf.ts",
-    "publish:dual": "bun run scripts/publish-dual.ts",
-    "publish:dual:dry": "bun run scripts/publish-dual.ts --dry-run"
+    "perf:compare": "bun run scripts/compare-perf.ts"
   },
   "bin": {
     "duckdb-introspect": "dist/duckdb-introspect.mjs"
   },
   "peerDependencies": {
-    "@duckdb/node-api": "1.4.4-r.1",
+    "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
     "drizzle-orm": "^0.40.1"
   },
   "peerDependenciesMeta": {
@@ -30,7 +28,7 @@
     }
   },
   "devDependencies": {
-    "@duckdb/node-api": "1.4.4-r.1",
+    "@duckdb/node-api": "1.5.1-r.1",
     "@types/bun": "^1.3.11",
     "@types/uuid": "^10.0.0",
     "@vitest/ui": "^1.6.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -51,6 +51,12 @@ type ResultColumnsLike = {
   deduplicatedColumnNames?: () => string[];
 };
 
+type ResultTypeMetadataLike = ResultColumnsLike & {
+  columnCount?: number;
+  columnName?: (columnIndex: number) => string;
+  columnTypeId?: (columnIndex: number) => number;
+};
+
 type ClosableResource = {
   close?: () => Promise<void> | void;
   closeSync?: () => void;
@@ -235,18 +241,77 @@ function resolveResultColumns(result: ResultColumnsLike): string[] {
   return deduplicateColumns(result.columnNames());
 }
 
+function isUnsupportedNodeApiTypeError(error: unknown): boolean {
+  return (
+    error instanceof Error && error.message.includes('Unexpected type id: 0')
+  );
+}
+
+function findUnsupportedNodeApiColumns(
+  result: ResultTypeMetadataLike
+): string[] {
+  if (
+    typeof result.columnCount !== 'number' ||
+    typeof result.columnName !== 'function' ||
+    typeof result.columnTypeId !== 'function'
+  ) {
+    return [];
+  }
+
+  const unsupportedColumns: string[] = [];
+  for (
+    let columnIndex = 0;
+    columnIndex < result.columnCount;
+    columnIndex += 1
+  ) {
+    if (result.columnTypeId(columnIndex) === 0) {
+      unsupportedColumns.push(result.columnName(columnIndex));
+    }
+  }
+
+  return unsupportedColumns;
+}
+
+function wrapUnsupportedNodeApiTypeError(
+  result: ResultTypeMetadataLike,
+  error: unknown
+): Error {
+  if (!isUnsupportedNodeApiTypeError(error)) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+
+  const unsupportedColumns = findUnsupportedNodeApiColumns(result);
+  const columnsText =
+    unsupportedColumns.length > 0
+      ? ` for column${
+          unsupportedColumns.length === 1 ? '' : 's'
+        } ${unsupportedColumns.map((column) => `"${column}"`).join(', ')}`
+      : '';
+
+  const wrapped = new Error(
+    `DuckDB returned a column type that @duckdb/node-api cannot materialize to JavaScript${columnsText}. This currently affects some DuckDB 1.5 types, including VARIANT and GEOMETRY. Cast those columns to a supported representation before selecting them, for example CAST(col AS VARCHAR), variant_extract(...), ST_AsText(...), or ST_AsWKB(...).`
+  );
+  (wrapped as Error & { cause?: unknown }).cause = error;
+  return wrapped;
+}
+
 async function materializeResultRows(
   result: {
     getRowsJS: () => Promise<unknown[][] | undefined>;
-  } & ResultColumnsLike
+  } & ResultTypeMetadataLike
 ): Promise<MaterializedRows> {
-  const rows = (await result.getRowsJS()) ?? [];
+  let rows: unknown[][];
+  try {
+    rows = (await result.getRowsJS()) ?? [];
+  } catch (error) {
+    throw wrapUnsupportedNodeApiTypeError(result, error);
+  }
   const columns = resolveResultColumns(result);
 
   return { columns, rows };
 }
 
-type StreamResultLike = ResultColumnsLike & {
+type StreamResultLike = ResultTypeMetadataLike & {
   yieldRowsJs: () => AsyncIterable<unknown[][]>;
   close?: () => Promise<void> | void;
   cancel?: () => Promise<void> | void;
@@ -442,15 +507,19 @@ export async function* executeInBatches(
   let buffer: RowData[] = [];
 
   try {
-    for await (const chunk of result.yieldRowsJs()) {
-      const objects = mapRowsToObjects(columns, chunk);
-      for (const row of objects) {
-        buffer.push(row);
-        if (buffer.length >= rowsPerChunk) {
-          yield buffer;
-          buffer = [];
+    try {
+      for await (const chunk of result.yieldRowsJs()) {
+        const objects = mapRowsToObjects(columns, chunk);
+        for (const row of objects) {
+          buffer.push(row);
+          if (buffer.length >= rowsPerChunk) {
+            yield buffer;
+            buffer = [];
+          }
         }
       }
+    } catch (error) {
+      throw wrapUnsupportedNodeApiTypeError(result, error);
     }
 
     if (buffer.length > 0) {
@@ -486,14 +555,18 @@ export async function* executeInBatchesRaw(
   let buffer: unknown[][] = [];
 
   try {
-    for await (const chunk of result.yieldRowsJs()) {
-      for (const row of chunk) {
-        buffer.push(row as unknown[]);
-        if (buffer.length >= rowsPerChunk) {
-          yield { columns, rows: buffer };
-          buffer = [];
+    try {
+      for await (const chunk of result.yieldRowsJs()) {
+        for (const row of chunk) {
+          buffer.push(row as unknown[]);
+          if (buffer.length >= rowsPerChunk) {
+            yield { columns, rows: buffer };
+            buffer = [];
+          }
         }
       }
+    } catch (error) {
+      throw wrapUnsupportedNodeApiTypeError(result, error);
     }
 
     if (buffer.length > 0) {
@@ -536,5 +609,12 @@ export async function executeArrowOnClient(
   }
 
   // Fallback: return column-major JS arrays to avoid per-row object creation.
-  return result.getColumnsObjectJS();
+  try {
+    return await result.getColumnsObjectJS();
+  } catch (error) {
+    throw wrapUnsupportedNodeApiTypeError(
+      result as unknown as ResultTypeMetadataLike,
+      error
+    );
+  }
 }

--- a/test/duckdb-15-types.test.ts
+++ b/test/duckdb-15-types.test.ts
@@ -1,0 +1,52 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import { sql } from 'drizzle-orm';
+import { afterAll, beforeAll, expect, test } from 'vitest';
+import { drizzle, type DuckDBDatabase } from '../src';
+
+let instance: DuckDBInstance;
+let connection: DuckDBConnection;
+let db: DuckDBDatabase;
+
+beforeAll(async () => {
+  instance = await DuckDBInstance.create(':memory:');
+  connection = await instance.connect();
+  db = drizzle(connection);
+});
+
+afterAll(() => {
+  connection?.closeSync();
+  instance?.closeSync?.();
+});
+
+test('VARIANT columns surface a descriptive node-api compatibility error', async () => {
+  try {
+    await db.execute(
+      sql`create table duckdb_variant_test (id integer, data variant)`
+    );
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+    expect(String(error)).toMatch(/variant|syntax error|type/i);
+    return;
+  }
+
+  await db.execute(sql`
+    insert into duckdb_variant_test values
+      (1, 42::variant),
+      (2, {'name': 'Alice'}::variant)
+  `);
+
+  await expect(
+    (async () =>
+      await db.execute(sql`select data from duckdb_variant_test order by id`))()
+  ).rejects.toThrow(
+    /@duckdb\/node-api cannot materialize to JavaScript.*VARIANT and GEOMETRY/i
+  );
+
+  const rows = await db.execute(
+    sql`select cast(data as varchar) as data_text from duckdb_variant_test order by id`
+  );
+
+  expect(rows[0]).toEqual({ data_text: '42' });
+  expect(rows[1]?.data_text).toContain('Alice');
+});


### PR DESCRIPTION
## Summary
- add declared support for `@duckdb/node-api` 1.5.1 while keeping 1.4.4 support
- improve driver errors for DuckDB 1.5 raw `VARIANT` and `GEOMETRY` values that `@duckdb/node-api` cannot materialize yet
- document the current 1.5 support boundary and cut the package version to `1.5.1`

## Validation
- `bunx prettier --check .`
- `bunx tsc --noEmit --project tsconfig.check.json`
- `CI=1 bun test $(rg --files test -g '*.test.ts' | rg -v 'integration\\.test\\.ts$')`
- `bun run build`
- repeated compatibility pass on `@duckdb/node-api@1.4.4-r.1` and `1.5.1-r.1`