### PR TITLE
[codex] Refactor pooled client handling

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -73,6 +73,39 @@ export interface PrepareParamsOptions {
   warnOnStringArrayLiteral?: () => void;
 }
 
+async function withConnection<T>(
+  client: DuckDBClientLike,
+  callback: (connection: DuckDBConnection) => Promise<T>
+): Promise<T> {
+  if (!isPool(client)) {
+    return await callback(client);
+  }
+
+  const connection = await client.acquire();
+  try {
+    return await callback(connection);
+  } finally {
+    await client.release(connection);
+  }
+}
+
+async function* withConnectionStream<T>(
+  client: DuckDBClientLike,
+  callback: (connection: DuckDBConnection) => AsyncGenerator<T, void, void>
+): AsyncGenerator<T, void, void> {
+  if (!isPool(client)) {
+    yield* callback(client);
+    return;
+  }
+
+  const connection = await client.acquire();
+  try {
+    yield* callback(connection);
+  } finally {
+    await client.release(connection);
+  }
+}
+
 export function prepareParams(
   params: unknown[],
   options: PrepareParamsOptions = {}
@@ -347,44 +380,35 @@ async function materializeRows(
   params: unknown[],
   options: ExecuteClientOptions = {}
 ): Promise<MaterializedRows> {
-  if (isPool(client)) {
-    const connection = await client.acquire();
-    try {
-      return await materializeRows(connection, query, params, options);
-    } finally {
-      await client.release(connection);
-    }
-  }
+  return await withConnection(client, async (connection) => {
+    const values = toNodeApiValues(params);
 
-  const values = toNodeApiValues(params);
-
-  const connection = client as DuckDBConnection;
-
-  if (options.prepareCache && typeof connection.prepare === 'function') {
-    const cache = getPreparedCache(connection, options.prepareCache.size);
-    try {
-      const statement = await getOrPrepareStatement(
-        connection,
-        query,
-        options.prepareCache
-      );
-      if (values) {
-        statement.bind(values as DuckDBValue[]);
-      } else {
-        statement.clearBindings?.();
+    if (options.prepareCache && typeof connection.prepare === 'function') {
+      const cache = getPreparedCache(connection, options.prepareCache.size);
+      try {
+        const statement = await getOrPrepareStatement(
+          connection,
+          query,
+          options.prepareCache
+        );
+        if (values) {
+          statement.bind(values as DuckDBValue[]);
+        } else {
+          statement.clearBindings?.();
+        }
+        const result = await statement.run();
+        cache.entries.delete(query);
+        cache.entries.set(query, { statement });
+        return await materializeResultRows(result);
+      } catch (error) {
+        evictCacheEntry(cache, query);
+        throw error;
       }
-      const result = await statement.run();
-      cache.entries.delete(query);
-      cache.entries.set(query, { statement });
-      return await materializeResultRows(result);
-    } catch (error) {
-      evictCacheEntry(cache, query);
-      throw error;
     }
-  }
 
-  const result = await connection.run(query, values);
-  return await materializeResultRows(result);
+    const result = await connection.run(query, values);
+    return await materializeResultRows(result);
+  });
 }
 
 function clearPreparedCache(connection: DuckDBConnection): void {
@@ -502,45 +526,43 @@ async function* streamRawBatches(
   params: unknown[],
   options: ExecuteInBatchesOptions = {}
 ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
-  if (isPool(client)) {
-    const connection = await client.acquire();
-    try {
-      yield* streamRawBatches(connection, query, params, options);
-      return;
-    } finally {
-      await client.release(connection);
-    }
-  }
+  yield* withConnectionStream(
+    client,
+    async function* (connection): AsyncGenerator<ExecuteBatchesRawChunk> {
+      const rowsPerChunk = resolveRowsPerChunk(options);
+      const values = toNodeApiValues(params);
 
-  const rowsPerChunk = resolveRowsPerChunk(options);
-  const values = toNodeApiValues(params);
+      const result = (await connection.stream(
+        query,
+        values
+      )) as StreamResultLike;
+      const columns = resolveResultColumns(result);
 
-  const result = (await client.stream(query, values)) as StreamResultLike;
-  const columns = resolveResultColumns(result);
+      let rows: unknown[][] = [];
 
-  let rows: unknown[][] = [];
-
-  try {
-    try {
-      for await (const chunk of result.yieldRowsJs()) {
-        for (const row of chunk) {
-          rows.push(row as unknown[]);
-          if (rows.length >= rowsPerChunk) {
-            yield { columns, rows };
-            rows = [];
+      try {
+        try {
+          for await (const chunk of result.yieldRowsJs()) {
+            for (const row of chunk) {
+              rows.push(row as unknown[]);
+              if (rows.length >= rowsPerChunk) {
+                yield { columns, rows };
+                rows = [];
+              }
+            }
           }
+        } catch (error) {
+          throw wrapUnsupportedNodeApiTypeError(result, error);
         }
-      }
-    } catch (error) {
-      throw wrapUnsupportedNodeApiTypeError(result, error);
-    }
 
-    if (rows.length > 0) {
-      yield { columns, rows };
+        if (rows.length > 0) {
+          yield { columns, rows };
+        }
+      } finally {
+        await closeStreamResult(result);
+      }
     }
-  } finally {
-    await closeStreamResult(result);
-  }
+  );
 }
 
 /**
@@ -575,35 +597,28 @@ export async function executeArrowOnClient(
   query: string,
   params: unknown[]
 ): Promise<unknown> {
-  if (isPool(client)) {
-    const connection = await client.acquire();
-    try {
-      return await executeArrowOnClient(connection, query, params);
-    } finally {
-      await client.release(connection);
+  return await withConnection(client, async (connection) => {
+    const values = toNodeApiValues(params);
+    const result = await connection.run(query, values);
+
+    // Runtime detection for Arrow API support (optional method, not in base type)
+    const maybeArrow =
+      (result as unknown as { toArrow?: () => Promise<unknown> }).toArrow ??
+      (result as unknown as { getArrowTable?: () => Promise<unknown> })
+        .getArrowTable;
+
+    if (typeof maybeArrow === 'function') {
+      return await maybeArrow.call(result);
     }
-  }
 
-  const values = toNodeApiValues(params);
-  const result = await client.run(query, values);
-
-  // Runtime detection for Arrow API support (optional method, not in base type)
-  const maybeArrow =
-    (result as unknown as { toArrow?: () => Promise<unknown> }).toArrow ??
-    (result as unknown as { getArrowTable?: () => Promise<unknown> })
-      .getArrowTable;
-
-  if (typeof maybeArrow === 'function') {
-    return await maybeArrow.call(result);
-  }
-
-  // Fallback: return column-major JS arrays to avoid per-row object creation.
-  try {
-    return await result.getColumnsObjectJS();
-  } catch (error) {
-    throw wrapUnsupportedNodeApiTypeError(
-      result as unknown as ResultTypeMetadataLike,
-      error
-    );
-  }
+    // Fallback: return column-major JS arrays to avoid per-row object creation.
+    try {
+      return await result.getColumnsObjectJS();
+    } catch (error) {
+      throw wrapUnsupportedNodeApiTypeError(
+        result as unknown as ResultTypeMetadataLike,
+        error
+      );
+    }
+  });
 }

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -76,6 +76,21 @@ describe('executeArrowOnClient', () => {
     const data = await executeArrowOnClient(client, 'select 1', []);
     expect(data).toBe(fallback);
   });
+
+  test('releases pooled connections after execution', async () => {
+    const connection = makeClient({ fallbackValue: { columns: true } });
+    let releaseCalls = 0;
+    const pool: DuckDBClientLike = {
+      acquire: async () => connection as any,
+      release: async () => {
+        releaseCalls += 1;
+      },
+    } as DuckDBClientLike;
+
+    await executeArrowOnClient(pool, 'select 1', []);
+
+    expect(releaseCalls).toBe(1);
+  });
 });
 
 describe('executeInBatches', () => {
@@ -197,5 +212,26 @@ describe('executeInBatchesRaw', () => {
     }
 
     expect(chunks[0]?.columns).toEqual(['id', 'id_1']);
+  });
+
+  test('releases pooled connections when the consumer exits early', async () => {
+    const connection = makeClient({
+      rows: [[1], [2], [3]],
+    });
+    let releaseCalls = 0;
+    const pool: DuckDBClientLike = {
+      acquire: async () => connection as any,
+      release: async () => {
+        releaseCalls += 1;
+      },
+    } as DuckDBClientLike;
+
+    for await (const _chunk of executeInBatchesRaw(pool, 'select', [], {
+      rowsPerChunk: 1,
+    })) {
+      break;
+    }
+
+    expect(releaseCalls).toBe(1);
   });
 });


### PR DESCRIPTION
This refactor tightens the internal client execution paths that sit underneath query materialization, Arrow extraction, and batch streaming.

Before this change, `src/client.ts` repeated the same pool acquire and release pattern in several places. The behavior was already correct, but the repetition made the hot-path utilities harder to scan and slightly easier to drift apart over time. That kind of drift would show up as inconsistent resource cleanup, especially when one execution path is updated and another is missed.

The root cause was that pooled and direct connections were handled inline inside each execution function instead of through one shared internal mechanism. That left three separate places responsible for the same lifecycle concern.

The fix is small and internal: introduce `withConnection()` for promise-based execution and `withConnectionStream()` for streaming execution, then route the existing materialization, Arrow, and batch code through those helpers. Public APIs and result shapes stay the same. The follow-up test coverage adds explicit assertions that pooled connections are released after Arrow execution and when streamed batch consumers exit early.

Validation used a targeted unit run for `test/client-execute.test.ts`, a full `bun run build`, and a full `bun test` pass in the repository.
