### PR TITLE
[codex] sanitize numeric options

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -491,9 +491,16 @@ export interface ExecuteBatchesRawChunk {
 function resolveRowsPerChunk(
   options: ExecuteInBatchesOptions | undefined
 ): number {
-  return options?.rowsPerChunk && options.rowsPerChunk > 0
-    ? options.rowsPerChunk
-    : 100_000;
+  const rowsPerChunk = options?.rowsPerChunk;
+  if (
+    typeof rowsPerChunk !== 'number' ||
+    !Number.isFinite(rowsPerChunk) ||
+    rowsPerChunk <= 0
+  ) {
+    return 100_000;
+  }
+
+  return Math.max(1, Math.floor(rowsPerChunk));
 }
 
 async function* streamRawBatches(

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,6 +6,14 @@ export interface PreparedStatementCacheConfig {
 
 const DEFAULT_PREPARED_CACHE_SIZE = 32;
 
+function normalizePositiveInteger(value: number, fallback: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return fallback;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
 export function resolvePrepareCacheOption(
   option?: PrepareCacheOption
 ): PreparedStatementCacheConfig | undefined {
@@ -16,10 +24,15 @@ export function resolvePrepareCacheOption(
   }
 
   if (typeof option === 'number') {
-    const size = Math.max(1, Math.floor(option));
-    return { size };
+    return {
+      size: normalizePositiveInteger(option, DEFAULT_PREPARED_CACHE_SIZE),
+    };
   }
 
-  const size = option.size ?? DEFAULT_PREPARED_CACHE_SIZE;
-  return { size: Math.max(1, Math.floor(size)) };
+  return {
+    size: normalizePositiveInteger(
+      option.size ?? DEFAULT_PREPARED_CACHE_SIZE,
+      DEFAULT_PREPARED_CACHE_SIZE
+    ),
+  };
 }

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -22,6 +22,16 @@ export const POOL_PRESETS: Record<PoolPreset, number> = {
   memory: 4, // In-memory testing
 };
 
+const DEFAULT_POOL_SIZE = 4;
+
+function normalizePoolSize(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return DEFAULT_POOL_SIZE;
+  }
+
+  return Math.max(1, Math.floor(value));
+}
+
 export interface DuckDBPoolConfig {
   /** Maximum concurrent connections. Defaults to 4. */
   size?: number;
@@ -35,9 +45,9 @@ export function resolvePoolSize(
   pool: DuckDBPoolConfig | PoolPreset | false | undefined
 ): number | false {
   if (pool === false) return false;
-  if (pool === undefined) return 4;
-  if (typeof pool === 'string') return POOL_PRESETS[pool];
-  return pool.size ?? 4;
+  if (pool === undefined) return DEFAULT_POOL_SIZE;
+  if (typeof pool === 'string') return POOL_PRESETS[pool] ?? DEFAULT_POOL_SIZE;
+  return normalizePoolSize(pool.size);
 }
 
 export interface DuckDBConnectionPoolOptions {
@@ -76,7 +86,7 @@ export function createDuckDBConnectionPool(
   instance: DuckDBInstance,
   options: DuckDBConnectionPoolOptions = {}
 ): DuckDBConnectionPool & { size: number } {
-  const size = options.size && options.size > 0 ? options.size : 4;
+  const size = normalizePoolSize(options.size);
   const acquireTimeout = options.acquireTimeout ?? 30_000;
   const maxWaitingRequests = options.maxWaitingRequests ?? 100;
   const maxLifetimeMs = options.maxLifetimeMs;

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -107,6 +107,35 @@ describe('executeInBatches', () => {
     expect(chunks).toEqual([[{ id: 1 }, { id: 2 }, { id: 3 }]]);
   });
 
+  test('rounds fractional rowsPerChunk down to an integer', async () => {
+    const client = makeClient({
+      rows: [[1], [2], [3]],
+    });
+    const chunks: Array<Array<{ id: number }>> = [];
+
+    for await (const chunk of executeInBatches(client, 'select', [], {
+      rowsPerChunk: 1.9,
+    })) {
+      chunks.push(chunk as Array<{ id: number }>);
+    }
+
+    expect(chunks).toEqual([[{ id: 1 }], [{ id: 2 }], [{ id: 3 }]]);
+  });
+
+  test('falls back to the default chunk size for non-finite rowsPerChunk', async () => {
+    const rows = Array.from({ length: 100_001 }, (_, index) => [index + 1]);
+    const client = makeClient({ rows });
+    const chunkSizes: number[] = [];
+
+    for await (const chunk of executeInBatches(client, 'select', [], {
+      rowsPerChunk: Number.POSITIVE_INFINITY,
+    })) {
+      chunkSizes.push(chunk.length);
+    }
+
+    expect(chunkSizes).toEqual([100_000, 1]);
+  });
+
   test('closes stream when consumer exits early', async () => {
     let closeCalls = 0;
     const client = makeClient({

--- a/test/driver-factory.test.ts
+++ b/test/driver-factory.test.ts
@@ -2,7 +2,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { sql } from 'drizzle-orm';
 import { describe, expect, test, afterEach } from 'vitest';
 import { drizzle } from '../src/driver.ts';
-import { POOL_PRESETS } from '../src/pool.ts';
+import { POOL_PRESETS, resolvePoolSize } from '../src/pool.ts';
 import { DuckDBDatabase } from '../src/driver.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
 import { DuckDBSession } from '../src/session.ts';
@@ -44,6 +44,15 @@ describe('Driver Factory Tests', () => {
 
     test('giga preset has size 16', () => {
       expect(POOL_PRESETS.giga).toBe(16);
+    });
+
+    test('floors fractional explicit pool sizes', () => {
+      expect(resolvePoolSize({ size: 2.9 })).toBe(2);
+    });
+
+    test('falls back when explicit pool sizes are not finite', () => {
+      expect(resolvePoolSize({ size: Number.POSITIVE_INFINITY })).toBe(4);
+      expect(resolvePoolSize({ size: Number.NaN })).toBe(4);
     });
   });
 

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { resolvePrepareCacheOption } from '../src/options.ts';
+
+describe('prepare cache options', () => {
+  test('floors fractional cache sizes', () => {
+    expect(resolvePrepareCacheOption(3.9)).toEqual({ size: 3 });
+    expect(resolvePrepareCacheOption({ size: 2.2 })).toEqual({ size: 2 });
+  });
+
+  test('falls back when cache sizes are not finite', () => {
+    expect(resolvePrepareCacheOption(Number.POSITIVE_INFINITY)).toEqual({
+      size: 32,
+    });
+    expect(resolvePrepareCacheOption({ size: Number.NaN })).toEqual({
+      size: 32,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
This change hardens numeric option handling in the DuckDB driver so invalid JavaScript inputs do not silently turn into pathological runtime settings. Before this patch, non-finite or fractional values could slip through configuration paths and produce surprising behavior such as unbounded prepared-statement caches, oversized connection pools, or ineffective batch chunking. Those cases are easy to hit from plain JavaScript consumers where runtime type checking is the last line of defense.

## User impact
Users passing `Infinity`, `NaN`, or fractional numbers into `prepareCache`, pool sizing, or `rowsPerChunk` could get behavior that was technically accepted but operationally wrong. In the worst case, `prepareCache: Infinity` could keep growing the cache without limit and `rowsPerChunk: Infinity` could defeat streaming backpressure by buffering an entire result set into one chunk.

## Root cause
The public option resolvers only applied loose truthiness or `Math.floor()` checks. That handled the common happy path but it did not reject non-finite numbers and it did not consistently normalize fractional values across the different config surfaces.

## Fix
The fix normalizes these numeric options at the library boundary. Prepared statement cache sizes and explicit pool sizes now fall back to their documented defaults when callers provide non-finite values, and fractional values are rounded down to the nearest valid integer. Streaming batch chunk sizes now do the same, preserving the intended memory-safety behavior of batched execution.

## Validation
I ran the targeted option and execution tests, then the full local verification pass:

- `bun x vitest run test/options.test.ts test/client-execute.test.ts test/driver-factory.test.ts`
- `bun run build`
- `bun test`

## Dependency review
I also tested `drizzle-orm@0.45.2` in an isolated temporary worktree. That update is not safe yet for this repository because it fails the build and the generated-schema typecheck path, so it is intentionally left pinned for now.
