### PR TITLE
[codex] fix json materialization fallback

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@vitest/ui": "4.1.5",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.3",
-        "tinybench": "6.0.0",
+        "tinybench": "6.0.1",
         "typescript": "6.0.3",
         "uuid": "14.0.0",
         "vitest": "4.1.5",
@@ -210,7 +210,7 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
-    "tinybench": ["tinybench@6.0.0", "", {}, "sha512-BWlWpVbbZXaYjRV0twGLNQO00Zj4HA/sjLOQP2IvzQqGwRGp+2kh7UU3ijyJ3ywFRogYDRbiHDMrUOfaMnN56g=="],
+    "tinybench": ["tinybench@6.0.1", "", {}, "sha512-cMdWsxmysdg8mNWf1pujiWl3TW0cU6m8QuNw55QlnP3I6N96Grb0wnu5N0syHIu3LbiVZCNqlfWzWDq84HZphA=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@vitest/ui": "4.1.5",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.3",
-    "tinybench": "6.0.0",
+    "tinybench": "6.0.1",
     "typescript": "6.0.3",
     "uuid": "14.0.0",
     "vitest": "4.1.5"

--- a/src/client.ts
+++ b/src/client.ts
@@ -92,17 +92,17 @@ async function readPreferredResult<T>({
   readPreferred,
   wrapError,
 }: PreferredResultReader<T>): Promise<T> {
-  try {
-    if (readPreferred) {
+  if (readPreferred) {
+    try {
       return await readPreferred();
+    } catch {
+      // Fall back when precision-preserving materialization is unavailable.
     }
+  }
 
+  try {
     return await readDefault();
   } catch (error) {
-    if (readPreferred) {
-      return await readPreferred();
-    }
-
     throw wrapError(error);
   }
 }

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -18,7 +18,9 @@ function makeClient(options: {
   deduplicatedColumns?: string[];
   columnTypeIds?: number[];
   getRowsError?: Error;
+  getRowsJsonError?: Error;
   getColumnsObjectError?: Error;
+  getColumnsObjectJsonError?: Error;
   onDeduplicatedColumns?: () => void;
   onStreamClose?: () => void;
 }): DuckDBClientLike {
@@ -31,7 +33,9 @@ function makeClient(options: {
     columns = ['id'],
     columnTypeIds,
     getRowsError,
+    getRowsJsonError,
     getColumnsObjectError,
+    getColumnsObjectJsonError,
     onStreamClose,
   } = options;
   const deduplicatedColumns = Object.prototype.hasOwnProperty.call(
@@ -51,14 +55,24 @@ function makeClient(options: {
           }
           return fallbackValue;
         },
-        getColumnsObjectJson: async () => jsonColumnsValue,
+        getColumnsObjectJson: async () => {
+          if (getColumnsObjectJsonError) {
+            throw getColumnsObjectJsonError;
+          }
+          return jsonColumnsValue;
+        },
         getRowsJS: async () => {
           if (getRowsError) {
             throw getRowsError;
           }
           return rows;
         },
-        getRowsJson: async () => jsonRows,
+        getRowsJson: async () => {
+          if (getRowsJsonError) {
+            throw getRowsJsonError;
+          }
+          return jsonRows;
+        },
         columnNames: () => columns,
         columnCount: columns.length,
         columnTypeId:
@@ -143,6 +157,19 @@ describe('executeArrowOnClient', () => {
       columns: ['ts_ns'],
       columnTypeIds: [22],
       getColumnsObjectError: new Error('Unexpected type id: 0'),
+    });
+
+    const data = await executeArrowOnClient(client, 'select 1', []);
+    expect(data).toBe(fallback);
+  });
+
+  test('falls back to JS column materialization when JSON materialization fails', async () => {
+    const fallback = { ts_ns: [new Date('2024-03-01T12:34:56.123Z')] };
+    const client = makeClient({
+      fallbackValue: fallback,
+      columns: ['ts_ns'],
+      columnTypeIds: [22],
+      getColumnsObjectJsonError: new Error('json reader unavailable'),
     });
 
     const data = await executeArrowOnClient(client, 'select 1', []);
@@ -307,6 +334,25 @@ describe('executeOnClient', () => {
     expect(rows).toEqual([
       {
         ts_ns: '2024-03-01 12:34:56.123456789',
+      },
+    ]);
+  });
+
+  test('falls back to JS rows when JSON materialization fails for precise time families', async () => {
+    const date = new Date('2024-03-01T12:34:56.123Z');
+    const client = makeClient({
+      rows: [[date]],
+      columns: ['ts_ns'],
+      deduplicatedColumns: ['ts_ns'],
+      columnTypeIds: [22],
+      getRowsJsonError: new Error('json reader unavailable'),
+    });
+
+    const rows = await executeOnClient(client, 'select', []);
+
+    expect(rows).toEqual([
+      {
+        ts_ns: date,
       },
     ]);
   });


### PR DESCRIPTION
## Issue

DuckDB 1.5 result materialization prefers the JSON reader for type families where the JavaScript reader can lose precision or fail, such as timestamp variants. The shared helper had a bug in that preferred-reader path: if the preferred JSON reader threw, it retried the same preferred reader instead of falling back to the default reader or wrapping the default reader error.

## Cause and effect

When a node-api result exposed JSON materialization metadata but the JSON materializer was unavailable or failed, callers could see a hard failure even though the default JavaScript materializer was still capable of returning rows or columnar data. The retry also did extra work without changing the outcome.

## Fix

The result-reader helper now tries the preferred precision-preserving reader once, then falls back to the default reader if the preferred path is unavailable. If the default reader fails, the existing DuckDB node-api compatibility wrapping still applies.

This keeps backward-compatible behavior for successful JSON materialization while making the fallback path resilient.

## Package update

Updated the development-only benchmark dependency `tinybench` from `6.0.0` to `6.0.1`. No other package updates were reported by `bun outdated` after the bump.

## Validation

- `bun test test/client-execute.test.ts`
- `bun test`
- `bun run build`
- `bun outdated`

I also pulled `/Users/leov/workspace/motherduck/mono` and checked recent DuckDB/MotherDuck changes. The relevant recent SDK pin is already aligned with this repository's `@duckdb/node-api@1.5.2-r.1` baseline.
