### PR TITLE
[codex] Extract transaction internals helper

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -393,10 +393,7 @@ export class DuckDBTransaction<
 > extends PgTransaction<DuckDBQueryResultHKT, TFullSchema, TSchema> {
   static readonly [entityKind]: string = 'DuckDBTransaction';
 
-  private getInternals(): DuckDBTransactionWithInternals<
-    TFullSchema,
-    TSchema
-  > {
+  private getInternals(): DuckDBTransactionWithInternals<TFullSchema, TSchema> {
     // PgTransaction keeps dialect/session private, but DuckDB transaction
     // helpers need the session for DuckDB-specific execution paths.
     return this as unknown as DuckDBTransactionWithInternals<

--- a/src/session.ts
+++ b/src/session.ts
@@ -393,6 +393,22 @@ export class DuckDBTransaction<
 > extends PgTransaction<DuckDBQueryResultHKT, TFullSchema, TSchema> {
   static readonly [entityKind]: string = 'DuckDBTransaction';
 
+  private getInternals(): DuckDBTransactionWithInternals<
+    TFullSchema,
+    TSchema
+  > {
+    // PgTransaction keeps dialect/session private, but DuckDB transaction
+    // helpers need the session for DuckDB-specific execution paths.
+    return this as unknown as DuckDBTransactionWithInternals<
+      TFullSchema,
+      TSchema
+    >;
+  }
+
+  private markRollbackOnly(): void {
+    this.getInternals().session.markRollbackOnly();
+  }
+
   rollback(): never {
     throw new TransactionRollbackError();
   }
@@ -445,9 +461,7 @@ export class DuckDBTransaction<
   }
 
   setTransaction(config: PgTransactionConfig): Promise<void> {
-    // Cast needed: PgTransaction doesn't expose dialect/session properties in public API
-    type Tx = DuckDBTransactionWithInternals<TFullSchema, TSchema>;
-    return (this as unknown as Tx).session.execute(
+    return this.getInternals().session.execute(
       sql`set transaction ${this.getTransactionConfigSQL(config)}`
     );
   }
@@ -456,32 +470,24 @@ export class DuckDBTransaction<
     query: SQL,
     options: ExecuteInBatchesOptions = {}
   ): AsyncGenerator<GenericRowData<T>[], void, void> {
-    // Cast needed: PgTransaction doesn't expose session property in public API
-    type Tx = DuckDBTransactionWithInternals<TFullSchema, TSchema>;
-    return (this as unknown as Tx).session.executeBatches<T>(query, options);
+    return this.getInternals().session.executeBatches<T>(query, options);
   }
 
   executeBatchesRaw(
     query: SQL,
     options: ExecuteInBatchesOptions = {}
   ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
-    // Cast needed: PgTransaction doesn't expose session property in public API
-    type Tx = DuckDBTransactionWithInternals<TFullSchema, TSchema>;
-    return (this as unknown as Tx).session.executeBatchesRaw(query, options);
+    return this.getInternals().session.executeBatchesRaw(query, options);
   }
 
   executeArrow(query: SQL): Promise<unknown> {
-    // Cast needed: PgTransaction doesn't expose session property in public API
-    type Tx = DuckDBTransactionWithInternals<TFullSchema, TSchema>;
-    return (this as unknown as Tx).session.executeArrow(query);
+    return this.getInternals().session.executeArrow(query);
   }
 
   override async transaction<T>(
     transaction: (tx: DuckDBTransaction<TFullSchema, TSchema>) => Promise<T>
   ): Promise<T> {
-    // Cast needed: PgTransaction doesn't expose dialect/session properties in public API
-    type Tx = DuckDBTransactionWithInternals<TFullSchema, TSchema>;
-    const internals = this as unknown as Tx;
+    const internals = this.getInternals();
     const savepoint = `drizzle_savepoint_${this.nestedIndex + 1}`;
     const savepointSql = sql.raw(`savepoint ${savepoint}`);
     const releaseSql = sql.raw(`release savepoint ${savepoint}`);
@@ -496,7 +502,7 @@ export class DuckDBTransaction<
 
     // Check dialect-level savepoint support (per-instance, not global)
     if (internals.dialect.areSavepointsUnsupported()) {
-      return this.runNestedWithoutSavepoint(transaction, nestedTx, internals);
+      return this.runNestedWithoutSavepoint(transaction, nestedTx);
     }
 
     let createdSavepoint = false;
@@ -509,7 +515,7 @@ export class DuckDBTransaction<
         throw error;
       }
       internals.dialect.markSavepointsUnsupported();
-      return this.runNestedWithoutSavepoint(transaction, nestedTx, internals);
+      return this.runNestedWithoutSavepoint(transaction, nestedTx);
     }
 
     try {
@@ -522,22 +528,17 @@ export class DuckDBTransaction<
       if (createdSavepoint) {
         await internals.session.execute(rollbackSql);
       }
-      (
-        internals.session as DuckDBSession<TFullSchema, TSchema>
-      ).markRollbackOnly();
+      this.markRollbackOnly();
       throw error;
     }
   }
 
   private runNestedWithoutSavepoint<T>(
     transaction: (tx: DuckDBTransaction<TFullSchema, TSchema>) => Promise<T>,
-    nestedTx: DuckDBTransaction<TFullSchema, TSchema>,
-    internals: DuckDBTransactionWithInternals<TFullSchema, TSchema>
+    nestedTx: DuckDBTransaction<TFullSchema, TSchema>
   ): Promise<T> {
     return transaction(nestedTx).catch((error) => {
-      (
-        internals.session as DuckDBSession<TFullSchema, TSchema>
-      ).markRollbackOnly();
+      this.markRollbackOnly();
       throw error;
     });
   }


### PR DESCRIPTION
## Issue

DuckDB transaction helpers in `src/session.ts` each repeated the same cast from Drizzle's `PgTransaction` to DuckDB's internal transaction shape. That made the transaction code harder to maintain and spread the unsafe cast across several methods.

## Cause and effect

`PgTransaction` keeps the dialect and session properties private from the public type surface, but DuckDB-specific helpers still need access to the session for batch execution, Arrow execution, transaction config, and rollback marking. Repeating that access pattern increased the chance that future transaction methods would drift or add another local cast.

## Root cause

The implementation had no single local helper for retrieving the DuckDB transaction internals, so every method that needed the session recreated the same cast and explanatory comment.

## Fix

This extracts a private `getInternals()` helper on `DuckDBTransaction` and routes the DuckDB-specific session calls through it. It also centralizes rollback-only marking with a private `markRollbackOnly()` helper and trims the now-unused internals argument from the nested no-savepoint fallback.

## Validation

- `bun x vitest run test/transactions.savepoint.test.ts test/execution-paths.test.ts`
- `bun run build:declarations`
- `bun test`
- `bun run build`
