### PR TITLE
[codex] Refactor client JSON fallback

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -76,9 +76,35 @@ type DisconnectableResource = ClosableResource & {
 
 const PREPARED_CACHE = Symbol.for('drizzle-duckdb:prepared-cache');
 
+interface PreferredResultReader<T> {
+  readDefault: () => Promise<T>;
+  readPreferred?: () => Promise<T>;
+  wrapError: (error: unknown) => Error;
+}
+
 export interface PrepareParamsOptions {
   rejectStringArrayLiterals?: boolean;
   warnOnStringArrayLiteral?: () => void;
+}
+
+async function readPreferredResult<T>({
+  readDefault,
+  readPreferred,
+  wrapError,
+}: PreferredResultReader<T>): Promise<T> {
+  try {
+    if (readPreferred) {
+      return await readPreferred();
+    }
+
+    return await readDefault();
+  } catch (error) {
+    if (readPreferred) {
+      return await readPreferred();
+    }
+
+    throw wrapError(error);
+  }
 }
 
 async function withConnection<T>(
@@ -430,21 +456,18 @@ async function materializeResultRows(
   } & ResultTypeMetadataLike &
     ResultJsonRowsLike
 ): Promise<MaterializedRows> {
-  const preferJson = prefersJsonMaterialization(result);
-  let rows: unknown[][];
-  try {
-    if (preferJson && typeof result.getRowsJson === 'function') {
-      rows = (await result.getRowsJson()) ?? [];
-    } else {
-      rows = (await result.getRowsJS()) ?? [];
-    }
-  } catch (error) {
-    if (preferJson && typeof result.getRowsJson === 'function') {
-      rows = (await result.getRowsJson()) ?? [];
-    } else {
-      throw wrapUnsupportedNodeApiTypeError(result, error);
-    }
-  }
+  const getRowsJson =
+    typeof result.getRowsJson === 'function'
+      ? result.getRowsJson.bind(result)
+      : undefined;
+  const rows = await readPreferredResult({
+    readDefault: async () => (await result.getRowsJS()) ?? [],
+    readPreferred:
+      prefersJsonMaterialization(result) && getRowsJson
+        ? async () => (await getRowsJson()) ?? []
+        : undefined,
+    wrapError: (error) => wrapUnsupportedNodeApiTypeError(result, error),
+  });
   const columns = resolveResultColumns(result);
 
   return { columns, rows };
@@ -716,31 +739,20 @@ export async function executeArrowOnClient(
     }
 
     // Fallback: return column-major JS arrays to avoid per-row object creation.
-    try {
-      if (
-        prefersJsonMaterialization(
-          result as unknown as ResultTypeMetadataLike
-        ) &&
-        typeof (result as ResultJsonRowsLike).getColumnsObjectJson ===
-          'function'
-      ) {
-        return await (result as ResultJsonRowsLike).getColumnsObjectJson!();
-      }
-      return await result.getColumnsObjectJS();
-    } catch (error) {
-      if (
-        prefersJsonMaterialization(
-          result as unknown as ResultTypeMetadataLike
-        ) &&
-        typeof (result as ResultJsonRowsLike).getColumnsObjectJson ===
-          'function'
-      ) {
-        return await (result as ResultJsonRowsLike).getColumnsObjectJson!();
-      }
-      throw wrapUnsupportedNodeApiTypeError(
-        result as unknown as ResultTypeMetadataLike,
-        error
-      );
-    }
+    const resultMetadata = result as unknown as ResultTypeMetadataLike;
+    const resultJsonRows = result as ResultJsonRowsLike;
+    const getColumnsObjectJson =
+      typeof resultJsonRows.getColumnsObjectJson === 'function'
+        ? resultJsonRows.getColumnsObjectJson.bind(result)
+        : undefined;
+    return await readPreferredResult({
+      readDefault: () => result.getColumnsObjectJS(),
+      readPreferred:
+        prefersJsonMaterialization(resultMetadata) && getColumnsObjectJson
+          ? () => getColumnsObjectJson()
+          : undefined,
+      wrapError: (error) =>
+        wrapUnsupportedNodeApiTypeError(resultMetadata, error),
+    });
   });
 }

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -11,21 +11,27 @@ import {
 function makeClient(options: {
   arrowValue?: unknown;
   fallbackValue?: unknown;
+  jsonColumnsValue?: unknown;
   rows?: unknown[][];
   jsonRows?: unknown[][];
   columns?: string[];
   deduplicatedColumns?: string[];
   columnTypeIds?: number[];
+  getRowsError?: Error;
+  getColumnsObjectError?: Error;
   onDeduplicatedColumns?: () => void;
   onStreamClose?: () => void;
 }): DuckDBClientLike {
   const {
     arrowValue,
     fallbackValue = {},
+    jsonColumnsValue = fallbackValue,
     rows = [[1], [2], [3]],
     jsonRows = rows,
     columns = ['id'],
     columnTypeIds,
+    getRowsError,
+    getColumnsObjectError,
     onStreamClose,
   } = options;
   const deduplicatedColumns = Object.prototype.hasOwnProperty.call(
@@ -39,9 +45,19 @@ function makeClient(options: {
     async run(_query: string, _values?: unknown[]) {
       return {
         toArrow: arrowValue === undefined ? undefined : async () => arrowValue,
-        getColumnsObjectJS: async () => fallbackValue,
-        getColumnsObjectJson: async () => fallbackValue,
-        getRowsJS: async () => rows,
+        getColumnsObjectJS: async () => {
+          if (getColumnsObjectError) {
+            throw getColumnsObjectError;
+          }
+          return fallbackValue;
+        },
+        getColumnsObjectJson: async () => jsonColumnsValue,
+        getRowsJS: async () => {
+          if (getRowsError) {
+            throw getRowsError;
+          }
+          return rows;
+        },
         getRowsJson: async () => jsonRows,
         columnNames: () => columns,
         columnCount: columns.length,
@@ -105,6 +121,20 @@ describe('executeArrowOnClient', () => {
       fallbackValue: fallback,
       columns: ['ts_ns'],
       columnTypeIds: [22],
+    });
+
+    const data = await executeArrowOnClient(client, 'select 1', []);
+    expect(data).toBe(fallback);
+  });
+
+  test('falls back to JSON column materialization when JS materialization fails', async () => {
+    const fallback = { ts_ns: ['2024-03-01 12:34:56.123456789'] };
+    const client = makeClient({
+      fallbackValue: { ignored: true },
+      jsonColumnsValue: fallback,
+      columns: ['ts_ns'],
+      columnTypeIds: [22],
+      getColumnsObjectError: new Error('Unexpected type id: 0'),
     });
 
     const data = await executeArrowOnClient(client, 'select 1', []);
@@ -224,6 +254,25 @@ describe('executeOnClient', () => {
       columns: ['ts_ns'],
       deduplicatedColumns: ['ts_ns'],
       columnTypeIds: [22],
+    });
+
+    const rows = await executeOnClient(client, 'select', []);
+
+    expect(rows).toEqual([
+      {
+        ts_ns: '2024-03-01 12:34:56.123456789',
+      },
+    ]);
+  });
+
+  test('falls back to JSON rows when JS materialization fails for precise time families', async () => {
+    const client = makeClient({
+      rows: [[new Date('2024-03-01T12:34:56.123Z')]],
+      jsonRows: [['2024-03-01 12:34:56.123456789']],
+      columns: ['ts_ns'],
+      deduplicatedColumns: ['ts_ns'],
+      columnTypeIds: [22],
+      getRowsError: new Error('Unexpected type id: 0'),
     });
 
     const rows = await executeOnClient(client, 'select', []);


### PR DESCRIPTION
This change is a small targeted refactor in the DuckDB client result-materialization path.

The issue was not a user-facing bug in the current branch, but the client code had the same JSON-fallback logic duplicated in multiple places. Both `materializeResultRows()` and `executeArrowOnClient()` needed to decide whether DuckDB result payloads should prefer JSON materialization for precise time-family types, fall back from JS materialization when node-api cannot represent a type, and wrap unsupported-type errors consistently. That duplication made the behavior harder to reason about and increased the chance of future drift between the two execution paths.

The root cause was that the fallback policy lived inline in each call site instead of being expressed once as a shared operation. As a result, a change to one path would have needed to be mirrored manually in the other.

The fix extracts that behavior into a shared helper in `src/client.ts` and keeps the existing semantics for preferring JSON materialization when the result metadata indicates it is needed. The refactor also adds focused regression coverage in `test/client-execute.test.ts` for the cases where JS materialization throws and the client must recover through the JSON path. During validation, the first version of the refactor exposed that node-api reader methods depend on their `this` binding, so the final change explicitly preserves the bound methods before invoking the shared helper.

Validation:
- `bun x vitest run test/client-execute.test.ts`
- `bun x vitest run test/timestamps.test.ts test/client-execute.test.ts`
- `bun run build`
- `bun test`
