### PR TITLE
[codex] Wire array literal warning callback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,11 +9,11 @@
       },
       "devDependencies": {
         "@duckdb/node-api": "1.5.1-r.1",
-        "@types/bun": "^1.3.11",
+        "@types/bun": "^1.3.12",
         "@types/node": "25.6.0",
         "@vitest/ui": "4.1.4",
         "drizzle-orm": "0.45.2",
-        "prettier": "3.8.2",
+        "prettier": "3.8.3",
         "tinybench": "6.0.0",
         "typescript": "6.0.2",
         "uuid": "13.0.0",
@@ -98,7 +98,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -130,7 +130,7 @@
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.12", "", { "dependencies": { "@types/node": "*" } }, "sha512-HqOLj5PoFajAQciOMRiIZGNoKxDJSr6qigAttOX40vJuSp6DN/CxWp9s3C1Xwm4oH7ybueITwiaOcWXoYVoRkA=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -196,7 +196,7 @@
 
     "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
 
-    "prettier": ["prettier@3.8.2", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-8c3mgTe0ASwWAJK+78dpviD+A8EqhndQPUBpNUIPt6+xWlIigCwfN01lWr9MAede4uqXGTEKeQWTvzb3vjia0Q=="],
+    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
     "rolldown": ["rolldown@1.0.0-rc.12", "", { "dependencies": { "@oxc-project/types": "=0.122.0", "@rolldown/pluginutils": "1.0.0-rc.12" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-arm64": "1.0.0-rc.12", "@rolldown/binding-darwin-x64": "1.0.0-rc.12", "@rolldown/binding-freebsd-x64": "1.0.0-rc.12", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A=="],
 
@@ -234,10 +234,6 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "bun-types/@types/node": ["@types/node@25.2.0", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w=="],
-
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/docs/api/drizzle.md
+++ b/docs/api/drizzle.md
@@ -50,6 +50,9 @@ interface DuckDBDrizzleConfig<TSchema> {
 
   // Throw on Postgres-style array literals like '{1,2,3}' (default: false)
   rejectStringArrayLiterals?: boolean;
+
+  // Handle the first coerced Postgres-style array literal warning
+  arrayLiteralWarning?: (query: string) => void;
 }
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -162,6 +162,24 @@ await db.execute(sql`SELECT * FROM t WHERE tags = '{a,b}'`);
 // Error: Postgres-style array literals are not supported
 ```
 
+### arrayLiteralWarning
+
+Handle the first detected Postgres-style array literal warning yourself.
+
+| Type                     | Default | Description                                                    |
+| ------------------------ | ------- | -------------------------------------------------------------- |
+| `(query: string) => void` | logging | Called once with the SQL text when a `'{...}'` parameter is coerced |
+
+**Usage**:
+
+```typescript
+const db = drizzle(connection, {
+  arrayLiteralWarning: (query) => {
+    console.warn('Array literal parameter detected', query);
+  },
+});
+```
+
 ### pool
 
 Control connection pooling when using async connection strings/config. DuckDB runs one query per connection; pooling enables parallelism.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -166,8 +166,8 @@ await db.execute(sql`SELECT * FROM t WHERE tags = '{a,b}'`);
 
 Handle the first detected Postgres-style array literal warning yourself.
 
-| Type                     | Default | Description                                                    |
-| ------------------------ | ------- | -------------------------------------------------------------- |
+| Type                      | Default | Description                                                         |
+| ------------------------- | ------- | ------------------------------------------------------------------- |
 | `(query: string) => void` | logging | Called once with the SQL text when a `'{...}'` parameter is coerced |
 
 **Usage**:

--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@duckdb/node-api": "1.5.1-r.1",
-    "@types/bun": "^1.3.11",
+    "@types/bun": "^1.3.12",
     "@types/node": "25.6.0",
     "@vitest/ui": "4.1.4",
     "drizzle-orm": "0.45.2",
-    "prettier": "3.8.2",
+    "prettier": "3.8.3",
     "tinybench": "6.0.0",
     "typescript": "6.0.2",
     "uuid": "13.0.0",

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -53,6 +53,7 @@ import {
 export interface PgDriverOptions {
   logger?: Logger;
   rejectStringArrayLiterals?: boolean;
+  arrayLiteralWarning?: (query: string) => void;
   prepareCache?: PreparedStatementCacheConfig;
 }
 
@@ -71,6 +72,7 @@ export class DuckDBDriver {
     return new DuckDBSession(this.client, this.dialect, schema, {
       logger: this.options.logger,
       rejectStringArrayLiterals: this.options.rejectStringArrayLiterals,
+      arrayLiteralWarning: this.options.arrayLiteralWarning,
       prepareCache: this.options.prepareCache,
     });
   }
@@ -88,6 +90,7 @@ export interface DuckDBDrizzleConfig<
   TSchema extends Record<string, unknown> = Record<string, never>,
 > extends DrizzleConfig<TSchema> {
   rejectStringArrayLiterals?: boolean;
+  arrayLiteralWarning?: (query: string) => void;
   prepareCache?: PrepareCacheOption;
   /** Pool configuration. Use preset name, size config, or false to disable. */
   pool?: DuckDBPoolConfig | PoolPreset | false;
@@ -165,6 +168,7 @@ function createFromClient<
   const driver = new DuckDBDriver(finalClient, dialect, {
     logger,
     rejectStringArrayLiterals: config.rejectStringArrayLiterals,
+    arrayLiteralWarning: config.arrayLiteralWarning,
     prepareCache,
   });
   const session = driver.createSession(schema);

--- a/src/session.ts
+++ b/src/session.ts
@@ -186,6 +186,7 @@ export class DuckDBPreparedQuery<
 export interface DuckDBSessionOptions {
   logger?: Logger;
   rejectStringArrayLiterals?: boolean;
+  arrayLiteralWarning?: (query: string) => void;
   prepareCache?: PreparedStatementCacheConfig;
 }
 
@@ -314,6 +315,10 @@ export class DuckDBSession<
       return;
     }
     this.hasWarnedArrayLiteral = true;
+    if (this.options.arrayLiteralWarning) {
+      this.options.arrayLiteralWarning(query);
+      return;
+    }
     this.logger.logQuery(
       `[duckdb] ${arrayLiteralWarning}\nquery: ${query}`,
       []

--- a/test/session-options.test.ts
+++ b/test/session-options.test.ts
@@ -95,9 +95,9 @@ describe('Session Options Tests', () => {
         )
       `);
 
-      // The rejectStringArrayLiterals option affects parameter handling
-      // This test verifies the option is accepted
-      expect(db).toBeDefined();
+      await expect(async () => {
+        await db.execute(sql`INSERT INTO reject_test VALUES (1, ${'{1,2,3}'})`);
+      }).toThrow('Stringified array literals are not supported');
 
       await db.close();
     });
@@ -150,11 +150,11 @@ describe('Session Options Tests', () => {
         )
       `);
 
-      // Insert with array literal - should trigger warning if detected
-      await db.execute(sql`INSERT INTO warn_test VALUES (1, [1, 2, 3])`);
+      await db.execute(sql`INSERT INTO warn_test VALUES (1, ${'{1,2,3}'})`);
+      await db.execute(sql`INSERT INTO warn_test VALUES (2, ${'{4,5,6}'})`);
 
-      // Note: The warning may or may not be triggered depending on
-      // how the query is constructed. This test validates the callback mechanism.
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain('INSERT INTO warn_test');
       await db.close();
     });
   });

--- a/test/session-options.test.ts
+++ b/test/session-options.test.ts
@@ -95,9 +95,11 @@ describe('Session Options Tests', () => {
         )
       `);
 
-      await expect(async () => {
-        await db.execute(sql`INSERT INTO reject_test VALUES (1, ${'{1,2,3}'})`);
-      }).toThrow('Stringified array literals are not supported');
+      await expect(
+        Promise.resolve(
+          db.execute(sql`INSERT INTO reject_test VALUES (1, ${'{1,2,3}'})`)
+        )
+      ).rejects.toThrow('Stringified array literals are not supported');
 
       await db.close();
     });


### PR DESCRIPTION
## Issue

The driver already had an internal warning path for stringified Postgres-style array literals, but the documented `arrayLiteralWarning` callback was not part of the public config type and was never passed from `drizzle()` into the session. Consumers could provide the option in JavaScript, but it had no effect.

## Cause And Effect

`DuckDBDrizzleConfig`, `PgDriverOptions`, and `DuckDBSessionOptions` only carried `rejectStringArrayLiterals`. When array literal coercion happened, the session always used its default logger warning path. Users who wanted to route this warning into their own telemetry or suppress the default logger behavior could not do so.

## Fix

This wires `arrayLiteralWarning` through the driver and session config. When provided, the session calls the callback once with the SQL text for the first coerced Postgres-style array literal. Without the callback, the existing default logger warning behavior stays unchanged.

The regression tests now assert the strict rejection path actually throws during parameter preparation and that the callback fires once for coerced string array literals.

## Package Review

I checked package updates with `bun outdated`. `@duckdb/node-api@1.5.2-r.1` matches MotherDuck mono's recent DuckDB 1.5.2 bump, but it currently fails the MotherDuck integration tests locally because the MotherDuck extension is unavailable for DuckDB v1.5.2 on osx_arm64. Per the automation rule, that update was not kept. Safe patch updates for `@types/bun` and `prettier` are included.

## Validation

- `bun run build`
- `bun test` with 593 passing, 7 skipped, 0 failing
- Tried `@duckdb/node-api@1.5.2-r.1`; rejected after MotherDuck integration failures caused by unavailable v1.5.2 extension on osx_arm64
