### PR TITLE
[codex] Update DuckDB node API validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.1-r.1`. The repo now develops against `1.5.1-r.1`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.1`. The repo now develops against `1.5.2-r.1`, and `1.4.4-r.1` remains supported.
 Tested `drizzle-orm` versions currently span `0.40.1` through `0.45.x`.
 
 ## Quick Start
@@ -304,7 +304,7 @@ This connector aims for compatibility with Drizzle's Postgres driver but has som
 | Joins and subqueries  | Full support                                                                 |
 | Transactions          | No savepoints (nested transactions reuse outer)                              |
 | JSON/JSONB columns    | Use `duckDbJson()` instead                                                   |
-| Prepared statements   | No statement caching                                                         |
+| Prepared statements   | Optional per-connection cache via `prepareCache`; no named statements         |
 | Streaming results     | Chunked reads via `executeBatches()` / `executeArrow()`; no cursor streaming |
 | Concurrent queries    | One query per connection; use pooling for parallelism                        |
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,14 +8,14 @@
         "node-sql-parser": "^5.4.0",
       },
       "devDependencies": {
-        "@duckdb/node-api": "1.5.1-r.1",
+        "@duckdb/node-api": "1.5.2-r.1",
         "@types/bun": "^1.3.12",
         "@types/node": "25.6.0",
         "@vitest/ui": "4.1.4",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.3",
         "tinybench": "6.0.0",
-        "typescript": "6.0.2",
+        "typescript": "6.0.3",
         "uuid": "13.0.0",
         "vitest": "4.1.4",
       },
@@ -32,21 +32,21 @@
     "esbuild": "0.25.12",
   },
   "packages": {
-    "@duckdb/node-api": ["@duckdb/node-api@1.5.1-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.1-r.1" } }, "sha512-8U8p44ZL4rJtUrgVaSLm2hOMk3XTwEgs5eJoxYiR6iQXKVEr8vi6z3Vrxhb61g9sgsEZIAmckD7e3zZ1lmPHYA=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.2-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.2-r.1" } }, "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.1-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.1-r.1", "@duckdb/node-bindings-darwin-x64": "1.5.1-r.1", "@duckdb/node-bindings-linux-arm64": "1.5.1-r.1", "@duckdb/node-bindings-linux-x64": "1.5.1-r.1", "@duckdb/node-bindings-win32-arm64": "1.5.1-r.1", "@duckdb/node-bindings-win32-x64": "1.5.1-r.1" } }, "sha512-3vmIlY/ACTLutlMup4F+D2Gzo+kiUoMaIL4TvM4x34cMqnKfsZ+4lMjqfSKYmdcgNGXYXwPwIYaJlvMRhU3Tbg=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.2-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1", "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1", "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1", "@duckdb/node-bindings-linux-x64": "1.5.2-r.1", "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1", "@duckdb/node-bindings-win32-x64": "1.5.2-r.1" } }, "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.1-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vm0Q/P8/OB/ZDITNTUe80emlg0b7/EcqTPBRu4GmULbt/fFDtkEAjDHDblKZL1yazf7X6JFEabHBGuWL5jmjEw=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.2-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.1-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GOKWYbOP1v5jppGjlCaQzvyzVnY8/dGd7UJcnT213uiSMq/mtQk2yvzZCPhq7UdxmqR0TSd+TKttpozd8ANyOQ=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.2-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.1-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-b0tHCtC+GZnD6gJA+ldUwy8FhnugR1Uq0/LjLiusOQOoK5pRXyfiQjgIe/SiKSeE5iEr+FWUXEprSD81HOaaQg=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.2-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.1-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-AczM4qyMuMXHIa7w1YacIu6FFPpwzUsQSkPUFKsAJzyuRcxAlGEwt+2GnVZSACGQFpKbL9nAkuu3Icq6ttxwag=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.2-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA=="],
 
-    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.1-r.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-SrgAiFttkfFXCCAMrmMBWtnBMtEjVaC38XtG6zEdbvmp2RTEPo/dFcvRP75vS/Hm5Iq8Tgiuoq4tIdovwEw5yg=="],
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.2-r.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.1-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-JkL9xvXx9i8ceU1fGJsb9gqgRn30RFi0HyfpuESK2AZInKx5mJn8fvYcj4AQg/Ip9SZ1S4a2Jh5DOFY81koubw=="],
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.2-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ=="],
 
     "@emnapi/core": ["@emnapi/core@1.9.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.0", "tslib": "^2.4.0" } }, "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA=="],
 
@@ -222,7 +222,7 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "typescript": ["typescript@6.0.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 

--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 DuckDB provides several types not found in standard Postgres. This guide covers how to use them with Drizzle.
 
-DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.1-r.1` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
+DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.2-r.1` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
 
 ## Import
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.1-r.1`. The repo now develops against `1.5.1-r.1`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.1`. The repo now develops against `1.5.2-r.1`, and `1.4.4-r.1` remains supported.
 
 ## Requirements
 

--- a/docs/integrations/motherduck.md
+++ b/docs/integrations/motherduck.md
@@ -158,7 +158,7 @@ MotherDuck caches query results. Repeated queries on the same data will be faste
 
 ### Read Scaling and Session Affinity
 
-MotherDuck can use read scaling tokens to spread reads across replicas. Set a stable `session_hint` in your connection options to keep related queries on the same replica. Instance cache TTL determines how long a replica stays warm, so reuse the same `session_hint` while you want cache affinity.
+MotherDuck can use read scaling tokens to spread reads across replicas. Set a stable `session_name` in your connection options to keep related queries on the same replica. Instance cache TTL determines how long a replica stays warm, so reuse the same `session_name` while you want cache affinity. Older integrations may still pass `session_hint`, but MotherDuck now treats `session_name` as the preferred option.
 
 ```typescript
 const db = await drizzle({
@@ -166,7 +166,7 @@ const db = await drizzle({
     path: 'md:',
     options: {
       motherduck_token: process.env.MOTHERDUCK_TOKEN,
-      session_hint: 'analytics-dashboard',
+      session_name: 'analytics-dashboard',
     },
   },
 });

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -21,7 +21,7 @@ This page documents known differences between Drizzle DuckDB and Drizzle's stand
 | Aggregations                         | Full    |                                                                                                                     |
 | Transactions                         | Partial | No savepoints in current 1.4.x/1.5.x builds (driver probes once, then falls back)                                   |
 | Concurrent queries                   | Partial | One query per connection; use pooling for parallelism                                                               |
-| Prepared statements                  | Partial | No statement caching; no named statements                                                                           |
+| Prepared statements                  | Partial | Optional per-connection cache via `prepareCache`; no named statements                                               |
 | JSON/JSONB columns                   | None    | Use `duckDbJson()` instead                                                                                          |
 | `VARIANT` / `GEOMETRY` raw JS values | Partial | DuckDB 1.5 types exist, but `@duckdb/node-api` cannot yet materialize raw values reliably. Cast in the query first. |
 | Streaming results                    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks                                          |
@@ -52,7 +52,7 @@ await db.transaction(async (tx) => {
 
 ## DuckDB 1.5 Core Types
 
-DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.1-r.1` still throws a low-level conversion error when those raw values are materialized into JavaScript.
+DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.2-r.1` still throws a low-level conversion error when those raw values are materialized into JavaScript.
 
 Use explicit projections when querying those columns:
 

--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
     }
   },
   "devDependencies": {
-    "@duckdb/node-api": "1.5.1-r.1",
+    "@duckdb/node-api": "1.5.2-r.1",
     "@types/bun": "^1.3.12",
     "@types/node": "25.6.0",
     "@vitest/ui": "4.1.4",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.3",
     "tinybench": "6.0.0",
-    "typescript": "6.0.2",
+    "typescript": "6.0.3",
     "uuid": "13.0.0",
     "vitest": "4.1.4"
   },


### PR DESCRIPTION
## Issue

The repository still validated development against @duckdb/node-api 1.5.1-r.1 even though the 1.5.2-r.1 client is available. The docs also still used MotherDuck session_hint in the read scaling example, while MotherDuck has moved to session_name as the preferred option. The limitations tables also claimed prepared statement caching was unavailable even though the driver already supports prepareCache.

## Cause And Effect

The stale validation target could leave regressions or behavior changes in the latest DuckDB Node API unnoticed. The session_hint docs nudged users toward an older option name, and the prepared statement note understated the current performance tuning surface.

## Fix

This updates the dev dependency and lockfile to @duckdb/node-api 1.5.2-r.1 and TypeScript 6.0.3, refreshes the installation and DuckDB 1.5 type docs, switches the MotherDuck session affinity example to session_name while preserving a backwards-compatible note for session_hint, and corrects the prepared statement limitation text to mention prepareCache.

## Validation

- bun outdated
- bun run build
- bun test
- git diff --check
