### PR TITLE
[codex] cleanup ducklake setup failures

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,7 @@
     },
   },
   "overrides": {
-    "esbuild": "0.25.12",
+    "esbuild": "0.28.0",
   },
   "packages": {
     "@duckdb/node-api": ["@duckdb/node-api@1.5.2-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.2-r.1" } }, "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A=="],

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dist/**/*.d.ts"
   ],
   "overrides": {
-    "esbuild": "0.25.12"
+    "esbuild": "0.28.0"
   },
   "dependencies": {
     "node-sql-parser": "^5.4.0"

--- a/src/driver.ts
+++ b/src/driver.ts
@@ -292,56 +292,71 @@ async function createFromConnectionString<
   config: DuckDBDrizzleConfig<TSchema> = {}
 ): Promise<DuckDBDatabase<TSchema, ExtractTablesWithRelations<TSchema>>> {
   const instance = await DuckDBInstance.create(path, instanceOptions);
-  const ducklakeConfig = config.ducklake;
-  const poolOptions = resolvePoolOptions(config.pool);
-  const { poolSize, resolvedPoolSize, isLocalCatalog } =
-    resolveDuckLakePoolSize(config.pool, ducklakeConfig);
+  let createdClient: DuckDBClientLike | undefined;
 
-  if (
-    ducklakeConfig &&
-    resolvedPoolSize !== false &&
-    typeof resolvedPoolSize === 'number' &&
-    resolvedPoolSize > 1 &&
-    isLocalCatalog
-  ) {
-    console.warn(
-      '[ducklake] DuckDB catalog files support a single client connection. Pool sizes greater than 1 can cause write conflicts.'
-    );
-  }
+  try {
+    const ducklakeConfig = config.ducklake;
+    const poolOptions = resolvePoolOptions(config.pool);
+    const { poolSize, resolvedPoolSize, isLocalCatalog } =
+      resolveDuckLakePoolSize(config.pool, ducklakeConfig);
 
-  if (poolSize === false) {
-    const connection = await instance.connect();
-    try {
+    if (
+      ducklakeConfig &&
+      resolvedPoolSize !== false &&
+      typeof resolvedPoolSize === 'number' &&
+      resolvedPoolSize > 1 &&
+      isLocalCatalog
+    ) {
+      console.warn(
+        '[ducklake] DuckDB catalog files support a single client connection. Pool sizes greater than 1 can cause write conflicts.'
+      );
+    }
+
+    if (poolSize === false) {
+      const connection = await instance.connect();
+      createdClient = connection;
       if (ducklakeConfig) {
         await configureDuckLake(connection, ducklakeConfig);
       }
-    } catch (error) {
-      await closeClientConnection(connection);
-      throw error;
+      const { ducklake, ...restConfig } = config;
+      const db = createFromClient(
+        connection,
+        restConfig as DuckDBDrizzleConfig<TSchema>,
+        instance
+      );
+      createdClient = undefined;
+      return db;
     }
+
+    const pool = createDuckDBConnectionPool(instance, {
+      ...poolOptions,
+      size: poolSize,
+      setup: ducklakeConfig
+        ? async (connection) => {
+            await configureDuckLake(connection, ducklakeConfig);
+          }
+        : undefined,
+    });
+    createdClient = pool;
     const { ducklake, ...restConfig } = config;
-    return createFromClient(
-      connection,
+    const db = createFromClient(
+      pool,
       restConfig as DuckDBDrizzleConfig<TSchema>,
       instance
     );
+    createdClient = undefined;
+    return db;
+  } catch (error) {
+    if (createdClient) {
+      if (isPool(createdClient) && createdClient.close) {
+        await createdClient.close();
+      } else if (!isPool(createdClient)) {
+        await closeClientConnection(createdClient);
+      }
+    }
+    await closeDuckDbInstance(instance);
+    throw error;
   }
-
-  const pool = createDuckDBConnectionPool(instance, {
-    ...poolOptions,
-    size: poolSize,
-    setup: ducklakeConfig
-      ? async (connection) => {
-          await configureDuckLake(connection, ducklakeConfig);
-        }
-      : undefined,
-  });
-  const { ducklake, ...restConfig } = config;
-  return createFromClient(
-    pool,
-    restConfig as DuckDBDrizzleConfig<TSchema>,
-    instance
-  );
 }
 
 // Overload 1: Connection string (async, auto-pools)

--- a/test/driver-factory.test.ts
+++ b/test/driver-factory.test.ts
@@ -1,6 +1,6 @@
-import { DuckDBInstance } from '@duckdb/node-api';
+import { DuckDBInstance, type DuckDBConnection } from '@duckdb/node-api';
 import { sql } from 'drizzle-orm';
-import { describe, expect, test, afterEach } from 'vitest';
+import { describe, expect, test, afterEach, vi } from 'vitest';
 import { drizzle } from '../src/driver.ts';
 import { POOL_PRESETS, resolvePoolSize } from '../src/pool.ts';
 import { DuckDBDatabase } from '../src/driver.ts';
@@ -15,6 +15,7 @@ describe('Driver Factory Tests', () => {
       await db.close();
       db = null;
     }
+    vi.restoreAllMocks();
   });
 
   describe('Pool Presets', () => {
@@ -184,6 +185,32 @@ describe('Driver Factory Tests', () => {
 
       await expect(dbWithFailingClient.close()).rejects.toBe(closeError);
       expect(instanceClosed).toBe(1);
+    });
+
+    test('connection-string setup closes resources when DuckLake setup fails', async () => {
+      const setupError = new Error('ducklake setup failed');
+      const connection = {
+        run: vi.fn(async () => {
+          throw setupError;
+        }),
+        closeSync: vi.fn(),
+      } as unknown as DuckDBConnection;
+      const instance = {
+        connect: vi.fn(async () => connection),
+        closeSync: vi.fn(),
+      } as unknown as DuckDBInstance;
+
+      vi.spyOn(DuckDBInstance, 'create').mockResolvedValue(instance);
+
+      await expect(
+        drizzle(':memory:', {
+          pool: false,
+          ducklake: { catalog: 'md:meta_db' },
+        })
+      ).rejects.toBe(setupError);
+
+      expect(connection.closeSync).toHaveBeenCalledTimes(1);
+      expect(instance.closeSync).toHaveBeenCalledTimes(1);
     });
   });
 });


### PR DESCRIPTION
## Issue

DuckLake setup through the connection-string `drizzle()` entrypoint can fail after a DuckDB instance and connection have already been created. Before this change, the single-connection path closed the connection on configuration failure but left the newly created instance owned by nobody. That can leave native handles alive in short-lived scripts, tests, and serverless-style startup failures.

The automation review also checked the latest `motherduck/mono` changes after pulling `main`. The relevant package signal is continued use of the 1.5.2 SDK line, which this repository already targets. No runtime compatibility change was needed for the new sandbox navigation or hostcontroller commits.

## Cause and effect

`createFromConnectionString()` created the `DuckDBInstance` before resolving pool and DuckLake setup. If `configureDuckLake()` or later database construction threw, ownership never reached the returned `DuckDBDatabase`, so callers could not call `db.close()` to clean up the instance.

## Fix

The connection-string factory now tracks the newly created client while setup is in progress. If setup fails, it closes the opened connection or pool and then closes the instance before rethrowing the original error. Once database construction succeeds, ownership is transferred to `DuckDBDatabase` unchanged, preserving the existing public API and backwards compatibility.

The package override for `esbuild` was also updated from `0.25.12` to `0.28.0`, which matches the current Vite peer range used by the locked toolchain.

## Validation

- `bun run build`
- `bun test` (599 passed, 7 skipped)
- Focused regression coverage in `test/driver-factory.test.ts`
