### PR TITLE
[codex] Refactor drizzle target resolution

### DIFF
--- a/src/driver.ts
+++ b/src/driver.ts
@@ -125,6 +125,96 @@ function isConfigObject(data: unknown): data is Record<string, unknown> {
   );
 }
 
+interface ResolvedConnectionTarget<
+  TSchema extends Record<string, unknown> = Record<string, never>,
+> {
+  kind: 'connection';
+  path: string;
+  instanceOptions: Record<string, string> | undefined;
+  config: DuckDBDrizzleConfig<TSchema>;
+}
+
+interface ResolvedClientTarget<
+  TSchema extends Record<string, unknown> = Record<string, never>,
+> {
+  kind: 'client';
+  client: DuckDBClientLike;
+  config: DuckDBDrizzleConfig<TSchema>;
+}
+
+type ResolvedDrizzleTarget<
+  TSchema extends Record<string, unknown> = Record<string, never>,
+> = ResolvedConnectionTarget<TSchema> | ResolvedClientTarget<TSchema>;
+
+function resolveConnectionTarget(
+  connection: string | DuckDBConnectionConfig
+): Omit<ResolvedConnectionTarget, 'config' | 'kind'> {
+  if (typeof connection === 'string') {
+    return {
+      path: connection,
+      instanceOptions: undefined,
+    };
+  }
+
+  return {
+    path: connection.path,
+    instanceOptions: connection.options,
+  };
+}
+
+function resolveDrizzleTarget<
+  TSchema extends Record<string, unknown> = Record<string, never>,
+>(
+  clientOrConfigOrPath:
+    | string
+    | DuckDBClientLike
+    | DuckDBDrizzleConfigWithConnection<TSchema>
+    | DuckDBDrizzleConfigWithClient<TSchema>,
+  config: DuckDBDrizzleConfig<TSchema> = {}
+): ResolvedDrizzleTarget<TSchema> {
+  if (typeof clientOrConfigOrPath === 'string') {
+    return {
+      kind: 'connection',
+      ...resolveConnectionTarget(clientOrConfigOrPath),
+      config,
+    };
+  }
+
+  if (isConfigObject(clientOrConfigOrPath)) {
+    if ('connection' in clientOrConfigOrPath) {
+      const { connection, ...restConfig } = clientOrConfigOrPath;
+
+      return {
+        kind: 'connection',
+        ...resolveConnectionTarget(
+          connection as DuckDBDrizzleConfigWithConnection<TSchema>['connection']
+        ),
+        config: restConfig as DuckDBDrizzleConfig<TSchema>,
+      };
+    }
+
+    if ('client' in clientOrConfigOrPath) {
+      const { client, ...restConfig } = clientOrConfigOrPath;
+
+      return {
+        kind: 'client',
+        client: client as DuckDBClientLike,
+        config: restConfig as DuckDBDrizzleConfig<TSchema>,
+      };
+    }
+
+    throw new Error(
+      'Invalid drizzle config: either connection or client must be provided'
+    );
+  }
+
+  return {
+    kind: 'client',
+    client: clientOrConfigOrPath as DuckDBClientLike,
+    config,
+  };
+}
+
 /** Internal: create database from a client (connection or pool) */
 function createFromClient<
   TSchema extends Record<string, unknown> = Record<string, never>,
@@ -304,51 +394,17 @@ export function drizzle<
 ):
   | DuckDBDatabase<TSchema, ExtractTablesWithRelations<TSchema>>
   | Promise<DuckDBDatabase<TSchema, ExtractTablesWithRelations<TSchema>>> {
-  // String path -> async with auto-pool
-  if (typeof clientOrConfigOrPath === 'string') {
-    return createFromConnectionString(clientOrConfigOrPath, undefined, config);
-  }
+  const target = resolveDrizzleTarget(clientOrConfigOrPath, config);
 
-  // Config object with connection or client
-  if (isConfigObject(clientOrConfigOrPath)) {
-    const configObj = clientOrConfigOrPath as
-      | DuckDBDrizzleConfigWithConnection<TSchema>
-      | DuckDBDrizzleConfigWithClient<TSchema>;
-
-    if ('connection' in configObj) {
-      const connConfig =
-        configObj as DuckDBDrizzleConfigWithConnection<TSchema>;
-      const { connection, ...restConfig } = connConfig;
-      if (typeof connection === 'string') {
-        return createFromConnectionString(
-          connection,
-          undefined,
-          restConfig as DuckDBDrizzleConfig<TSchema>
-        );
-      }
-      return createFromConnectionString(
-        connection.path,
-        connection.options,
-        restConfig as DuckDBDrizzleConfig<TSchema>
-      );
-    }
-
-    if ('client' in configObj) {
-      const clientConfig = configObj as DuckDBDrizzleConfigWithClient<TSchema>;
-      const { client: clientValue, ...restConfig } = clientConfig;
-      return createFromClient(
-        clientValue,
-        restConfig as DuckDBDrizzleConfig<TSchema>
-      );
-    }
-
-    throw new Error(
-      'Invalid drizzle config: either connection or client must be provided'
+  if (target.kind === 'connection') {
+    return createFromConnectionString(
+      target.path,
+      target.instanceOptions,
+      target.config
     );
   }
 
-  // Direct client (backward compatible)
-  return createFromClient(clientOrConfigOrPath as DuckDBClientLike, config);
+  return createFromClient(target.client, target.config);
 }
 
 export class DuckDBDatabase<

--- a/test/driver-factory.test.ts
+++ b/test/driver-factory.test.ts
@@ -73,6 +73,44 @@ describe('Driver Factory Tests', () => {
     });
   });
 
+  describe('drizzle() config object entrypoints', () => {
+    test('creates database from config with connection string', async () => {
+      db = await drizzle({
+        connection: ':memory:',
+        pool: false,
+      });
+
+      const result = await db.execute(sql`SELECT 1 as value`);
+      expect(result[0]).toEqual({ value: 1 });
+    });
+
+    test('creates database from config with connection object', async () => {
+      db = await drizzle({
+        connection: { path: ':memory:' },
+        pool: false,
+      });
+
+      const result = await db.execute(sql`SELECT 1 as value`);
+      expect(result[0]).toEqual({ value: 1 });
+    });
+
+    test('creates database from config with explicit client', async () => {
+      const instance = await DuckDBInstance.create(':memory:');
+      const connection = await instance.connect();
+
+      db = drizzle({
+        client: connection,
+      });
+
+      const result = await db.execute(sql`SELECT 1 as value`);
+      expect(result[0]).toEqual({ value: 1 });
+
+      await db.close();
+      db = null;
+      instance.closeSync?.();
+    });
+  });
+
   describe('drizzle() pool options', () => {
     test('forwards acquireTimeout to auto-created pools', async () => {
       db = await drizzle(':memory:', {


### PR DESCRIPTION
This change refactors the `drizzle()` entrypoint so every supported invocation form is normalized through one internal resolver before the driver decides whether to create a connection-backed database or reuse an explicit client.

Before this change, the overload implementation handled string paths, config objects with `connection`, config objects with `client`, and direct clients in separate branches inside `src/driver.ts`. That worked, but it duplicated the same normalization work and depended on several ad hoc type casts in the main control flow. The practical user impact was not a runtime bug today, but it made the factory path harder to reason about and riskier to extend because each new entrypoint shape would need to keep those branches in sync.

The root cause was that argument parsing and database construction were interleaved in the public `drizzle()` implementation. The fix is to separate those responsibilities: `resolveConnectionTarget()` now converts both connection strings and connection config objects into one internal shape, and `resolveDrizzleTarget()` collapses every public overload input into a single discriminated target. Once that normalization is done, `drizzle()` only has to dispatch once to either `createFromConnectionString()` or `createFromClient()`.

The tests now cover the object-based factory entrypoints directly, including `drizzle({ connection: ':memory:' })`, `drizzle({ connection: { path: ':memory:' } })`, and `drizzle({ client })`, so the refactor is pinned to behavior instead of relying on incidental coverage from adjacent cases.

Validation used for this change:
- `bun install`
- `bun run build`
- `bun test`
