### PR TITLE
[codex] fix introspection type aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.1.1",
+  "version": "1.5.1.2",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -571,13 +571,82 @@ interface TypeMappingResult {
   builder: string;
 }
 
+export function normalizeTypeLiteral(raw: string): string {
+  const trimmed = raw.trim().replace(/\s+/g, ' ');
+
+  const arrayMatch = /^(.*?)(\[(?:\d+)?\])$/.exec(trimmed);
+  if (arrayMatch) {
+    const [, base, suffix] = arrayMatch;
+    return `${normalizeTypeLiteral(base ?? '')}${suffix ?? ''}`;
+  }
+
+  const canonicalPrefixes: Array<[RegExp, string]> = [
+    [/^TIMESTAMP WITHOUT TIME ZONE\b/i, 'TIMESTAMP'],
+    [/^TIMESTAMP WITH TIME ZONE\b/i, 'TIMESTAMP WITH TIME ZONE'],
+    [/^TIMESTAMPTZ\b/i, 'TIMESTAMP WITH TIME ZONE'],
+    [/^TIME WITHOUT TIME ZONE\b/i, 'TIME'],
+    [/^CHARACTER VARYING\b/i, 'VARCHAR'],
+    [/^CHARACTER\b/i, 'CHAR'],
+  ];
+
+  for (const [pattern, replacement] of canonicalPrefixes) {
+    const match = pattern.exec(trimmed);
+    if (match) {
+      return `${replacement}${trimmed.slice(match[0].length)}`;
+    }
+  }
+
+  const upper = trimmed.toUpperCase();
+  const simpleTypes = new Set([
+    'BOOLEAN',
+    'BOOL',
+    'SMALLINT',
+    'INT2',
+    'INT16',
+    'TINYINT',
+    'INTEGER',
+    'INT',
+    'INT4',
+    'SIGNED',
+    'BIGINT',
+    'INT8',
+    'UBIGINT',
+    'DECIMAL',
+    'NUMERIC',
+    'REAL',
+    'FLOAT4',
+    'DOUBLE',
+    'DOUBLE PRECISION',
+    'FLOAT',
+    'CHAR',
+    'VARCHAR',
+    'TEXT',
+    'STRING',
+    'UUID',
+    'JSON',
+    'INET',
+    'INTERVAL',
+    'BLOB',
+    'BYTEA',
+    'VARBINARY',
+    'TIMESTAMP',
+    'TIME',
+    'DATE',
+  ]);
+  if (simpleTypes.has(upper)) {
+    return upper;
+  }
+
+  return trimmed;
+}
+
 function mapDuckDbType(
   column: IntrospectedColumn,
   imports: ImportBuckets,
   options: ColumnEmitOptions
 ): TypeMappingResult {
   const raw = column.dataType.trim();
-  const upper = raw.toUpperCase();
+  const upper = normalizeTypeLiteral(raw);
 
   if (upper === 'BOOLEAN' || upper === 'BOOL') {
     imports.pgCore.add('boolean');
@@ -818,23 +887,25 @@ export function parseStructFields(
   for (const part of splitTopLevel(inner, ',')) {
     const trimmed = part.trim();
     if (!trimmed) continue;
-    const match = /^"?([^"]+)"?\s+(.*)$/i.exec(trimmed);
+    const match =
+      /^"([^"]+)"\s+(.*)$/i.exec(trimmed) ??
+      /^([^\s"]+)\s+(.*)$/i.exec(trimmed);
     if (!match) {
       continue;
     }
     const [, name, type] = match;
-    result.push({ name, type: type.trim() });
+    result.push({ name, type: normalizeTypeLiteral(type) });
   }
   return result;
 }
 
 export function parseMapValue(raw: string): string {
-  const inner = raw.replace(/^MAP\(/i, '').replace(/\)$/, '');
+  const inner = raw.trim().replace(/^MAP\(/i, '').replace(/\)$/, '');
   const parts = splitTopLevel(inner, ',');
   if (parts.length < 2) {
     return 'TEXT';
   }
-  return parts[1]?.trim() ?? 'TEXT';
+  return normalizeTypeLiteral(parts[1] ?? 'TEXT');
 }
 
 export function splitTopLevel(input: string, delimiter: string): string[] {

--- a/test/introspect.snapshot.test.ts
+++ b/test/introspect.snapshot.test.ts
@@ -50,7 +50,7 @@ test('introspection snapshot covers DuckDB-specific types', async () => {
     `bigint("visits", { mode: 'number' }).notNull()`,
     `bigint("hits", { mode: 'number' })`,
     `numeric("price", { precision: 12, scale: 2 })`,
-    `duckDbStruct("payload", { "NAME": "VARCHAR", "VALUES": "INTEGER[]" })`,
+    `duckDbStruct("payload", { "name": "VARCHAR", "values": "INTEGER[]" })`,
     `duckDbMap("extras", "INTEGER[]")`,
     `duckDbList("tags", "VARCHAR")`,
     `duckDbList("labels", "VARCHAR")`,

--- a/test/introspect.unit.test.ts
+++ b/test/introspect.unit.test.ts
@@ -5,7 +5,30 @@ import {
   splitTopLevel,
   buildDefault,
   toIdentifier,
+  normalizeTypeLiteral,
 } from '../src/introspect.ts';
+
+describe('normalizeTypeLiteral', () => {
+  test('canonicalizes character varying aliases', () => {
+    expect(normalizeTypeLiteral('character varying')).toBe('VARCHAR');
+    expect(normalizeTypeLiteral('character varying(255)[]')).toBe(
+      'VARCHAR(255)[]'
+    );
+  });
+
+  test('canonicalizes character aliases', () => {
+    expect(normalizeTypeLiteral('character(8)')).toBe('CHAR(8)');
+  });
+
+  test('canonicalizes timestamp aliases', () => {
+    expect(normalizeTypeLiteral('timestamp without time zone')).toBe(
+      'TIMESTAMP'
+    );
+    expect(normalizeTypeLiteral('timestamptz')).toBe(
+      'TIMESTAMP WITH TIME ZONE'
+    );
+  });
+});
 
 describe('parseStructFields', () => {
   test('parses simple struct fields', () => {
@@ -58,6 +81,16 @@ describe('parseStructFields', () => {
     ]);
   });
 
+  test('canonicalizes Postgres string aliases in nested fields', () => {
+    const result = parseStructFields(
+      'name character varying, tags character varying[]'
+    );
+    expect(result).toEqual([
+      { name: 'name', type: 'VARCHAR' },
+      { name: 'tags', type: 'VARCHAR[]' },
+    ]);
+  });
+
   test('handles whitespace around fields', () => {
     const result = parseStructFields('  name  VARCHAR  ,  age  INTEGER  ');
     // Should parse at least one field
@@ -96,6 +129,11 @@ describe('parseMapValue', () => {
   test('handles nested MAP in value', () => {
     const result = parseMapValue('MAP(TEXT, MAP(TEXT, INT))');
     expect(result).toBe('MAP(TEXT, INT)');
+  });
+
+  test('canonicalizes Postgres string aliases in map values', () => {
+    const result = parseMapValue('MAP(character varying, character varying[])');
+    expect(result).toBe('VARCHAR[]');
   });
 });
 


### PR DESCRIPTION
## What changed

This updates the DuckDB introspection pipeline so schema generation handles Postgres-style type aliases that can surface through MotherDuck and pgendpoint metadata, including `character varying`, `character`, `timestamp without time zone`, and `timestamptz`.

The visible user effect was that introspection could generate the wrong builder for otherwise supported columns, or emit helper arguments such as `"CHARACTER VARYING"` that do not typecheck against this package's DuckDB helpers. Nested `STRUCT(...)` and `MAP(...)` metadata had the same problem, and struct field names were also being uppercased as a side effect of the old normalization path.

The root cause was that the generator matched type names against DuckDB-native spellings only and uppercased entire complex literals before parsing nested definitions. That worked for raw `duckdb_columns()` output in simple cases, but it was not robust when metadata came through more Postgres-compatible surfaces.

The fix adds a focused type-literal canonicalizer and uses it consistently in the introspection mapper, struct field parser, and map value parser. The normalization is prefix-based, so aliases are canonicalized without rewriting the inner contents of complex types. That keeps nested field names stable while still converting supported aliases to the builder spellings this package expects.

## Validation

- `bun test`
- `bun run build`
- `bun test test/introspect.unit.test.ts test/introspect.test.ts test/introspect.snapshot.test.ts test/introspect.typecheck.test.ts test/helpers-import-path.test.ts`

## Notes

I also reviewed dependency drift and the recent `motherduck/mono` changes before making edits. The pinned runtime and dev dependency set in this repo is already current, so there was no safe package update to land in the same PR.
