### PR TITLE
[codex] Extract positive integer normalizer

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
-        "drizzle-orm": "^0.40.1",
+        "drizzle-orm": ">=0.40.1 <0.46.0",
       },
       "optionalPeers": [
         "@duckdb/node-api",

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,7 +11,10 @@ import {
   wrapperToNodeApiValue,
   type AnyDuckDBValueWrapper,
 } from './value-wrappers.ts';
-import type { PreparedStatementCacheConfig } from './options.ts';
+import {
+  normalizePositiveInteger,
+  type PreparedStatementCacheConfig,
+} from './options.ts';
 import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
 
 export type DuckDBClientLike = DuckDBConnection | DuckDBConnectionPool;
@@ -515,16 +518,7 @@ export interface ExecuteBatchesRawChunk {
 function resolveRowsPerChunk(
   options: ExecuteInBatchesOptions | undefined
 ): number {
-  const rowsPerChunk = options?.rowsPerChunk;
-  if (
-    typeof rowsPerChunk !== 'number' ||
-    !Number.isFinite(rowsPerChunk) ||
-    rowsPerChunk <= 0
-  ) {
-    return 100_000;
-  }
-
-  return Math.max(1, Math.floor(rowsPerChunk));
+  return normalizePositiveInteger(options?.rowsPerChunk, 100_000);
 }
 
 async function* streamRawBatches(

--- a/src/options.ts
+++ b/src/options.ts
@@ -6,8 +6,11 @@ export interface PreparedStatementCacheConfig {
 
 const DEFAULT_PREPARED_CACHE_SIZE = 32;
 
-function normalizePositiveInteger(value: number, fallback: number): number {
-  if (!Number.isFinite(value) || value <= 0) {
+export function normalizePositiveInteger(
+  value: number | undefined,
+  fallback: number
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
     return fallback;
   }
 

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -1,5 +1,6 @@
 import { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
 import { closeClientConnection, type DuckDBConnectionPool } from './client.ts';
+import { normalizePositiveInteger } from './options.ts';
 
 /** Pool size presets for different MotherDuck instance types */
 export type PoolPreset =
@@ -24,14 +25,6 @@ export const POOL_PRESETS: Record<PoolPreset, number> = {
 
 const DEFAULT_POOL_SIZE = 4;
 
-function normalizePoolSize(value: number | undefined): number {
-  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
-    return DEFAULT_POOL_SIZE;
-  }
-
-  return Math.max(1, Math.floor(value));
-}
-
 export interface DuckDBPoolConfig {
   /** Maximum concurrent connections. Defaults to 4. */
   size?: number;
@@ -47,7 +40,7 @@ export function resolvePoolSize(
   if (pool === false) return false;
   if (pool === undefined) return DEFAULT_POOL_SIZE;
   if (typeof pool === 'string') return POOL_PRESETS[pool] ?? DEFAULT_POOL_SIZE;
-  return normalizePoolSize(pool.size);
+  return normalizePositiveInteger(pool.size, DEFAULT_POOL_SIZE);
 }
 
 export interface DuckDBConnectionPoolOptions {
@@ -86,7 +79,7 @@ export function createDuckDBConnectionPool(
   instance: DuckDBInstance,
   options: DuckDBConnectionPoolOptions = {}
 ): DuckDBConnectionPool & { size: number } {
-  const size = normalizePoolSize(options.size);
+  const size = normalizePositiveInteger(options.size, DEFAULT_POOL_SIZE);
   const acquireTimeout = options.acquireTimeout ?? 30_000;
   const maxWaitingRequests = options.maxWaitingRequests ?? 100;
   const maxLifetimeMs = options.maxLifetimeMs;


### PR DESCRIPTION
This change cleans up a small but recurring source of duplicated configuration logic in the DuckDB driver internals.

The issue was that positive-integer option normalization lived in three separate places: prepared statement cache sizing in `src/options.ts`, pool sizing in `src/pool.ts`, and batch chunk sizing in `src/client.ts`. Each copy handled the same edge cases such as non-finite values, zero, negatives, and fractional inputs. That duplication made the behavior harder to audit and increased the risk that a future tweak would drift across call sites.

The root cause was simple copy-and-paste reuse of a tiny validation pattern instead of a shared internal helper. Users would not necessarily see a bug immediately, but the maintenance risk was real because cache sizing, connection pool sizing, and batch streaming chunk sizing are all supposed to normalize input the same way.

The fix extracts a single `normalizePositiveInteger()` helper in `src/options.ts` and reuses it from the pool and batching code paths. The behavior stays the same: invalid or non-positive values still fall back to the existing defaults, and fractional values still floor down to the nearest integer. While validating the branch, `bun install` also refreshed `bun.lock` so its recorded `drizzle-orm` peer range matches the current `package.json`, which keeps frozen lockfile installs aligned with the checked-in manifest.

Validation used the same commands that gate CI:

- `bun install --frozen-lockfile`
- `bunx prettier --check src/client.ts src/options.ts src/pool.ts`
- `bunx tsc --noEmit --project tsconfig.check.json`
- `bun run build`
- `CI=1 SKIP_MOTHERDUCK=1 bun run test`
- `npm pack --dry-run`

In this local shell, the dedicated MotherDuck integration tests fail only because the environment is receiving an external auth redirect instead of a valid MotherDuck extension response. The main CI workflow does not provide a MotherDuck token, so those tests are skipped there, and the separate MotherDuck workflow will validate the integration path with repository secrets.
