### PR TITLE
[codex] Fix duplicate result column normalization

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
-        "drizzle-orm": "^0.40.1",
+        "drizzle-orm": ">=0.40.1 <0.46.0",
       },
       "optionalPeers": [
         "@duckdb/node-api",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.1",
+  "version": "1.5.1.1",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -209,6 +209,36 @@ function deduplicateColumns(columns: string[]): string[] {
   });
 }
 
+function normalizeDeduplicatedColumns(
+  columns: string[],
+  deduplicatedColumns: string[]
+): string[] {
+  if (columns.length !== deduplicatedColumns.length) {
+    return deduplicatedColumns;
+  }
+
+  let changed = false;
+  const normalized = deduplicatedColumns.map((column, index) => {
+    const original = columns[index];
+    if (column === original) {
+      return column;
+    }
+
+    const duplicatePrefix = `${original}:`;
+    if (column.startsWith(duplicatePrefix)) {
+      const suffix = column.slice(duplicatePrefix.length);
+      if (/^\d+$/.test(suffix)) {
+        changed = true;
+        return `${original}_${suffix}`;
+      }
+    }
+
+    return column;
+  });
+
+  return changed ? normalized : deduplicatedColumns;
+}
+
 function destroyPreparedStatement(entry: PreparedCacheEntry | undefined): void {
   if (!entry) return;
   try {
@@ -277,11 +307,16 @@ async function getOrPrepareStatement(
 }
 
 function resolveResultColumns(result: ResultColumnsLike): string[] {
+  const columns = result.columnNames();
+
   if (typeof result.deduplicatedColumnNames === 'function') {
-    return result.deduplicatedColumnNames();
+    return normalizeDeduplicatedColumns(
+      columns,
+      result.deduplicatedColumnNames()
+    );
   }
 
-  return deduplicateColumns(result.columnNames());
+  return deduplicateColumns(columns);
 }
 
 function isUnsupportedNodeApiTypeError(error: unknown): boolean {

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from 'vitest';
 import {
   executeArrowOnClient,
+  executeArraysOnClient,
   executeInBatches,
   executeInBatchesRaw,
+  executeOnClient,
   type DuckDBClientLike,
 } from '../src/client.ts';
 
@@ -34,6 +36,15 @@ function makeClient(options: {
       return {
         toArrow: arrowValue === undefined ? undefined : async () => arrowValue,
         getColumnsObjectJS: async () => fallbackValue,
+        getRowsJS: async () => rows,
+        columnNames: () => columns,
+        deduplicatedColumnNames:
+          deduplicatedColumns === undefined
+            ? undefined
+            : () => {
+                options.onDeduplicatedColumns?.();
+                return deduplicatedColumns;
+              },
       };
     },
     async stream(_query: string, _values?: unknown[]) {
@@ -170,13 +181,44 @@ describe('executeInBatches', () => {
   });
 });
 
+describe('executeOnClient', () => {
+  test('normalizes node-api duplicate column suffixes for object rows', async () => {
+    const client = makeClient({
+      rows: [[1, 2]],
+      columns: ['id', 'id'],
+      deduplicatedColumns: ['id', 'id:1'],
+    });
+
+    const rows = await executeOnClient(client, 'select', []);
+
+    expect(rows).toEqual([{ id: 1, id_1: 2 }]);
+  });
+});
+
+describe('executeArraysOnClient', () => {
+  test('normalizes node-api duplicate column suffixes for array results', async () => {
+    const client = makeClient({
+      rows: [[1, 2]],
+      columns: ['id', 'id'],
+      deduplicatedColumns: ['id', 'id:1'],
+    });
+
+    const result = await executeArraysOnClient(client, 'select', []);
+
+    expect(result).toEqual({
+      columns: ['id', 'id_1'],
+      rows: [[1, 2]],
+    });
+  });
+});
+
 describe('executeInBatchesRaw', () => {
-  test('uses deduplicatedColumnNames when provided', async () => {
+  test('normalizes node-api duplicate column suffixes when provided', async () => {
     let calls = 0;
     const client = makeClient({
       rows: [[1, 2]],
       columns: ['id', 'id'],
-      deduplicatedColumns: ['id', 'id_1'],
+      deduplicatedColumns: ['id', 'id:1'],
       onDeduplicatedColumns: () => {
         calls += 1;
       },


### PR DESCRIPTION
## Summary

This fixes a result-shape bug in the client execution layer and bumps the package version to `1.5.1.1` because the change is release-worthy without breaking backward compatibility.

## User impact

Queries that return duplicate column aliases could currently surface mixed key formats depending on which execution path Drizzle used. When `@duckdb/node-api` provided `deduplicatedColumnNames()`, callers would receive names like `id:1`, while the fallback path and existing expectations in this package use `id_1`.

That inconsistency leaks into object rows, array metadata, and streaming consumers. It makes duplicate-column handling unpredictable across equivalent queries.

## Root cause

The library trusted `@duckdb/node-api` deduplicated column names verbatim. The installed node-api implementation uses `:` suffixes for duplicates, but this package already normalizes fallback duplicates with `_N` suffixes.

## Fix

The client now normalizes node-api duplicate markers only when they are true dedupe suffixes for the original column at the same index. That preserves normal column names while converting node-api duplicate markers from `name:1` to `name_1`.

Regression coverage now exercises materialized object rows, array results, and streaming batches so all public execution modes stay aligned.

## Validation

- `bun test test/client-execute.test.ts`
- `bun run build`
- `bun test`
