### PR TITLE
[codex] fix batched json streaming

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -476,6 +476,7 @@ async function executePreparedQuery(
 
 type StreamResultLike = ResultTypeMetadataLike & {
   yieldRowsJs: () => AsyncIterable<unknown[][]>;
+  yieldRowsJson?: () => AsyncIterable<unknown[][]>;
   close?: () => Promise<void> | void;
   cancel?: () => Promise<void> | void;
 };
@@ -641,12 +642,18 @@ async function* streamRawBatches(
         values
       )) as StreamResultLike;
       const columns = resolveResultColumns(result);
+      const preferJson =
+        prefersJsonMaterialization(result) &&
+        typeof result.yieldRowsJson === 'function';
+      const rowStream = preferJson
+        ? result.yieldRowsJson!()
+        : result.yieldRowsJs();
 
       let rows: unknown[][] = [];
 
       try {
         try {
-          for await (const chunk of result.yieldRowsJs()) {
+          for await (const chunk of rowStream) {
             for (const row of chunk) {
               rows.push(row as unknown[]);
               if (rows.length >= rowsPerChunk) {

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -61,6 +61,11 @@ function makeClient(options: {
     async stream(_query: string, _values?: unknown[]) {
       return {
         columnNames: () => columns,
+        columnCount: columns.length,
+        columnTypeId:
+          columnTypeIds === undefined
+            ? undefined
+            : (index: number) => columnTypeIds[index] ?? -1,
         deduplicatedColumnNames:
           deduplicatedColumns === undefined
             ? undefined
@@ -70,6 +75,9 @@ function makeClient(options: {
               },
         async *yieldRowsJs() {
           yield rows;
+        },
+        async *yieldRowsJson() {
+          yield jsonRows;
         },
         close() {
           onStreamClose?.();
@@ -201,6 +209,25 @@ describe('executeInBatches', () => {
     }
 
     expect(closeCalls).toBe(1);
+  });
+
+  test('uses JSON streaming for precise time families', async () => {
+    const client = makeClient({
+      rows: [[new Date('2024-03-01T12:34:56.123Z')]],
+      jsonRows: [['2024-03-01 12:34:56.123456789']],
+      columns: ['ts_ns'],
+      deduplicatedColumns: ['ts_ns'],
+      columnTypeIds: [22],
+    });
+    const chunks: Array<Array<{ ts_ns: string }>> = [];
+
+    for await (const chunk of executeInBatches(client, 'select', [], {
+      rowsPerChunk: 1,
+    })) {
+      chunks.push(chunk as Array<{ ts_ns: string }>);
+    }
+
+    expect(chunks).toEqual([[{ ts_ns: '2024-03-01 12:34:56.123456789' }]]);
   });
 });
 


### PR DESCRIPTION
This change fixes a gap between the package's normal execution path and its batched streaming helpers.

Users who call `executeBatches()` or `executeBatchesRaw()` against DuckDB's precise time families can currently get JavaScript-materialized values even when the non-streaming paths correctly switch to JSON materialization. That makes batched reads behave differently from `execute()` and `select()`, and it can drop precision for types such as `TIMESTAMP_NS`.

The root cause is in `streamRawBatches()` in `src/client.ts`. The code always iterated `yieldRowsJs()`, while the regular materialization path already inspects `columnTypeId()` and switches to JSON row materialization when the node API reports a type family that should stay in its JSON representation.

The fix keeps the existing behavior for ordinary result sets, but when the stream metadata indicates a precise time family and the node API exposes `yieldRowsJson()`, the batched path now streams JSON rows instead of JS rows. This keeps batched execution aligned with the rest of the driver without breaking existing callers. I also added regression coverage in `test/client-execute.test.ts` so the streaming helpers are explicitly tested for the precise-type path.

Validation:
- `bun x vitest run test/client-execute.test.ts`
- `bun test`
- `bun run build`
