### PR TITLE
[codex] Share AST visitor helpers

### DIFF
--- a/src/sql/visitors/ast-helpers.ts
+++ b/src/sql/visitors/ast-helpers.ts
@@ -1,0 +1,45 @@
+import type {
+  Binary,
+  ColumnRefItem,
+  ExpressionValue,
+} from 'node-sql-parser';
+
+export function isColumnRef(expr: unknown): expr is ColumnRefItem {
+  return (
+    typeof expr === 'object' &&
+    expr !== null &&
+    'type' in expr &&
+    expr.type === 'column_ref'
+  );
+}
+
+export function isUnqualifiedColumnRef(
+  expr: unknown
+): expr is ColumnRefItem {
+  return isColumnRef(expr) && (!('table' in expr) || !expr.table);
+}
+
+export function isQualifiedColumnRef(expr: unknown): expr is ColumnRefItem {
+  return isColumnRef(expr) && 'table' in expr && !!expr.table;
+}
+
+export function getColumnName(col: ColumnRefItem): string | null {
+  if (typeof col.column === 'string') {
+    return col.column;
+  }
+  if (col.column && 'expr' in col.column && col.column.expr?.value) {
+    return String(col.column.expr.value);
+  }
+  return null;
+}
+
+export function isBinaryExpr(
+  expr: ExpressionValue | Binary | null | undefined
+): expr is Binary {
+  return (
+    !!expr &&
+    typeof expr === 'object' &&
+    'type' in expr &&
+    (expr as { type?: string }).type === 'binary_expr'
+  );
+}

--- a/src/sql/visitors/ast-helpers.ts
+++ b/src/sql/visitors/ast-helpers.ts
@@ -1,8 +1,4 @@
-import type {
-  Binary,
-  ColumnRefItem,
-  ExpressionValue,
-} from 'node-sql-parser';
+import type { Binary, ColumnRefItem, ExpressionValue } from 'node-sql-parser';
 
 export function isColumnRef(expr: unknown): expr is ColumnRefItem {
   return (
@@ -13,9 +9,7 @@ export function isColumnRef(expr: unknown): expr is ColumnRefItem {
   );
 }
 
-export function isUnqualifiedColumnRef(
-  expr: unknown
-): expr is ColumnRefItem {
+export function isUnqualifiedColumnRef(expr: unknown): expr is ColumnRefItem {
   return isColumnRef(expr) && (!('table' in expr) || !expr.table);
 }
 

--- a/src/sql/visitors/column-qualifier.ts
+++ b/src/sql/visitors/column-qualifier.ts
@@ -18,6 +18,12 @@ import type {
   OrderBy,
   Column,
 } from 'node-sql-parser';
+import {
+  getColumnName,
+  isBinaryExpr,
+  isQualifiedColumnRef,
+  isUnqualifiedColumnRef,
+} from './ast-helpers.ts';
 
 type TableSource = {
   name: string;
@@ -55,37 +61,6 @@ function getQualifier(source: TableSource): Qualifier {
   };
 }
 
-function isUnqualifiedColumnRef(expr: ExpressionValue): expr is ColumnRefItem {
-  return (
-    typeof expr === 'object' &&
-    expr !== null &&
-    'type' in expr &&
-    expr.type === 'column_ref' &&
-    (!('table' in expr) || !expr.table)
-  );
-}
-
-function isQualifiedColumnRef(expr: ExpressionValue): expr is ColumnRefItem {
-  return (
-    typeof expr === 'object' &&
-    expr !== null &&
-    'type' in expr &&
-    expr.type === 'column_ref' &&
-    'table' in expr &&
-    !!expr.table
-  );
-}
-
-function getColumnName(col: ColumnRefItem): string | null {
-  if (typeof col.column === 'string') {
-    return col.column;
-  }
-  if (col.column && 'expr' in col.column && col.column.expr?.value) {
-    return String(col.column.expr.value);
-  }
-  return null;
-}
-
 function applyQualifier(col: ColumnRefItem, qualifier: Qualifier): void {
   col.table = qualifier.table;
   if (!('schema' in col) || !col.schema) {
@@ -120,17 +95,6 @@ function unwrapColumnRef(
     }
   }
   return null;
-}
-
-function isBinaryExpr(
-  expr: ExpressionValue | Binary | null | undefined
-): expr is Binary {
-  return (
-    !!expr &&
-    typeof expr === 'object' &&
-    'type' in expr &&
-    (expr as { type?: string }).type === 'binary_expr'
-  );
 }
 
 function walkOnClause(

--- a/src/sql/visitors/generate-series-alias.ts
+++ b/src/sql/visitors/generate-series-alias.ts
@@ -12,7 +12,6 @@
 
 import type {
   AST,
-  Binary,
   ColumnRefItem,
   ExpressionValue,
   From,
@@ -21,36 +20,7 @@ import type {
   OrderBy,
   Column,
 } from 'node-sql-parser';
-
-function getColumnName(col: ColumnRefItem): string | null {
-  if (typeof col.column === 'string') {
-    return col.column;
-  }
-  if (col.column && 'expr' in col.column && col.column.expr?.value) {
-    return String(col.column.expr.value);
-  }
-  return null;
-}
-
-function isColumnRef(expr: ExpressionValue): expr is ColumnRefItem {
-  return (
-    typeof expr === 'object' &&
-    expr !== null &&
-    'type' in expr &&
-    expr.type === 'column_ref'
-  );
-}
-
-function isBinaryExpr(
-  expr: ExpressionValue | Binary | null | undefined
-): expr is Binary {
-  return (
-    !!expr &&
-    typeof expr === 'object' &&
-    'type' in expr &&
-    (expr as { type?: string }).type === 'binary_expr'
-  );
-}
+import { getColumnName, isBinaryExpr, isColumnRef } from './ast-helpers.ts';
 
 function getGenerateSeriesAliases(from: Select['from']): Set<string> {
   const aliases = new Set<string>();
@@ -107,7 +77,7 @@ function walkExpression(
   }
 
   if (isBinaryExpr(expr)) {
-    const binary = expr as Binary;
+    const binary = expr;
     transformed =
       walkExpression(binary.left as ExpressionValue, aliases) || transformed;
     transformed =


### PR DESCRIPTION
## What changed

The AST visitor layer had duplicated helpers for recognizing column references, checking binary expressions, and extracting column names. This PR extracts those shared guards into `src/sql/visitors/ast-helpers.ts` and updates the join column qualifier and `generate_series` alias rewriter to use them.

## Why

Both visitors depend on the same node-sql-parser AST shapes. Keeping those guards duplicated makes small parser-shape fixes easier to apply in one visitor but miss in the other. That can create inconsistent behavior between join qualification and `generate_series` alias rewriting, which are both part of the same SQL compatibility transform path.

## Fix

The new helper module owns the shared `isColumnRef`, qualified and unqualified column-ref checks, `getColumnName`, and `isBinaryExpr` utilities. The existing visitor logic still performs the same mutations as before, but the duplicated type guard code now has a single implementation.

## Validation

- `bun run build`
- `bun x vitest run test/ast-transformer.test.ts test/generate-series-alias.test.ts test/ambiguous-columns.test.ts`
- `bun test`
