### PR TITLE
[codex] extract joined row nullify helpers

### DIFF
--- a/src/sql/result-mapper.ts
+++ b/src/sql/result-mapper.ts
@@ -29,6 +29,12 @@ type SQLCarrier = {
 type DecoderInput<TDecoder extends DriverValueDecoder<unknown, unknown>> =
   Parameters<TDecoder['mapFromDriverValue']>[0];
 
+type NullifyMap = Record<string, string | false>;
+
+const passthroughDecoder: DriverValueDecoder<unknown, unknown> = {
+  mapFromDriverValue: (value) => value,
+};
+
 function toDecoderInput<TDecoder extends DriverValueDecoder<unknown, unknown>>(
   decoder: TDecoder,
   value: unknown
@@ -56,6 +62,72 @@ function findColumnInSql(sqlValue: SQL | undefined): AnyColumn | undefined {
   return sqlValue?.queryChunks.find((chunk: unknown) => is(chunk, Column)) as
     | AnyColumn
     | undefined;
+}
+
+function resolveFieldDecoder(
+  field: unknown
+): DriverValueDecoder<unknown, unknown> {
+  if (is(field, Column)) {
+    return field;
+  }
+
+  if (is(field, SQL)) {
+    return (field as SQLInternal).decoder;
+  }
+
+  const fieldSql = getFieldSql(field as SQLCarrier);
+  const column = findColumnInSql(fieldSql);
+
+  if (is(column, PgCustomColumn)) {
+    return column;
+  }
+
+  return fieldSql?.decoder ?? passthroughDecoder;
+}
+
+function trackNullifyTarget(
+  nullifyMap: NullifyMap,
+  objectName: string,
+  tableName: string,
+  value: unknown
+): void {
+  if (!(objectName in nullifyMap)) {
+    nullifyMap[objectName] = value === null ? tableName : false;
+    return;
+  }
+
+  if (nullifyMap[objectName] && nullifyMap[objectName] !== tableName) {
+    nullifyMap[objectName] = false;
+  }
+}
+
+function trackJoinedObjectNullability(
+  nullifyMap: NullifyMap,
+  field: unknown,
+  path: string[],
+  value: unknown
+): void {
+  if (path.length !== 2) {
+    return;
+  }
+
+  const objectName = path[0] as string;
+
+  if (is(field, Column)) {
+    trackNullifyTarget(nullifyMap, objectName, getTableName(field.table), value);
+    return;
+  }
+
+  if (!is(field, SQL.Aliased)) {
+    return;
+  }
+
+  const column = findColumnInSql(getFieldSql(field as SQLCarrier));
+  const tableName = column?.table && getTableName(column.table);
+
+  if (tableName) {
+    trackNullifyTarget(nullifyMap, objectName, tableName, value);
+  }
 }
 
 export function normalizeInet(value: unknown): unknown {
@@ -243,27 +315,11 @@ export function mapResultRow<TResult>(
   row: unknown[],
   joinsNotNullableMap: Record<string, boolean> | undefined
 ): TResult {
-  const nullifyMap: Record<string, string | false> = {};
+  const nullifyMap: NullifyMap = {};
 
   const result = columns.reduce<Record<string, any>>(
     (acc, { path, field }, columnIndex) => {
-      let decoder: DriverValueDecoder<unknown, unknown>;
-      if (is(field, Column)) {
-        decoder = field;
-      } else if (is(field, SQL)) {
-        decoder = (field as SQLInternal).decoder;
-      } else {
-        const fieldSql = getFieldSql(field as SQLCarrier);
-        const col = findColumnInSql(fieldSql);
-
-        if (is(col, PgCustomColumn)) {
-          decoder = col;
-        } else {
-          decoder = fieldSql?.decoder ?? {
-            mapFromDriverValue: (value) => value,
-          };
-        }
-      }
+      const decoder = resolveFieldDecoder(field);
       let node = acc;
       for (const [pathChunkIndex, pathChunk] of path.entries()) {
         if (pathChunkIndex < path.length - 1) {
@@ -279,43 +335,8 @@ export function mapResultRow<TResult>(
         const value = (node[pathChunk] =
           rawValue === null ? null : mapDriverValue(decoder, rawValue));
 
-        if (joinsNotNullableMap && is(field, Column) && path.length === 2) {
-          const objectName = path[0]!;
-          if (!(objectName in nullifyMap)) {
-            nullifyMap[objectName] =
-              value === null ? getTableName(field.table) : false;
-          } else if (
-            typeof nullifyMap[objectName] === 'string' &&
-            nullifyMap[objectName] !== getTableName(field.table)
-          ) {
-            nullifyMap[objectName] = false;
-          }
-          continue;
-        }
-
-        if (
-          joinsNotNullableMap &&
-          is(field, SQL.Aliased) &&
-          path.length === 2
-        ) {
-          const col = findColumnInSql(getFieldSql(field as SQLCarrier));
-          const tableName = col?.table && getTableName(col?.table);
-
-          if (!tableName) {
-            continue;
-          }
-
-          const objectName = path[0]!;
-
-          if (!(objectName in nullifyMap)) {
-            nullifyMap[objectName] = value === null ? tableName : false;
-            continue;
-          }
-
-          if (nullifyMap[objectName] && nullifyMap[objectName] !== tableName) {
-            nullifyMap[objectName] = false;
-          }
-          continue;
+        if (joinsNotNullableMap) {
+          trackJoinedObjectNullability(nullifyMap, field, path, value);
         }
       }
       return acc;

--- a/src/sql/result-mapper.ts
+++ b/src/sql/result-mapper.ts
@@ -114,7 +114,12 @@ function trackJoinedObjectNullability(
   const objectName = path[0] as string;
 
   if (is(field, Column)) {
-    trackNullifyTarget(nullifyMap, objectName, getTableName(field.table), value);
+    trackNullifyTarget(
+      nullifyMap,
+      objectName,
+      getTableName(field.table),
+      value
+    );
     return;
   }
 

--- a/test/nullify.test.ts
+++ b/test/nullify.test.ts
@@ -124,3 +124,41 @@ test('return null instead of object if join has no match', async () => {
     },
   ]);
 });
+
+test('return null for joined objects built only from aliased SQL fields', async () => {
+  const { id: cityId } = await ctx.db
+    .insert(citiesTable)
+    .values({ id: 3, name: 'Rome' })
+    .returning({ id: citiesTable.id })
+    .then((rows) => rows[0]!);
+
+  await ctx.db.insert(users2Table).values([
+    { id: 3, name: 'Alice', cityId },
+    { id: 4, name: 'Bob' },
+  ]);
+
+  const res = await ctx.db
+    .select({
+      id: users2Table.id,
+      city: {
+        upperName: sql<string>`upper(${citiesTable.name})`.as('upper_name'),
+      },
+    })
+    .from(users2Table)
+    .leftJoin(citiesTable, eq(users2Table.cityId, citiesTable.id))
+    .where(sql`${users2Table.id} in (3, 4)`)
+    .orderBy(users2Table.id);
+
+  nodeAssert.deepEqual(res, [
+    {
+      id: 3,
+      city: {
+        upperName: 'ROME',
+      },
+    },
+    {
+      id: 4,
+      city: null,
+    },
+  ]);
+});


### PR DESCRIPTION
This change tightens a small but busy piece of row-mapping logic in the DuckDB session layer. The `mapResultRow()` path had two kinds of duplication: it resolved decoders inline with several branches inside the reduction loop, and it duplicated the bookkeeping that decides when a nested joined object should collapse back to `null` for both plain columns and SQL-aliased fields.

The root cause is that support for custom columns and aliased SQL projections grew around the original mapper without extracting the shared join-nullability rules. That left the hot path harder to read and easier to break when adjusting how joined selections are decoded, especially for nullable joins that mix normal columns and computed SQL fields.

The fix extracts small internal helpers for decoder resolution and joined-object nullability tracking while preserving the existing behavior. I also added a regression test that covers the aliased-SQL case directly, so a nested joined object built only from aliased SQL fields still becomes `null` when the join has no match.

Validation included `bun run build`, the focused mapper tests, and the full `bun test` suite, all of which passed locally.
