### PR TITLE
[codex] Refactor pool expiry handling

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -60,10 +60,8 @@ type ConnectionMetadata = {
   lastUsedAt: number;
 };
 
-type PooledConnection = {
+type PooledConnection = ConnectionMetadata & {
   connection: DuckDBConnection;
-  createdAt: number;
-  lastUsedAt: number;
 };
 
 type WaitingRequest = {
@@ -133,15 +131,37 @@ export function createDuckDBConnectionPool(
     waiter.reject(new Error(POOL_CLOSED_MESSAGE));
   };
 
-  const shouldRecycle = (conn: PooledConnection, now: number): boolean => {
-    if (maxLifetimeMs !== undefined && now - conn.createdAt >= maxLifetimeMs) {
-      return true;
-    }
-    if (idleTimeoutMs !== undefined && now - conn.lastUsedAt >= idleTimeoutMs) {
+  const hasExceededMaxLifetime = (
+    meta: ConnectionMetadata,
+    now: number
+  ): boolean => {
+    if (maxLifetimeMs !== undefined && now - meta.createdAt >= maxLifetimeMs) {
       return true;
     }
     return false;
   };
+
+  const shouldRecycleIdleConnection = (
+    meta: ConnectionMetadata,
+    now: number
+  ): boolean => {
+    if (hasExceededMaxLifetime(meta, now)) {
+      return true;
+    }
+    if (idleTimeoutMs !== undefined && now - meta.lastUsedAt >= idleTimeoutMs) {
+      return true;
+    }
+    return false;
+  };
+
+  const toPooledConnection = (
+    connection: DuckDBConnection,
+    meta: ConnectionMetadata
+  ): PooledConnection => ({
+    connection,
+    createdAt: meta.createdAt,
+    lastUsedAt: meta.lastUsedAt,
+  });
 
   const acquire = async (): Promise<DuckDBConnection> => {
     if (closed) {
@@ -151,18 +171,11 @@ export function createDuckDBConnectionPool(
     while (idle.length > 0) {
       const pooled = idle.pop() as PooledConnection;
       const now = Date.now();
-      if (shouldRecycle(pooled, now)) {
+      if (shouldRecycleIdleConnection(pooled, now)) {
         await dropConnection(pooled.connection);
         continue;
       }
-      markConnectionUsed(
-        pooled.connection,
-        {
-          createdAt: pooled.createdAt,
-          lastUsedAt: pooled.lastUsedAt,
-        },
-        now
-      );
+      markConnectionUsed(pooled.connection, pooled, now);
       return pooled.connection;
     }
 
@@ -231,16 +244,13 @@ export function createDuckDBConnectionPool(
       const now = Date.now();
       const meta = readMetadata(connection, now);
 
-      const expired =
-        maxLifetimeMs !== undefined && now - meta.createdAt >= maxLifetimeMs;
-
       if (closed) {
         await dropConnection(connection);
         waiter.reject(new Error(POOL_CLOSED_MESSAGE));
         return;
       }
 
-      if (expired) {
+      if (hasExceededMaxLifetime(meta, now)) {
         await dropConnection(connection);
         try {
           const replacement = await acquire();
@@ -268,19 +278,12 @@ export function createDuckDBConnectionPool(
       now
     );
 
-    if (
-      maxLifetimeMs !== undefined &&
-      now - existingMeta.createdAt >= maxLifetimeMs
-    ) {
+    if (hasExceededMaxLifetime(existingMeta, now)) {
       await dropConnection(connection);
       return;
     }
 
-    idle.push({
-      connection,
-      createdAt: existingMeta.createdAt,
-      lastUsedAt: existingMeta.lastUsedAt,
-    });
+    idle.push(toPooledConnection(connection, existingMeta));
   };
 
   const close = async (): Promise<void> => {

--- a/test/pool.recycle.test.ts
+++ b/test/pool.recycle.test.ts
@@ -89,6 +89,36 @@ describe('Pool recycling and resilience', () => {
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
 
+  test('expired connections are replaced before resolving waiters', async () => {
+    const conn1 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+    const conn2 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+
+    const createSpy = vi
+      .spyOn(DuckDBConnection, 'create')
+      .mockResolvedValueOnce(conn1)
+      .mockResolvedValueOnce(conn2);
+
+    const pool = createDuckDBConnectionPool({} as any, {
+      size: 1,
+      maxLifetimeMs: 0,
+    });
+
+    const first = await pool.acquire();
+    expect(first).toBe(conn1);
+
+    const pendingAcquire = pool.acquire();
+    await pool.release(first);
+
+    const second = await pendingAcquire;
+    expect(second).toBe(conn2);
+    expect(conn1.closeSync).toHaveBeenCalled();
+
+    await pool.release(second);
+    await pool.close();
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
   test('idleTimeoutMs discards stale idle connections', async () => {
     const conn1 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
     const conn2 = { closeSync: vi.fn() } as unknown as DuckDBConnection;


### PR DESCRIPTION
This change is a small targeted refactor in the DuckDB connection pool.

The issue was not a user-visible bug in normal operation, but the pool's connection-expiry rules were implemented in multiple branches with slightly different local logic. That made the code harder to audit, especially around the path where a released connection must satisfy a queued waiter. In a pool, these branches are easy to drift apart over time, which raises the risk of a future regression where idle connections and waiter handoff behavior age out differently.

The root cause was duplicated lifecycle logic. Max-lifetime expiration was checked in more than one place, idle recycling used a separate branch, and the pool carried two nearly identical metadata shapes for the same timestamps. The behavior was correct today, but the implementation asked readers to re-prove the same rule in several places.

The fix extracts the shared max-lifetime check into a single helper, uses a dedicated helper for idle-connection recycling, and reuses the same metadata shape when reconstructing pooled connections. That keeps the pool's expiration behavior explicit while preserving the existing runtime behavior. I also added a focused regression test that covers the queued-waiter path where an expired connection is released and the pool must create a replacement before resolving the waiter.

Validation was done with `bun install`, `bun run build`, `bun test test/pool.recycle.test.ts`, and `bun test test/pool-close.test.ts test/pool.errors.test.ts test/pool.integration.test.ts test/pool.recycle.test.ts test/driver-factory.test.ts`.
