### PR TITLE
[codex] Fix DuckLake pool cleanup and CI stability

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,13 +10,12 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.1-r.1",
         "@types/bun": "^1.3.11",
-        "@types/uuid": "^10.0.0",
         "@vitest/ui": "^1.6.1",
         "drizzle-orm": "0.40.1",
         "prettier": "^3.8.1",
         "tinybench": "^2.9.0",
         "typescript": "^5.9.3",
-        "uuid": "^10.0.0",
+        "uuid": "^13.0.0",
         "vitest": "^1.6.1",
       },
       "peerDependencies": {
@@ -171,8 +170,6 @@
     "@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
-
-    "@types/uuid": ["@types/uuid@10.0.0", "", {}, "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ=="],
 
     "@vitest/expect": ["@vitest/expect@1.6.1", "", { "dependencies": { "@vitest/spy": "1.6.1", "@vitest/utils": "1.6.1", "chai": "^4.3.10" } }, "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog=="],
 
@@ -352,7 +349,7 @@
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
+    "uuid": ["uuid@13.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w=="],
 
     "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
 

--- a/package.json
+++ b/package.json
@@ -31,14 +31,13 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.1-r.1",
     "@types/bun": "^1.3.11",
-    "@types/uuid": "^10.0.0",
     "@vitest/ui": "^1.6.1",
     "drizzle-orm": "0.40.1",
     "prettier": "^3.8.1",
+    "tinybench": "^2.9.0",
     "typescript": "^5.9.3",
-    "uuid": "^10.0.0",
-    "vitest": "^1.6.1",
-    "tinybench": "^2.9.0"
+    "uuid": "^13.0.0",
+    "vitest": "^1.6.1"
   },
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -391,13 +391,20 @@ function clearPreparedCache(connection: DuckDBConnection): void {
 }
 
 function mapRowsToObjects(columns: string[], rows: unknown[][]): RowData[] {
-  return rows.map((vals) => {
-    const obj: Record<string, unknown> = {};
-    columns.forEach((col, idx) => {
-      obj[col] = vals[idx];
-    });
-    return obj;
-  }) as RowData[];
+  const mappedRows: RowData[] = new Array(rows.length);
+
+  for (let rowIndex = 0; rowIndex < rows.length; rowIndex += 1) {
+    const values = rows[rowIndex] as unknown[];
+    const row: RowData = {};
+
+    for (let columnIndex = 0; columnIndex < columns.length; columnIndex += 1) {
+      row[columns[columnIndex] as string] = values[columnIndex];
+    }
+
+    mappedRows[rowIndex] = row;
+  }
+
+  return mappedRows;
 }
 
 export async function closeClientConnection(

--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -177,11 +177,22 @@ export function wrapDuckLakePool(
   const wrapped: DuckDBConnectionPool & { size?: number } = {
     async acquire() {
       const connection = await pool.acquire();
-      if (!configuredConnections.has(connection)) {
+      if (configuredConnections.has(connection)) {
+        return connection;
+      }
+
+      try {
         await configureDuckLake(connection, config);
         configuredConnections.add(connection);
+        return connection;
+      } catch (error) {
+        try {
+          await pool.release(connection);
+        } catch {
+          // Preserve the original configuration error when cleanup also fails.
+        }
+        throw error;
       }
-      return connection;
     },
     release(connection) {
       return pool.release(connection);

--- a/test/ducklake.helpers.test.ts
+++ b/test/ducklake.helpers.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, test } from 'vitest';
+import type { DuckDBConnection } from '@duckdb/node-api';
+import { describe, expect, test, vi } from 'vitest';
 import {
   buildDuckLakeAttachSql,
   isDuckDbFileCatalog,
   normalizeDuckLakeConfig,
   resolveDuckLakePoolSize,
+  wrapDuckLakePool,
 } from '../src/ducklake.ts';
 
 describe('DuckLake helpers', () => {
@@ -63,5 +65,24 @@ describe('DuckLake helpers', () => {
     });
     expect(resolution.poolSize).toBe(1);
     expect(resolution.isLocalCatalog).toBe(true);
+  });
+
+  test('wrapDuckLakePool releases the slot when configuration fails', async () => {
+    const connection = {
+      run: vi.fn(async () => {
+        throw new Error('setup failed');
+      }),
+    } as unknown as DuckDBConnection;
+    const pool = {
+      acquire: vi.fn(async () => connection),
+      release: vi.fn(async () => undefined),
+    };
+    const wrapped = wrapDuckLakePool(pool, {
+      catalog: 'md:meta_db',
+    });
+
+    await expect(wrapped.acquire()).rejects.toThrow('setup failed');
+    expect(pool.release).toHaveBeenCalledTimes(1);
+    expect(pool.release).toHaveBeenCalledWith(connection);
   });
 });

--- a/test/motherduck.integration.test.ts
+++ b/test/motherduck.integration.test.ts
@@ -13,112 +13,157 @@ import { expect, test } from 'vitest';
 
 const motherduckToken = process.env.MOTHERDUCK_TOKEN;
 const skipMotherduck = !motherduckToken || process.env.SKIP_MOTHERDUCK === '1';
+const MOTHERDUCK_TRANSIENT_ERROR_PATTERNS = [
+  /DEADLINE_EXCEEDED/i,
+  /request timed out/i,
+];
+
+function isTransientMotherDuckError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return MOTHERDUCK_TRANSIENT_ERROR_PATTERNS.some((pattern) =>
+    pattern.test(error.message)
+  );
+}
+
+async function runWithMotherDuckRetry<T>(
+  operation: () => Promise<T>,
+  attempts = 3
+): Promise<T> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+
+      if (attempt === attempts || !isTransientMotherDuckError(error)) {
+        throw error;
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, attempt * 1_000));
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error('MotherDuck operation failed');
+}
 
 if (skipMotherduck) {
   test.skip('MotherDuck integration requires MOTHERDUCK_TOKEN');
 } else {
   test('runs the MotherDuck nyc.taxi example against sample_data', async () => {
-    const instance = await DuckDBInstance.create('md:', {
-      motherduck_token: motherduckToken,
-    });
-    const connection: DuckDBConnection = await instance.connect();
-    const db = drizzle(connection);
-
-    try {
-      await db.execute(sql`
-          create or replace temp view taxi_sample as
-          select
-            vendorid,
-            tpep_pickup_datetime,
-            passenger_count,
-            trip_distance,
-            total_amount,
-            tip_amount
-          from sample_data.nyc.taxi
-          limit 50000
-        `);
-
-      const taxiSample = pgTable('taxi_sample', {
-        vendorId: integer('vendorid'),
-        pickupTime: timestamp('tpep_pickup_datetime', { withTimezone: false }),
-        passengerCount: integer('passenger_count'),
-        tripDistance: doublePrecision('trip_distance'),
-        totalAmount: doublePrecision('total_amount'),
-        tipAmount: doublePrecision('tip_amount'),
+    await runWithMotherDuckRetry(async () => {
+      const instance = await DuckDBInstance.create('md:', {
+        motherduck_token: motherduckToken,
       });
+      const connection: DuckDBConnection = await instance.connect();
+      const db = drizzle(connection);
 
-      const trips = await db
-        .select({
-          pickupTime: taxiSample.pickupTime,
-          passengerCount: taxiSample.passengerCount,
-          tripDistance: taxiSample.tripDistance,
-          totalAmount: taxiSample.totalAmount,
-          tipAmount: taxiSample.tipAmount,
-        })
-        .from(taxiSample)
-        .limit(5);
+      try {
+        await db.execute(sql`
+            create or replace temp view taxi_sample as
+            select
+              vendorid,
+              tpep_pickup_datetime,
+              passenger_count,
+              trip_distance,
+              total_amount,
+              tip_amount
+            from sample_data.nyc.taxi
+            limit 50000
+          `);
 
-      expect(trips.length).toBeGreaterThan(0);
-      trips.forEach((trip) => {
-        expect(trip.pickupTime).toBeInstanceOf(Date);
-        expect(typeof trip.tripDistance).toBe('number');
-        expect(typeof trip.totalAmount).toBe('number');
-      });
+        const taxiSample = pgTable('taxi_sample', {
+          vendorId: integer('vendorid'),
+          pickupTime: timestamp('tpep_pickup_datetime', {
+            withTimezone: false,
+          }),
+          passengerCount: integer('passenger_count'),
+          tripDistance: doublePrecision('trip_distance'),
+          totalAmount: doublePrecision('total_amount'),
+          tipAmount: doublePrecision('tip_amount'),
+        });
 
-      const tipByPassengers = await db
-        .select({
-          passengers: taxiSample.passengerCount,
-          avgFare: sql<number>`avg(${taxiSample.totalAmount})`,
-          avgTip: sql<number>`avg(${taxiSample.tipAmount})`,
-        })
-        .from(taxiSample)
-        .groupBy(taxiSample.passengerCount)
-        .orderBy(sql`avg(${taxiSample.tipAmount}) desc`)
-        .limit(5);
+        const trips = await db
+          .select({
+            pickupTime: taxiSample.pickupTime,
+            passengerCount: taxiSample.passengerCount,
+            tripDistance: taxiSample.tripDistance,
+            totalAmount: taxiSample.totalAmount,
+            tipAmount: taxiSample.tipAmount,
+          })
+          .from(taxiSample)
+          .limit(5);
 
-      expect(tipByPassengers.length).toBeGreaterThan(0);
-      expect(Number(tipByPassengers[0].avgTip)).toBeGreaterThan(0);
-      for (let i = 1; i < tipByPassengers.length; i++) {
-        expect(Number(tipByPassengers[i - 1].avgTip)).toBeGreaterThanOrEqual(
-          Number(tipByPassengers[i].avgTip)
-        );
+        expect(trips.length).toBeGreaterThan(0);
+        trips.forEach((trip) => {
+          expect(trip.pickupTime).toBeInstanceOf(Date);
+          expect(typeof trip.tripDistance).toBe('number');
+          expect(typeof trip.totalAmount).toBe('number');
+        });
+
+        const tipByPassengers = await db
+          .select({
+            passengers: taxiSample.passengerCount,
+            avgFare: sql<number>`avg(${taxiSample.totalAmount})`,
+            avgTip: sql<number>`avg(${taxiSample.tipAmount})`,
+          })
+          .from(taxiSample)
+          .groupBy(taxiSample.passengerCount)
+          .orderBy(sql`avg(${taxiSample.tipAmount}) desc`)
+          .limit(5);
+
+        expect(tipByPassengers.length).toBeGreaterThan(0);
+        expect(Number(tipByPassengers[0].avgTip)).toBeGreaterThan(0);
+        for (let i = 1; i < tipByPassengers.length; i++) {
+          expect(Number(tipByPassengers[i - 1].avgTip)).toBeGreaterThanOrEqual(
+            Number(tipByPassengers[i].avgTip)
+          );
+        }
+      } finally {
+        connection.closeSync();
+        instance.closeSync();
       }
-    } finally {
-      connection.closeSync();
-      instance.closeSync();
-    }
+    });
   }, 120_000);
 
   test('introspection filters to current database and excludes sample_data tables', async () => {
-    const instance = await DuckDBInstance.create('md:', {
-      motherduck_token: motherduckToken,
-    });
-    const connection: DuckDBConnection = await instance.connect();
-    const db = drizzle(connection);
-
-    try {
-      // Get the current database name
-      const dbRows = await db.execute<{ current_database: string }>(
-        sql`SELECT current_database() as current_database`
-      );
-      const currentDatabase = dbRows[0]?.current_database;
-      expect(currentDatabase).toBeDefined();
-
-      // Run introspection with default settings (should filter to current database)
-      const result = await introspect(db, {
-        schemas: ['main'],
+    await runWithMotherDuckRetry(async () => {
+      const instance = await DuckDBInstance.create('md:', {
+        motherduck_token: motherduckToken,
       });
+      const connection: DuckDBConnection = await instance.connect();
+      const db = drizzle(connection);
 
-      // Verify that tables from sample_data.nyc are NOT included
-      const tableNames = result.files.metaJson.map((t) => t.name);
-      expect(tableNames).not.toContain('taxi');
-      expect(tableNames).not.toContain('weather');
+      try {
+        // Get the current database name
+        const dbRows = await db.execute<{ current_database: string }>(
+          sql`SELECT current_database() as current_database`
+        );
+        const currentDatabase = dbRows[0]?.current_database;
+        expect(currentDatabase).toBeDefined();
 
-      // The generated schema should not reference sample_data
-      expect(result.files.schemaTs).not.toContain('sample_data');
-    } finally {
-      connection.closeSync();
-      instance.closeSync();
-    }
+        // Run introspection with default settings (should filter to current database)
+        const result = await introspect(db, {
+          schemas: ['main'],
+        });
+
+        // Verify that tables from sample_data.nyc are NOT included
+        const tableNames = result.files.metaJson.map((t) => t.name);
+        expect(tableNames).not.toContain('taxi');
+        expect(tableNames).not.toContain('weather');
+
+        // The generated schema should not reference sample_data
+        expect(result.files.schemaTs).not.toContain('sample_data');
+      } finally {
+        connection.closeSync();
+        instance.closeSync();
+      }
+    });
   }, 120_000);
 }


### PR DESCRIPTION
This change fixes two reliability issues that could surface in normal use and in CI, and it also cleans up an outdated dependency.

DuckLake pooled connections could leak capacity when first-use configuration failed. `wrapDuckLakePool()` acquired a pool slot and then ran the DuckLake setup sequence, but if that setup threw, the connection was never returned to the underlying pool. From a user perspective that could gradually exhaust the pool after repeated setup failures and make later acquires hang or fail even though the process had available connections. The fix keeps the existing external API intact and adds cleanup on the error path so the acquired slot is always released before the original error is rethrown.

The MotherDuck integration suite was also vulnerable to transient remote timeouts. The failing case was not caused by a local logic regression. It was a `DEADLINE_EXCEEDED` response from MotherDuck during catalog work. That made the PR check flaky even when the code was correct. The tests now retry only for clearly transient timeout-style MotherDuck failures, with a short backoff, while still failing immediately for real product or query errors. This keeps the signal from the integration suite without treating a single remote timeout as a code failure.

On the performance side, row materialization now uses indexed loops instead of nested `map()` and `forEach()` callbacks in the hot path that converts raw column arrays into row objects. The behavior is unchanged, but it removes extra callback overhead in a frequently executed path.

I also removed `@types/uuid`, which is now a deprecated stub because `uuid` ships its own types, and updated `uuid` itself from `^10.0.0` to `^13.0.0`. The package upgrade was validated locally against the full CI-shaped test command before keeping it.

Validation:
- `bunx prettier --check .`
- `bunx tsc --noEmit --project tsconfig.check.json`
- `CI=1 bun run test`
- `bun run build`
- `npm pack --dry-run`
