### PR TITLE
[codex] refactor prepared cache execution path

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -383,7 +383,11 @@ async function executePreparedQuery(
   const cache = getPreparedCache(connection, cacheConfig.size);
 
   try {
-    const statement = await getOrPrepareStatement(connection, query, cacheConfig);
+    const statement = await getOrPrepareStatement(
+      connection,
+      query,
+      cacheConfig
+    );
     bindPreparedStatement(statement, values);
     const result = await statement.run();
     rememberPreparedStatement(cache, query, statement);

--- a/src/client.ts
+++ b/src/client.ts
@@ -253,6 +253,16 @@ function evictCacheEntry(cache: PreparedStatementCache, key: string): void {
   destroyPreparedStatement(entry);
 }
 
+function rememberPreparedStatement(
+  cache: PreparedStatementCache,
+  query: string,
+  statement: DuckDBPreparedStatement
+): DuckDBPreparedStatement {
+  cache.entries.delete(query);
+  cache.entries.set(query, { statement });
+  return statement;
+}
+
 async function getOrPrepareStatement(
   connection: DuckDBConnection,
   query: string,
@@ -261,19 +271,29 @@ async function getOrPrepareStatement(
   const cache = getPreparedCache(connection, cacheConfig.size);
   const cached = cache.entries.get(query);
   if (cached) {
-    cache.entries.delete(query);
-    cache.entries.set(query, cached);
-    return cached.statement;
+    return rememberPreparedStatement(cache, query, cached.statement);
   }
 
   const statement = await connection.prepare(query);
-  cache.entries.set(query, { statement });
+  rememberPreparedStatement(cache, query, statement);
 
   while (cache.entries.size > cache.size) {
     evictOldest(cache);
   }
 
   return statement;
+}
+
+function bindPreparedStatement(
+  statement: DuckDBPreparedStatement,
+  values: DuckDBValue[] | undefined
+): void {
+  if (values) {
+    statement.bind(values);
+    return;
+  }
+
+  statement.clearBindings?.();
 }
 
 function resolveResultColumns(result: ResultColumnsLike): string[] {
@@ -354,6 +374,26 @@ async function materializeResultRows(
   return { columns, rows };
 }
 
+async function executePreparedQuery(
+  connection: DuckDBConnection,
+  query: string,
+  values: DuckDBValue[] | undefined,
+  cacheConfig: PreparedStatementCacheConfig
+): Promise<MaterializedRows> {
+  const cache = getPreparedCache(connection, cacheConfig.size);
+
+  try {
+    const statement = await getOrPrepareStatement(connection, query, cacheConfig);
+    bindPreparedStatement(statement, values);
+    const result = await statement.run();
+    rememberPreparedStatement(cache, query, statement);
+    return await materializeResultRows(result);
+  } catch (error) {
+    evictCacheEntry(cache, query);
+    throw error;
+  }
+}
+
 type StreamResultLike = ResultTypeMetadataLike & {
   yieldRowsJs: () => AsyncIterable<unknown[][]>;
   close?: () => Promise<void> | void;
@@ -384,26 +424,12 @@ async function materializeRows(
     const values = toNodeApiValues(params);
 
     if (options.prepareCache && typeof connection.prepare === 'function') {
-      const cache = getPreparedCache(connection, options.prepareCache.size);
-      try {
-        const statement = await getOrPrepareStatement(
-          connection,
-          query,
-          options.prepareCache
-        );
-        if (values) {
-          statement.bind(values as DuckDBValue[]);
-        } else {
-          statement.clearBindings?.();
-        }
-        const result = await statement.run();
-        cache.entries.delete(query);
-        cache.entries.set(query, { statement });
-        return await materializeResultRows(result);
-      } catch (error) {
-        evictCacheEntry(cache, query);
-        throw error;
-      }
+      return await executePreparedQuery(
+        connection,
+        query,
+        values,
+        options.prepareCache
+      );
     }
 
     const result = await connection.run(query, values);

--- a/test/execution-paths.test.ts
+++ b/test/execution-paths.test.ts
@@ -89,3 +89,28 @@ test('prepare cache reuses prepared statements', async () => {
   prepareSpy.mockRestore();
   await db.close();
 });
+
+test('prepare cache evicts the least recently used statement', async () => {
+  const { connection, db } = await setupDb({ prepareCache: 1 });
+  const prepareSpy = vi.spyOn(connection, 'prepare');
+
+  const selectById = db
+    .select({ id: sampleTable.id })
+    .from(sampleTable)
+    .where(eq(sampleTable.id, sql.placeholder('pid')))
+    .prepare('cached_select_by_id');
+
+  const selectByValue = db
+    .select({ val: sampleTable.val })
+    .from(sampleTable)
+    .where(eq(sampleTable.val, sql.placeholder('pval')))
+    .prepare('cached_select_by_value');
+
+  expect(await selectById.execute({ pid: 1 })).toEqual([{ id: 1 }]);
+  expect(await selectByValue.execute({ pval: 'b' })).toEqual([{ val: 'b' }]);
+  expect(await selectById.execute({ pid: 3 })).toEqual([{ id: 3 }]);
+  expect(prepareSpy.mock.calls.length).toBe(3);
+
+  prepareSpy.mockRestore();
+  await db.close();
+});


### PR DESCRIPTION
This refactor tightens the prepared-statement cache execution path in the DuckDB client.

Before this change, the cache-management work for prepared statements was split across `getOrPrepareStatement()` and the `materializeRows()` prepared-cache branch. The same LRU refresh logic (`delete` then `set`) and binding logic were repeated in multiple places, which made the hot path harder to scan and made future cache behavior changes easier to get wrong.

The user-visible effect of the old structure was low today because behavior was already correct, but the code carried avoidable duplication in one of the more sensitive runtime paths. That duplication matters because cache hit, cache miss, rebinding, and post-run LRU refresh all have to stay aligned for prepared statements to remain reusable and evict correctly.

This change extracts that flow into small helpers:

- `rememberPreparedStatement()` centralizes LRU refresh behavior for cache hits and post-run reuse.
- `bindPreparedStatement()` centralizes the bind-versus-clear-bindings decision.
- `executePreparedQuery()` owns the cached prepared-statement execution flow, including eviction on failure.

I also added a focused regression test that proves a cache size of `1` evicts the least recently used statement. That test complements the existing reuse test by covering the eviction boundary directly.

Validation used for this change:

- `bun test test/execution-paths.test.ts`
- `bun run build`
- `bun test`
