### PR TITLE
[codex] Restore perf compare script

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@vitest/ui": "4.1.2",
         "drizzle-orm": "0.40.1",
         "prettier": "^3.8.1",
-        "tinybench": "^2.9.0",
+        "tinybench": "6.0.0",
         "typescript": "6.0.2",
         "uuid": "13.0.0",
         "vitest": "4.1.2",
@@ -213,7 +213,7 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
-    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+    "tinybench": ["tinybench@6.0.0", "", {}, "sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
@@ -238,6 +238,8 @@
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "bun-types/@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
+
+    "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@vitest/ui": "4.1.2",
     "drizzle-orm": "0.40.1",
     "prettier": "^3.8.1",
-    "tinybench": "^2.9.0",
+    "tinybench": "6.0.0",
     "typescript": "6.0.2",
     "uuid": "13.0.0",
     "vitest": "4.1.2"

--- a/scripts/compare-perf.ts
+++ b/scripts/compare-perf.ts
@@ -1,0 +1,199 @@
+#!/usr/bin/env bun
+import { readFile } from 'node:fs/promises';
+import process from 'node:process';
+
+export type ActionBenchRow = {
+  name: string;
+  unit?: string;
+  value: number;
+  range?: number;
+};
+
+export type LegacyPerfResult = {
+  name: string;
+  hz: number;
+  rme?: number;
+};
+
+export type LegacyPerfFile = {
+  meta?: Record<string, unknown>;
+  results: LegacyPerfResult[];
+};
+
+export type NormalizedBenchRow = {
+  name: string;
+  opsPerSecond: number;
+  relativeMargin: number;
+};
+
+export type ComparisonRow = {
+  name: string;
+  previous?: NormalizedBenchRow;
+  next?: NormalizedBenchRow;
+  percentChange?: number;
+  isRegressionRisk: boolean;
+};
+
+export type CliArgs = {
+  previousPath: string;
+  nextPath: string;
+  threshold: number;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function normalizeActionBenchRow(row: unknown): NormalizedBenchRow {
+  if (!isRecord(row) || typeof row.name !== 'string' || typeof row.value !== 'number') {
+    throw new Error('Invalid action-bench row');
+  }
+
+  return {
+    name: row.name,
+    opsPerSecond: row.value,
+    relativeMargin: typeof row.range === 'number' ? row.range : 0,
+  };
+}
+
+function normalizeLegacyResult(row: unknown): NormalizedBenchRow {
+  if (!isRecord(row) || typeof row.name !== 'string' || typeof row.hz !== 'number') {
+    throw new Error('Invalid legacy perf row');
+  }
+
+  return {
+    name: row.name,
+    opsPerSecond: row.hz,
+    relativeMargin: typeof row.rme === 'number' ? row.rme : 0,
+  };
+}
+
+export function normalizePerfFile(input: unknown): NormalizedBenchRow[] {
+  if (Array.isArray(input)) {
+    return input.map((row) => normalizeActionBenchRow(row));
+  }
+
+  if (isRecord(input) && Array.isArray(input.results)) {
+    return input.results.map((row) => normalizeLegacyResult(row));
+  }
+
+  throw new Error(
+    'Unsupported benchmark file format. Expected action-bench rows or a legacy { results: [...] } payload.'
+  );
+}
+
+export async function loadNormalizedFile(
+  path: string
+): Promise<NormalizedBenchRow[]> {
+  const raw = await readFile(path, 'utf8');
+  return normalizePerfFile(JSON.parse(raw));
+}
+
+export function percentChange(previous: number, next: number): number {
+  if (previous === 0) {
+    return 0;
+  }
+
+  return ((next - previous) / previous) * 100;
+}
+
+export function compareBenchmarks(
+  previousRows: NormalizedBenchRow[],
+  nextRows: NormalizedBenchRow[],
+  threshold: number
+): ComparisonRow[] {
+  const previousMap = new Map(previousRows.map((row) => [row.name, row]));
+  const nextMap = new Map(nextRows.map((row) => [row.name, row]));
+  const names = [...new Set([...previousMap.keys(), ...nextMap.keys()])].sort();
+
+  return names.map((name) => {
+    const previous = previousMap.get(name);
+    const next = nextMap.get(name);
+    const change =
+      previous && next
+        ? percentChange(previous.opsPerSecond, next.opsPerSecond)
+        : undefined;
+
+    return {
+      name,
+      previous,
+      next,
+      percentChange: change,
+      isRegressionRisk:
+        typeof change === 'number' && change <= threshold * -1,
+    };
+  });
+}
+
+export function renderComparison(rows: ComparisonRow[]): string {
+  return rows
+    .map((row) => {
+      if (!row.previous || !row.next) {
+        return `${row.name}: missing in ${row.previous ? 'new' : 'old'} run`;
+      }
+
+      const delta = row.percentChange ?? 0;
+      const trend = delta >= 0 ? 'faster' : 'slower';
+      const risk = row.isRegressionRisk ? ' regression risk' : '';
+
+      return `${row.name}: ${row.previous.opsPerSecond.toFixed(2)} -> ${row.next.opsPerSecond.toFixed(2)} ops/sec (${delta.toFixed(2)}% ${trend})${risk}`;
+    })
+    .join('\n');
+}
+
+export function parseArgs(argv: string[]): CliArgs {
+  let threshold = Number.parseFloat(process.env.THRESHOLD ?? '5');
+  const positional: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--threshold') {
+      const next = argv[index + 1];
+      if (!next) {
+        throw new Error('Missing value for --threshold');
+      }
+      threshold = Number.parseFloat(next);
+      index += 1;
+      continue;
+    }
+
+    if (arg === '--help' || arg === '-h') {
+      console.log(
+        'Usage: bun run scripts/compare-perf.ts [--threshold <percent>] <old.json> <new.json>'
+      );
+      process.exit(0);
+    }
+
+    positional.push(arg);
+  }
+
+  if (!Number.isFinite(threshold) || threshold < 0) {
+    throw new Error('Threshold must be a non-negative number');
+  }
+
+  const [previousPath, nextPath] = positional;
+  if (!previousPath || !nextPath) {
+    throw new Error(
+      'Usage: bun run scripts/compare-perf.ts [--threshold <percent>] <old.json> <new.json>'
+    );
+  }
+
+  return { previousPath, nextPath, threshold };
+}
+
+async function main(): Promise<void> {
+  const { previousPath, nextPath, threshold } = parseArgs(process.argv.slice(2));
+  const previousRows = await loadNormalizedFile(previousPath);
+  const nextRows = await loadNormalizedFile(nextPath);
+  const comparison = compareBenchmarks(previousRows, nextRows, threshold);
+
+  console.log(renderComparison(comparison));
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/compare-perf.ts
+++ b/scripts/compare-perf.ts
@@ -45,7 +45,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function normalizeActionBenchRow(row: unknown): NormalizedBenchRow {
-  if (!isRecord(row) || typeof row.name !== 'string' || typeof row.value !== 'number') {
+  if (
+    !isRecord(row) ||
+    typeof row.name !== 'string' ||
+    typeof row.value !== 'number'
+  ) {
     throw new Error('Invalid action-bench row');
   }
 
@@ -57,7 +61,11 @@ function normalizeActionBenchRow(row: unknown): NormalizedBenchRow {
 }
 
 function normalizeLegacyResult(row: unknown): NormalizedBenchRow {
-  if (!isRecord(row) || typeof row.name !== 'string' || typeof row.hz !== 'number') {
+  if (
+    !isRecord(row) ||
+    typeof row.name !== 'string' ||
+    typeof row.hz !== 'number'
+  ) {
     throw new Error('Invalid legacy perf row');
   }
 
@@ -119,8 +127,7 @@ export function compareBenchmarks(
       previous,
       next,
       percentChange: change,
-      isRegressionRisk:
-        typeof change === 'number' && change <= threshold * -1,
+      isRegressionRisk: typeof change === 'number' && change <= threshold * -1,
     };
   });
 }
@@ -183,7 +190,9 @@ export function parseArgs(argv: string[]): CliArgs {
 }
 
 async function main(): Promise<void> {
-  const { previousPath, nextPath, threshold } = parseArgs(process.argv.slice(2));
+  const { previousPath, nextPath, threshold } = parseArgs(
+    process.argv.slice(2)
+  );
   const previousRows = await loadNormalizedFile(previousPath);
   const nextRows = await loadNormalizedFile(nextPath);
   const comparison = compareBenchmarks(previousRows, nextRows, threshold);

--- a/test/perf-compare.test.ts
+++ b/test/perf-compare.test.ts
@@ -1,0 +1,149 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  compareBenchmarks,
+  loadNormalizedFile,
+  normalizePerfFile,
+  parseArgs,
+  renderComparison,
+} from '../scripts/compare-perf.ts';
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop() as string;
+    rmSync(dir, { force: true, recursive: true });
+  }
+});
+
+describe('compare-perf', () => {
+  test('normalizes current action-bench rows', () => {
+    const rows = normalizePerfFile([
+      { name: 'scan', unit: 'ops/s', value: 100, range: 1.5 },
+    ]);
+
+    expect(rows).toEqual([
+      { name: 'scan', opsPerSecond: 100, relativeMargin: 1.5 },
+    ]);
+  });
+
+  test('normalizes legacy perf output', () => {
+    const rows = normalizePerfFile({
+      results: [{ name: 'scan', hz: 100, rme: 1.5 }],
+    });
+
+    expect(rows).toEqual([
+      { name: 'scan', opsPerSecond: 100, relativeMargin: 1.5 },
+    ]);
+  });
+
+  test('loads current and legacy files from disk', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'compare-perf-'));
+    tempDirs.push(dir);
+
+    const currentPath = join(dir, 'current.json');
+    const legacyPath = join(dir, 'legacy.json');
+
+    writeFileSync(
+      currentPath,
+      JSON.stringify([{ name: 'scan', value: 100, range: 2 }]),
+      'utf8'
+    );
+    writeFileSync(
+      legacyPath,
+      JSON.stringify({ results: [{ name: 'scan', hz: 90, rme: 3 }] }),
+      'utf8'
+    );
+
+    await expect(loadNormalizedFile(currentPath)).resolves.toEqual([
+      { name: 'scan', opsPerSecond: 100, relativeMargin: 2 },
+    ]);
+    await expect(loadNormalizedFile(legacyPath)).resolves.toEqual([
+      { name: 'scan', opsPerSecond: 90, relativeMargin: 3 },
+    ]);
+  });
+
+  test('flags only negative deltas as regression risk', () => {
+    const rows = compareBenchmarks(
+      [{ name: 'scan', opsPerSecond: 100, relativeMargin: 1 }],
+      [
+        { name: 'scan', opsPerSecond: 92, relativeMargin: 1 },
+        { name: 'insert', opsPerSecond: 130, relativeMargin: 1 },
+      ],
+      5
+    );
+
+    expect(rows).toEqual([
+      {
+        name: 'insert',
+        previous: undefined,
+        next: { name: 'insert', opsPerSecond: 130, relativeMargin: 1 },
+        percentChange: undefined,
+        isRegressionRisk: false,
+      },
+      {
+        name: 'scan',
+        previous: { name: 'scan', opsPerSecond: 100, relativeMargin: 1 },
+        next: { name: 'scan', opsPerSecond: 92, relativeMargin: 1 },
+        percentChange: -8,
+        isRegressionRisk: true,
+      },
+    ]);
+  });
+
+  test('renders missing and regression rows', () => {
+    const output = renderComparison([
+      {
+        name: 'insert',
+        previous: undefined,
+        next: { name: 'insert', opsPerSecond: 130, relativeMargin: 1 },
+        percentChange: undefined,
+        isRegressionRisk: false,
+      },
+      {
+        name: 'scan',
+        previous: { name: 'scan', opsPerSecond: 100, relativeMargin: 1 },
+        next: { name: 'scan', opsPerSecond: 92, relativeMargin: 1 },
+        percentChange: -8,
+        isRegressionRisk: true,
+      },
+    ]);
+
+    expect(output).toContain('insert: missing in old run');
+    expect(output).toContain(
+      'scan: 100.00 -> 92.00 ops/sec (-8.00% slower) regression risk'
+    );
+  });
+
+  test('parses threshold flag and positional args', () => {
+    expect(parseArgs(['--threshold', '7.5', 'old.json', 'new.json'])).toEqual({
+      previousPath: 'old.json',
+      nextPath: 'new.json',
+      threshold: 7.5,
+    });
+  });
+});
+
+describe('package script targets', () => {
+  test('local bun script targets exist', () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf8')
+    ) as {
+      scripts?: Record<string, string>;
+    };
+
+    const missingTargets = Object.values(packageJson.scripts ?? [])
+      .map((script) => {
+        const match = script.match(/^bun run (scripts\/[^\s]+)$/);
+        return match?.[1];
+      })
+      .filter((target): target is string => Boolean(target))
+      .filter((target) => !existsSync(join(__dirname, '..', target)));
+
+    expect(missingTargets).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
The repository advertised a `perf:compare` workflow in `package.json` and `docs/architecture.md`, but the backing `scripts/compare-perf.ts` file had been deleted. That meant the local performance comparison command was broken even though the rest of the benchmark pipeline still existed. Contributors trying to compare benchmark outputs locally hit an immediate module resolution failure instead of getting a regression report.

The root cause was script drift after the AST rewrite work: the script entry remained in `package.json`, the docs still referenced it, but the file itself was removed. The old implementation also had a logic bug where any large delta, including a large improvement, was labeled as a regression risk because it checked the absolute value of the percent change.

This change restores `scripts/compare-perf.ts` with support for both benchmark formats that exist in this repository's history: the current `action-bench.json` row array emitted by `scripts/run-perf.ts`, and the older `{ results: [...] }` shape. The restored script now only flags negative deltas past the configured threshold as regression risk, which preserves backwards compatibility while fixing the false-positive warning behavior. I also added a guard test that scans local `bun run scripts/...` package scripts and fails if any of those targets are missing again.

## Dependency review
I updated `tinybench` from `2.9.0` to `6.0.0` and kept it because the repo still builds, the full test suite passes, and the perf runner still emits valid benchmark JSON. I also tested `drizzle-orm@0.45.2`, but did not keep that update because it breaks the current codebase at build time with new type errors in `src/session.ts` and `src/sql/result-mapper.ts`. Keeping `drizzle-orm` pinned avoids a breaking dependency bump while preserving current backwards compatibility.

## Validation
- `bun run build`
- `bun test`
- `bun run perf:run -- --gha-output <tmp>/action-bench.json test/perf/basic.bench.ts`
- `bun run perf:compare -- <current-format.json> <legacy-format.json>`
