### PR TITLE
[codex] Refactor transaction config validation

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -73,6 +73,22 @@ const VALID_TRANSACTION_ACCESS_MODES = new Set<string>([
   'read write',
 ]);
 
+function assertValidTransactionOption(
+  label: string,
+  value: string | undefined,
+  validValues: ReadonlySet<string>
+): void {
+  if (!value || validValues.has(value)) {
+    return;
+  }
+
+  throw new Error(
+    `Invalid transaction ${label} "${value}". Expected one of: ${Array.from(
+      validValues
+    ).join(', ')}.`
+  );
+}
+
 interface QueryParamPreparationOptions {
   logger: Logger;
   queryString: string;
@@ -416,27 +432,16 @@ export class DuckDBTransaction<
   }
 
   getTransactionConfigSQL(config: PgTransactionConfig): SQL {
-    if (
-      config.isolationLevel &&
-      !VALID_TRANSACTION_ISOLATION_LEVELS.has(config.isolationLevel)
-    ) {
-      throw new Error(
-        `Invalid transaction isolation level "${config.isolationLevel}". Expected one of: ${Array.from(
-          VALID_TRANSACTION_ISOLATION_LEVELS
-        ).join(', ')}.`
-      );
-    }
-
-    if (
-      config.accessMode &&
-      !VALID_TRANSACTION_ACCESS_MODES.has(config.accessMode)
-    ) {
-      throw new Error(
-        `Invalid transaction access mode "${config.accessMode}". Expected one of: ${Array.from(
-          VALID_TRANSACTION_ACCESS_MODES
-        ).join(', ')}.`
-      );
-    }
+    assertValidTransactionOption(
+      'isolation level',
+      config.isolationLevel,
+      VALID_TRANSACTION_ISOLATION_LEVELS
+    );
+    assertValidTransactionOption(
+      'access mode',
+      config.accessMode,
+      VALID_TRANSACTION_ACCESS_MODES
+    );
 
     if (
       config.deferrable !== undefined &&

--- a/test/session-options.test.ts
+++ b/test/session-options.test.ts
@@ -183,7 +183,9 @@ describe('Session Options Tests', () => {
         getTransactionConfigSQL({
           isolationLevel: 'serializable; drop table users;',
         })
-      ).toThrow('Invalid transaction isolation level');
+      ).toThrow(
+        'Invalid transaction isolation level "serializable; drop table users;". Expected one of: read uncommitted, read committed, repeatable read, serializable.'
+      );
     });
 
     test('rejects invalid access mode values', () => {
@@ -191,7 +193,9 @@ describe('Session Options Tests', () => {
         getTransactionConfigSQL({
           accessMode: 'read only; drop table users;',
         })
-      ).toThrow('Invalid transaction access mode');
+      ).toThrow(
+        'Invalid transaction access mode "read only; drop table users;". Expected one of: read only, read write.'
+      );
     });
 
     test('rejects non-boolean deferrable values', () => {


### PR DESCRIPTION
## Issue

Transaction option validation in `DuckDBTransaction.getTransactionConfigSQL` had two nearly identical branches for isolation levels and access modes. Both branches checked membership in an allowed set and then built the same style of error message.

## Cause And Effect

The duplicate validation logic made the transaction configuration path a little harder to maintain. If the allowed-value message or validation shape changed later, the two branches could drift and produce inconsistent errors for users supplying unsafe or unsupported transaction options.

## Root Cause

`getTransactionConfigSQL` encoded each string-valued transaction option independently even though the only meaningful differences were the option label, the submitted value, and the allowed value set.

## Fix

This refactor extracts the shared validation into `assertValidTransactionOption`, preserving the existing falsy-value behavior while centralizing the allowed-set check and error construction. `getTransactionConfigSQL` now calls the helper for both `isolationLevel` and `accessMode`, leaving deferrable validation separate because it has a different boolean contract.

## Validation

- `bun x vitest run test/session-options.test.ts`
- `bun run build`
- `bun test`
