### PR TITLE
[codex] Refactor batch streaming helpers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -479,6 +479,53 @@ function resolveRowsPerChunk(
     : 100_000;
 }
 
+async function* streamRawBatches(
+  client: DuckDBClientLike,
+  query: string,
+  params: unknown[],
+  options: ExecuteInBatchesOptions = {}
+): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
+  if (isPool(client)) {
+    const connection = await client.acquire();
+    try {
+      yield* streamRawBatches(connection, query, params, options);
+      return;
+    } finally {
+      await client.release(connection);
+    }
+  }
+
+  const rowsPerChunk = resolveRowsPerChunk(options);
+  const values = toNodeApiValues(params);
+
+  const result = (await client.stream(query, values)) as StreamResultLike;
+  const columns = resolveResultColumns(result);
+
+  let rows: unknown[][] = [];
+
+  try {
+    try {
+      for await (const chunk of result.yieldRowsJs()) {
+        for (const row of chunk) {
+          rows.push(row as unknown[]);
+          if (rows.length >= rowsPerChunk) {
+            yield { columns, rows };
+            rows = [];
+          }
+        }
+      }
+    } catch (error) {
+      throw wrapUnsupportedNodeApiTypeError(result, error);
+    }
+
+    if (rows.length > 0) {
+      yield { columns, rows };
+    }
+  } finally {
+    await closeStreamResult(result);
+  }
+}
+
 /**
  * Stream results from DuckDB in batches to avoid fully materializing rows in JS.
  */
@@ -488,45 +535,8 @@ export async function* executeInBatches(
   params: unknown[],
   options: ExecuteInBatchesOptions = {}
 ): AsyncGenerator<RowData[], void, void> {
-  if (isPool(client)) {
-    const connection = await client.acquire();
-    try {
-      yield* executeInBatches(connection, query, params, options);
-      return;
-    } finally {
-      await client.release(connection);
-    }
-  }
-
-  const rowsPerChunk = resolveRowsPerChunk(options);
-  const values = toNodeApiValues(params);
-
-  const result = (await client.stream(query, values)) as StreamResultLike;
-  const columns = resolveResultColumns(result);
-
-  let buffer: RowData[] = [];
-
-  try {
-    try {
-      for await (const chunk of result.yieldRowsJs()) {
-        const objects = mapRowsToObjects(columns, chunk);
-        for (const row of objects) {
-          buffer.push(row);
-          if (buffer.length >= rowsPerChunk) {
-            yield buffer;
-            buffer = [];
-          }
-        }
-      }
-    } catch (error) {
-      throw wrapUnsupportedNodeApiTypeError(result, error);
-    }
-
-    if (buffer.length > 0) {
-      yield buffer;
-    }
-  } finally {
-    await closeStreamResult(result);
+  for await (const chunk of streamRawBatches(client, query, params, options)) {
+    yield mapRowsToObjects(chunk.columns, chunk.rows);
   }
 }
 
@@ -536,45 +546,7 @@ export async function* executeInBatchesRaw(
   params: unknown[],
   options: ExecuteInBatchesOptions = {}
 ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
-  if (isPool(client)) {
-    const connection = await client.acquire();
-    try {
-      yield* executeInBatchesRaw(connection, query, params, options);
-      return;
-    } finally {
-      await client.release(connection);
-    }
-  }
-
-  const rowsPerChunk = resolveRowsPerChunk(options);
-  const values = toNodeApiValues(params);
-
-  const result = (await client.stream(query, values)) as StreamResultLike;
-  const columns = resolveResultColumns(result);
-
-  let buffer: unknown[][] = [];
-
-  try {
-    try {
-      for await (const chunk of result.yieldRowsJs()) {
-        for (const row of chunk) {
-          buffer.push(row as unknown[]);
-          if (buffer.length >= rowsPerChunk) {
-            yield { columns, rows: buffer };
-            buffer = [];
-          }
-        }
-      }
-    } catch (error) {
-      throw wrapUnsupportedNodeApiTypeError(result, error);
-    }
-
-    if (buffer.length > 0) {
-      yield { columns, rows: buffer };
-    }
-  } finally {
-    await closeStreamResult(result);
-  }
+  yield* streamRawBatches(client, query, params, options);
 }
 
 /**


### PR DESCRIPTION
## Summary

This change is a small targeted refactor in the client streaming path. Both `executeInBatches()` and `executeInBatchesRaw()` were carrying the same control flow for pool acquisition, stream setup, row buffering, unsupported node-api error wrapping, and result cleanup. That duplication made the code harder to scan and increased the chance that a future behavioral fix would land in one path but not the other.

The user-facing effect of that duplication was maintenance risk rather than a known runtime bug. Both APIs are intended to expose the same streaming behavior with different output shapes, so keeping their batching lifecycle aligned matters for cleanup semantics and future fixes.

## Root Cause

The raw-batch and object-batch APIs evolved as separate implementations even though they share the same streaming lifecycle. The only real behavioral difference is the last step: one API yields raw `{ columns, rows }` chunks and the other maps those same chunks into row objects.

## Fix

I extracted the shared streaming lifecycle into a single internal `streamRawBatches()` generator in `src/client.ts`. It now owns:

- pool acquisition and release
- stream startup
- row buffering by `rowsPerChunk`
- node-api unsupported-type error wrapping
- stream cleanup on normal completion and early consumer exit

`executeInBatchesRaw()` now delegates directly to that internal generator, and `executeInBatches()` layers object mapping on top of the raw chunks without re-implementing the lifecycle.

This keeps the public API unchanged while reducing duplicated logic and making the relationship between the two batch APIs explicit.

## Validation

I validated the refactor locally with:

- `bun test test/client-execute.test.ts test/client-close.test.ts`
- `bun run build`
- `bun test`

All local tests passed, including the early-exit stream-closing coverage for both batch APIs.
