### PR TITLE
[codex] Extract migration config normalizer

### DIFF
--- a/src/bin/duckdb-introspect.ts
+++ b/src/bin/duckdb-introspect.ts
@@ -258,7 +258,11 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(err instanceof Error ? err.message : err);
-  process.exit(1);
-});
+main()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exit(1);
+  });

--- a/src/dialect.ts
+++ b/src/dialect.ts
@@ -21,6 +21,7 @@ import {
 } from 'drizzle-orm';
 import type { QueryWithTypings } from 'drizzle-orm/sql/sql';
 
+import { normalizeMigrationConfig } from './migration-config.ts';
 import { transformSQL } from './sql/ast-transformer.ts';
 
 const enum SavepointSupport {
@@ -86,9 +87,7 @@ export class DuckDBDialect extends PgDialect {
     session: PgSession,
     config: MigrationConfig | string
   ): Promise<void> {
-    const migrationConfig: MigrationConfig =
-      typeof config === 'string' ? { migrationsFolder: config } : config;
-
+    const migrationConfig = normalizeMigrationConfig(config);
     const migrationsSchema = migrationConfig.migrationsSchema ?? 'drizzle';
     const migrationsTable =
       migrationConfig.migrationsTable ?? '__drizzle_migrations';

--- a/src/migration-config.ts
+++ b/src/migration-config.ts
@@ -1,0 +1,9 @@
+import type { MigrationConfig } from 'drizzle-orm/migrator';
+
+export type DuckDbMigrationConfig = MigrationConfig | string;
+
+export function normalizeMigrationConfig(
+  config: DuckDbMigrationConfig
+): MigrationConfig {
+  return typeof config === 'string' ? { migrationsFolder: config } : config;
+}

--- a/src/migrator.ts
+++ b/src/migrator.ts
@@ -1,17 +1,16 @@
-import type { MigrationConfig } from 'drizzle-orm/migrator';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import type { DuckDBDatabase } from './driver.ts';
 import type { PgSession } from 'drizzle-orm/pg-core/session';
-
-export type DuckDbMigrationConfig = MigrationConfig | string;
+import {
+  normalizeMigrationConfig,
+  type DuckDbMigrationConfig,
+} from './migration-config.ts';
 
 export async function migrate<TSchema extends Record<string, unknown>>(
   db: DuckDBDatabase<TSchema>,
   config: DuckDbMigrationConfig
 ) {
-  const migrationConfig: MigrationConfig =
-    typeof config === 'string' ? { migrationsFolder: config } : config;
-
+  const migrationConfig = normalizeMigrationConfig(config);
   const migrations = readMigrationFiles(migrationConfig);
 
   // Cast needed: Drizzle's internal PgSession type differs from exported type

--- a/test/migrator.test.ts
+++ b/test/migrator.test.ts
@@ -99,6 +99,21 @@ describe('Migrator Tests', () => {
     expect(result[0]?.name).toBe('users');
   });
 
+  test('migrate accepts a migrations folder string', async () => {
+    await db.execute(sql`DROP TABLE IF EXISTS users`);
+
+    await migrate(db, testMigrationsDir);
+
+    const result = await db.execute<{ name: string }>(sql`
+      SELECT table_name as name
+      FROM information_schema.tables
+      WHERE table_name = 'users'
+    `);
+
+    expect(result.length).toBe(1);
+    expect(result[0]?.name).toBe('users');
+  });
+
   test('migrate creates __drizzle_migrations table', async () => {
     // After the first migrate, the migrations table should exist
     const result = await db.execute<{ name: string }>(sql`


### PR DESCRIPTION
## Summary

This PR started as a small targeted refactor and then picked up a narrow CI fix after the MotherDuck integration workflow stalled inside the introspection CLI step.

The refactor removes duplicated migration config normalization logic from the DuckDB migrator entrypoints. Both `src/migrator.ts` and `src/dialect.ts` were converting a string migrations folder into a Drizzle `MigrationConfig` separately, which was easy to let drift over time.

While validating the branch, the `MotherDuck Integration` workflow stayed stuck in `Introspect seeded schema`. The most likely cause was the CLI process not terminating cleanly after successful output on Bun when MotherDuck-backed handles lingered. That failure mode affects CI users directly because the workflow never advances to the remaining integration checks.

## Root Cause

Two separate issues were present:

1. Migration config normalization was implemented inline in multiple places instead of behind one shared helper.

2. The introspection CLI relied on normal process teardown after success, which is fragile when database clients leave event-loop handles behind.

## Fix

The PR now does two small, focused things:

- adds `src/migration-config.ts` with `normalizeMigrationConfig()` and reuses it from both migration call sites
- updates `src/bin/duckdb-introspect.ts` to exit explicitly after a successful run so CI does not hang after writing the generated schema

It also adds regression coverage for the string-folder `migrate(db, folder)` path.

## Validation

- `bun test test/migrator.test.ts`
- `bun test test/introspect.test.ts test/introspect.snapshot.test.ts test/introspect.empty-database.test.ts test/introspect.unit.test.ts`
- `bun run build`
- `bun ./dist/duckdb-introspect.mjs --url :memory: --out <tmp>/schema.ts`
- A broader `bun test` run was started locally earlier, but it did not complete in a reasonable window, so GitHub Actions remains the full-suite authority for this branch.
