### PR TITLE
[codex] Refactor session param prep

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -61,6 +61,32 @@ const VALID_TRANSACTION_ACCESS_MODES = new Set<string>([
   'read write',
 ]);
 
+interface QueryParamPreparationOptions {
+  logger: Logger;
+  queryString: string;
+  params: unknown[];
+  rejectStringArrayLiterals: boolean;
+  warnOnStringArrayLiteral?: (sql: string) => void;
+}
+
+function prepareQueryParams({
+  logger,
+  queryString,
+  params,
+  rejectStringArrayLiterals,
+  warnOnStringArrayLiteral,
+}: QueryParamPreparationOptions): unknown[] {
+  const preparedParams = prepareParams(params, {
+    rejectStringArrayLiterals,
+    warnOnStringArrayLiteral: rejectStringArrayLiterals
+      ? undefined
+      : () => warnOnStringArrayLiteral?.(queryString),
+  });
+
+  logger.logQuery(queryString, preparedParams);
+  return preparedParams;
+}
+
 export class DuckDBPreparedQuery<
   T extends PreparedQueryConfig,
 > extends PgPreparedQuery<T> {
@@ -88,16 +114,13 @@ export class DuckDBPreparedQuery<
     placeholderValues: Record<string, unknown> | undefined = {}
   ): Promise<T['execute']> {
     this.dialect.assertNoPgJsonColumns();
-    const params = prepareParams(
-      fillPlaceholders(this.params, placeholderValues),
-      {
-        rejectStringArrayLiterals: this.rejectStringArrayLiterals,
-        warnOnStringArrayLiteral: this.warnOnStringArrayLiteral
-          ? () => this.warnOnStringArrayLiteral?.(this.queryString)
-          : undefined,
-      }
-    );
-    this.logger.logQuery(this.queryString, params);
+    const params = prepareQueryParams({
+      logger: this.logger,
+      queryString: this.queryString,
+      params: fillPlaceholders(this.params, placeholderValues),
+      rejectStringArrayLiterals: this.rejectStringArrayLiterals,
+      warnOnStringArrayLiteral: this.warnOnStringArrayLiteral,
+    });
 
     const { fields, joinsNotNullableMap, customResultMapper } =
       this as typeof this & { joinsNotNullableMap?: Record<string, boolean> };
@@ -279,14 +302,13 @@ export class DuckDBSession<
     this.dialect.resetPgJsonFlag();
     const builtQuery = this.dialect.sqlToQuery(query);
     this.dialect.assertNoPgJsonColumns();
-    const params = prepareParams(builtQuery.params, {
+    const params = prepareQueryParams({
+      logger: this.logger,
+      queryString: builtQuery.sql,
+      params: builtQuery.params,
       rejectStringArrayLiterals: this.rejectStringArrayLiterals,
-      warnOnStringArrayLiteral: this.rejectStringArrayLiterals
-        ? undefined
-        : () => this.warnOnStringArrayLiteral(builtQuery.sql),
+      warnOnStringArrayLiteral: this.warnOnStringArrayLiteral,
     });
-
-    this.logger.logQuery(builtQuery.sql, params);
     return { sql: builtQuery.sql, params };
   }
 


### PR DESCRIPTION
## Summary
This change removes duplicated query parameter preparation from `src/session.ts`.

Before this refactor, prepared queries and direct session execution each rebuilt the same string-array-literal handling and query logging flow with slightly different inline code. That duplication made the behavior harder to scan and made future changes to parameter preparation easier to miss in one path.

The root cause was that the shared behavior lived conceptually in one policy, but the implementation was split between `DuckDBPreparedQuery.execute()` and `DuckDBSession.prepareQueryExecution()`.

The fix extracts a single `prepareQueryParams()` helper that applies the array-literal coercion or rejection rules, preserves the one-time warning callback behavior, and logs the final SQL plus prepared params. Both execution paths now delegate to that helper, which keeps the behavior aligned without changing the surrounding transaction or query execution flow.

## Validation
I validated the change locally with:

- `bun test test/prepare-params.test.ts test/session-options.test.ts test/execution-paths.test.ts`
- `bun run build`
- `bun test`
