### PR TITLE
Release v1.5.1-3

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.1.2",
+  "version": "1.6.0",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.1.3",
+  "version": "1.5.1-3",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.6.0",
+  "version": "1.5.1.3",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
This PR prepares the `v1.5.1-3` release.

What changed:
- bump `@duckdbfan/drizzle-duckdb` from `1.5.1.2` to `1.5.1-3`

Validation:
- `bun run build`
- `bun test`
- `pre-commit run --all-files`
- `bun run publish:dual -- --dry-run`