### PR TITLE
[codex] Fix pool shutdown handling and refresh uuid

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,13 +10,12 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.1-r.1",
         "@types/bun": "^1.3.11",
-        "@types/uuid": "^10.0.0",
         "@vitest/ui": "^1.6.1",
         "drizzle-orm": "0.40.1",
         "prettier": "^3.8.1",
         "tinybench": "^2.9.0",
         "typescript": "^5.9.3",
-        "uuid": "^10.0.0",
+        "uuid": "^13.0.0",
         "vitest": "^1.6.1",
       },
       "peerDependencies": {
@@ -171,8 +170,6 @@
     "@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
-
-    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
 
@@ -352,7 +349,7 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,12 +31,11 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.1-r.1",
     "@types/bun": "^1.3.11",
-    "@types/uuid": "^10.0.0",
     "@vitest/ui": "^1.6.1",
     "drizzle-orm": "0.40.1",
     "prettier": "^3.8.1",
     "typescript": "^5.9.3",
-    "uuid": "^10.0.0",
+    "uuid": "^13.0.0",
     "vitest": "^1.6.1",
     "tinybench": "^2.9.0"
   },

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -87,6 +87,7 @@ export function createDuckDBConnectionPool(
   const metadata = new WeakMap<DuckDBConnection, ConnectionMetadata>();
 
   const idle: PooledConnection[] = [];
+  const leased = new Set<DuckDBConnection>();
   const waiting: WaitingRequest[] = [];
   let total = 0;
   let closed = false;
@@ -163,6 +164,7 @@ export function createDuckDBConnectionPool(
         },
         now
       );
+      leased.add(pooled.connection);
       return pooled.connection;
     }
 
@@ -188,6 +190,7 @@ export function createDuckDBConnectionPool(
         }
         const now = Date.now();
         metadata.set(connection, createMetadata(now));
+        leased.add(connection);
         return connection;
       } catch (error) {
         if (!slotReleased) {
@@ -225,6 +228,10 @@ export function createDuckDBConnectionPool(
   };
 
   const release = async (connection: DuckDBConnection): Promise<void> => {
+    if (!leased.delete(connection)) {
+      return;
+    }
+
     const waiter = waiting.shift();
     if (waiter) {
       clearTimeout(waiter.timeoutId);
@@ -252,6 +259,7 @@ export function createDuckDBConnectionPool(
       }
 
       markConnectionUsed(connection, meta, now);
+      leased.add(connection);
       waiter.resolve(connection);
       return;
     }
@@ -299,6 +307,14 @@ export function createDuckDBConnectionPool(
     );
     total = Math.max(0, total - toClose.length);
     toClose.forEach((item) => metadata.delete(item.connection));
+
+    const active = Array.from(leased);
+    leased.clear();
+    await Promise.allSettled(
+      active.map((connection) => closeClientConnection(connection))
+    );
+    total = Math.max(0, total - active.length);
+    active.forEach((connection) => metadata.delete(connection));
 
     // Wait for pending acquires to complete (with a reasonable timeout)
     const maxWait = 5000;

--- a/test/pool.recycle.test.ts
+++ b/test/pool.recycle.test.ts
@@ -117,4 +117,23 @@ describe('Pool recycling and resilience', () => {
 
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
+
+  test('close() shuts down leased connections and ignores late release', async () => {
+    const conn = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+
+    vi.spyOn(DuckDBConnection, 'create').mockResolvedValue(conn);
+
+    const pool = createDuckDBConnectionPool({} as any, {
+      size: 1,
+    });
+
+    const leased = await pool.acquire();
+    expect(leased).toBe(conn);
+
+    await pool.close();
+    expect(conn.closeSync).toHaveBeenCalledTimes(1);
+
+    await pool.release(leased);
+    expect(conn.closeSync).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## Summary

This PR fixes a shutdown hole in the DuckDB connection pool and refreshes the repo `uuid` dev dependency to the current major while removing the deprecated `@types/uuid` package.

## User-visible impact

Before this change, calling `pool.close()` only drained idle connections. Any connection that had been checked out but not yet released could stay alive after shutdown, which risks leaking native handles and keeping work running longer than expected during app teardown or test cleanup. Users of the public API do not need to change code. Shutdown is simply more reliable.

## Root cause

The pool tracked idle connections and pending acquires, but it did not track leased connections. That meant shutdown had no way to close active leases or ignore a later duplicate release safely. On the dependency side, the repo still carried the deprecated `@types/uuid` package even though modern `uuid` ships its own types.

## Fix

The pool now records leased connections when they are acquired, moves them back into the leased set when a waiter inherits a released connection, and force-closes any remaining leased connections during `close()`. Late or duplicate releases are now harmless no-ops instead of re-enqueueing stale handles. A regression test covers that shutdown path. I also updated `uuid` to `^13.0.0` and removed `@types/uuid`.

## Validation

- `bun x prettier --check src/pool.ts test/pool.recycle.test.ts package.json`
- `bun x tsc --noEmit --project tsconfig.check.json`
- `bun run build`
- `bun x vitest run test/duckdb.test.ts test/pool-close.test.ts test/pool.errors.test.ts test/pool.recycle.test.ts test/driver-factory.test.ts test/execution-paths.test.ts test/client-close.test.ts --pool=threads --poolOptions.threads.singleThread=true`
- `CI=1 bun x vitest run --pool=threads --poolOptions.threads.singleThread=true`
