### PR TITLE
[codex] extract select source fields

### DIFF
--- a/src/select-builder.ts
+++ b/src/select-builder.ts
@@ -1,4 +1,3 @@
-import { is } from 'drizzle-orm/entity';
 import {
   PgSelectBase,
   PgSelectBuilder,
@@ -7,26 +6,16 @@ import {
   type TableLikeHasEmptySelection,
 } from 'drizzle-orm/pg-core/query-builders';
 import { PgColumn, PgTable, type PgSession } from 'drizzle-orm/pg-core';
-import { Subquery, ViewBaseConfig, type SQLWrapper } from 'drizzle-orm';
+import { Subquery, type SQLWrapper } from 'drizzle-orm';
 import { PgViewBase } from 'drizzle-orm/pg-core/view-base';
 import type {
   GetSelectTableName,
   GetSelectTableSelection,
 } from 'drizzle-orm/query-builders/select.types';
-import { SQL, type ColumnsSelection } from 'drizzle-orm/sql/sql';
-import { aliasFields } from './sql/selection.ts';
+import { SQL } from 'drizzle-orm/sql/sql';
+import { getSelectSourceFields } from './sql/selection.ts';
 import type { DuckDBDialect } from './dialect.ts';
-import { getTableColumns, type DrizzleTypeError } from 'drizzle-orm/utils';
-
-interface PgViewBaseInternal<
-  TName extends string = string,
-  TExisting extends boolean = boolean,
-  TSelectedFields extends ColumnsSelection = ColumnsSelection,
-> extends PgViewBase<TName, TExisting, TSelectedFields> {
-  [ViewBaseConfig]?: {
-    selectedFields: SelectedFields;
-  };
-}
+import type { DrizzleTypeError } from 'drizzle-orm/utils';
 
 export class DuckDBSelectBuilder<
   TSelection extends SelectedFields | undefined,
@@ -64,7 +53,7 @@ export class DuckDBSelectBuilder<
     this._distinct = config.distinct;
   }
 
-  from<TFrom extends PgTable | Subquery | PgViewBaseInternal | SQL>(
+  from<TFrom extends PgTable | Subquery | PgViewBase | SQL>(
     source: TableLikeHasEmptySelection<TFrom> extends true
       ? DrizzleTypeError<"Cannot reference a data-modifying statement subquery if it doesn't contain a `returning` clause">
       : TFrom
@@ -80,21 +69,8 @@ export class DuckDBSelectBuilder<
     let fields: SelectedFields;
     if (this._fields) {
       fields = this._fields;
-    } else if (is(src, Subquery)) {
-      fields = Object.fromEntries(
-        Object.keys(src._.selectedFields).map((key) => [
-          key,
-          src[
-            key as unknown as keyof typeof src
-          ] as unknown as SelectedFields[string],
-        ])
-      );
-    } else if (is(src, PgViewBase)) {
-      fields = src[ViewBaseConfig]?.selectedFields as SelectedFields;
-    } else if (is(src, SQL)) {
-      fields = {};
     } else {
-      fields = aliasFields(getTableColumns<PgTable>(src), !isPartialSelect);
+      fields = getSelectSourceFields(src, isPartialSelect);
     }
 
     return new PgSelectBase({

--- a/src/sql/selection.ts
+++ b/src/sql/selection.ts
@@ -1,5 +1,26 @@
-import { Column, SQL, getTableName, is, sql } from 'drizzle-orm';
-import type { SelectedFields } from 'drizzle-orm/pg-core';
+import {
+  Column,
+  SQL,
+  Subquery,
+  ViewBaseConfig,
+  getTableName,
+  is,
+  sql,
+} from 'drizzle-orm';
+import { PgTable, type SelectedFields } from 'drizzle-orm/pg-core';
+import { PgViewBase } from 'drizzle-orm/pg-core/view-base';
+import type { ColumnsSelection } from 'drizzle-orm/sql/sql';
+import { getTableColumns } from 'drizzle-orm/utils';
+
+interface PgViewBaseInternal<
+  TName extends string = string,
+  TExisting extends boolean = boolean,
+  TSelectedFields extends ColumnsSelection = ColumnsSelection,
+> extends PgViewBase<TName, TExisting, TSelectedFields> {
+  [ViewBaseConfig]?: {
+    selectedFields: SelectedFields;
+  };
+}
 
 function mapEntries(
   obj: Record<string, unknown>,
@@ -57,4 +78,30 @@ export function aliasFields(
   fullJoin = false
 ): SelectedFields {
   return mapEntries(fields, undefined, fullJoin) as SelectedFields;
+}
+
+export function getSelectSourceFields(
+  source: PgTable | Subquery | PgViewBaseInternal | SQL,
+  isPartialSelect: boolean
+): SelectedFields {
+  if (is(source, Subquery)) {
+    return Object.fromEntries(
+      Object.keys(source._.selectedFields).map((key) => [
+        key,
+        source[
+          key as unknown as keyof typeof source
+        ] as unknown as SelectedFields[string],
+      ])
+    );
+  }
+
+  if (is(source, PgViewBase)) {
+    return source[ViewBaseConfig]?.selectedFields as SelectedFields;
+  }
+
+  if (is(source, SQL)) {
+    return {};
+  }
+
+  return aliasFields(getTableColumns<PgTable>(source), !isPartialSelect);
 }


### PR DESCRIPTION
## Summary
This change pulls source-selection resolution out of `DuckDBSelectBuilder.from()` and moves it into `src/sql/selection.ts` as `getSelectSourceFields()`.

Before this change, `from()` handled four different source shapes inline: explicit partial selections, subqueries, views, raw SQL fragments, and plain tables. That made the method denser than it needed to be and mixed builder orchestration with selection-shape derivation. For users, the behavior stayed correct, but the code path that governs aliased selections and subquery/view field propagation was harder to read and harder to adjust safely.

The root cause was that this logic had grown inside the builder instead of living next to the existing aliasing helpers. The fix is small and targeted: keep `DuckDBSelectBuilder` focused on constructing the select builder, and centralize the source-to-fields mapping logic in the SQL selection helper module where related selection behavior already lives.

## Validation
I validated the refactor locally with:

- `bun run build`
- `bun test`

Those checks passed before opening this PR.
