### PR TITLE
[codex] Fix nested DuckDB struct literals

### DIFF
--- a/src/columns.ts
+++ b/src/columns.ts
@@ -1,5 +1,5 @@
 import { sql, type SQL } from 'drizzle-orm';
-import type { SQLWrapper } from 'drizzle-orm/sql/sql';
+import { isSQLWrapper, type SQLWrapper } from 'drizzle-orm/sql/sql';
 import { customType } from 'drizzle-orm/pg-core';
 import {
   wrapList,
@@ -76,6 +76,77 @@ type ArrayDriverValue =
   | ListValueWrapper
   | ArrayValueWrapper;
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isStructType(typeHint: string | undefined): typeHint is StructColType {
+  return /^STRUCT\s*\(/i.test(typeHint?.trim() ?? '');
+}
+
+function splitTopLevel(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (char === '(') depth += 1;
+    if (char === ')') depth = Math.max(0, depth - 1);
+    if (char === delimiter && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}
+
+function parseStructSchema(
+  typeHint: string | undefined
+): Record<string, Primitive> | undefined {
+  if (!isStructType(typeHint)) {
+    return undefined;
+  }
+
+  const inner = typeHint
+    .trim()
+    .replace(/^STRUCT\s*\(/i, '')
+    .replace(/\)$/, '');
+  const fields: Record<string, Primitive> = {};
+
+  for (const part of splitTopLevel(inner, ',')) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const match =
+      /^"([^"]+)"\s+(.*)$/i.exec(trimmed) ??
+      /^([^\s"]+)\s+(.*)$/i.exec(trimmed);
+    if (!match) continue;
+
+    const [, key, type] = match;
+    fields[key] = type.trim() as Primitive;
+  }
+
+  return fields;
+}
+
+function arrayElementType(typeHint: string | undefined): string | undefined {
+  if (!typeHint) return undefined;
+  const trimmed = typeHint.trim();
+  if (trimmed.endsWith('[]')) {
+    return trimmed.slice(0, -2);
+  }
+
+  const fixedArrayMatch = /^(.*)\[\d+\]$/.exec(trimmed);
+  return fixedArrayMatch?.[1]?.trim();
+}
+
 function coerceArrayDriverValue<TData>(value: ArrayDriverValue): TData[] {
   if (Array.isArray(value)) {
     return value as TData[];
@@ -133,11 +204,25 @@ export function buildListLiteral(values: unknown[], elementType?: string): SQL {
     return sql`[]`;
   }
   const chunks = values.map((v) =>
-    typeof v === 'object' && !Array.isArray(v)
-      ? sql`${v as SQLWrapper}`
-      : sql.raw(formatLiteral(v, elementType))
+    valueToSqlLiteral(v, elementType)
   );
   return sql`list_value(${sql.join(chunks, sql.raw(', '))})`;
+}
+
+function valueToSqlLiteral(value: unknown, typeHint?: string): SQL {
+  if (Array.isArray(value)) {
+    return buildListLiteral(value, arrayElementType(typeHint));
+  }
+
+  if (isSQLWrapper(value)) {
+    return sql`${value}`;
+  }
+
+  if (isRecord(value)) {
+    return buildStructLiteral(value, parseStructSchema(typeHint));
+  }
+
+  return sql.raw(formatLiteral(value, typeHint));
 }
 
 export function buildStructLiteral(
@@ -146,15 +231,7 @@ export function buildStructLiteral(
 ): SQL {
   const parts = Object.entries(value).map(([key, val]) => {
     const typeHint = schema?.[key];
-    if (Array.isArray(val)) {
-      const inner =
-        typeof typeHint === 'string' && typeHint.endsWith('[]')
-          ? typeHint.slice(0, -2)
-          : undefined;
-
-      return sql`${sql.identifier(key)} := ${buildListLiteral(val, inner)}`;
-    }
-    return sql`${sql.identifier(key)} := ${val}`;
+    return sql`${sql.identifier(key)} := ${valueToSqlLiteral(val, typeHint)}`;
   });
   return sql`struct_pack(${sql.join(parts, sql.raw(', '))})`;
 }

--- a/src/columns.ts
+++ b/src/columns.ts
@@ -203,9 +203,7 @@ export function buildListLiteral(values: unknown[], elementType?: string): SQL {
   if (values.length === 0) {
     return sql`[]`;
   }
-  const chunks = values.map((v) =>
-    valueToSqlLiteral(v, elementType)
-  );
+  const chunks = values.map((v) => valueToSqlLiteral(v, elementType));
   return sql`list_value(${sql.join(chunks, sql.raw(', '))})`;
 }
 

--- a/test/columns.unit.test.ts
+++ b/test/columns.unit.test.ts
@@ -161,6 +161,20 @@ describe('buildStructLiteral', () => {
     const result = buildStructLiteral({ tags: [1, 2] }, { tags: 'INTEGER[]' });
     expect(result).toBeDefined();
   });
+
+  test('handles nested struct schema hints', () => {
+    const result = buildStructLiteral(
+      {
+        profile: {
+          city: 'Brussels',
+          tags: ['eu', 'be'],
+        },
+      },
+      { profile: 'STRUCT (city TEXT, tags TEXT[])' }
+    );
+
+    expect(result).toBeDefined();
+  });
 });
 
 describe('buildMapLiteral', () => {

--- a/test/duckdb_custom_types.test.ts
+++ b/test/duckdb_custom_types.test.ts
@@ -31,6 +31,17 @@ const listTable = pgTable('duck_list_types', {
   createdLabel: duckDbTimestamp('created_label', { mode: 'string' }),
 });
 
+const nestedStructTable = pgTable('duck_nested_struct_types', {
+  id: integer('id').primaryKey(),
+  profile: duckDbStruct<{
+    name: string;
+    address: { city: string; zip: number; tags: string[] };
+  }>('profile', {
+    name: 'TEXT',
+    address: 'STRUCT (city TEXT, zip INTEGER, tags TEXT[])',
+  }),
+});
+
 interface Context {
   db: DuckDBDatabase;
   connection: DuckDBConnection;
@@ -56,10 +67,22 @@ beforeAll(async () => {
       created_label timestamp
     )
   `);
+
+  await db.execute(sql`drop table if exists ${nestedStructTable}`);
+  await db.execute(sql`
+    create table ${nestedStructTable} (
+      id integer primary key,
+      profile struct(
+        name text,
+        address struct(city text, zip integer, tags text[])
+      )
+    )
+  `);
 });
 
 beforeEach(async () => {
   await ctx.db.execute(sql`delete from ${listTable}`);
+  await ctx.db.execute(sql`delete from ${nestedStructTable}`);
 });
 
 afterAll(() => {
@@ -116,4 +139,24 @@ test('array helpers use DuckDB list semantics', async () => {
 
   expect(containsOrm).toEqual([{ id: 1 }]);
   expect(overlapsDb).toEqual([{ id: 2 }]);
+});
+
+test('duckdb nested struct roundtrip', async () => {
+  await ctx.db.insert(nestedStructTable).values({
+    id: 1,
+    profile: {
+      name: 'Ada',
+      address: { city: 'Brussels', zip: 1000, tags: ['eu', 'be'] },
+    },
+  });
+
+  const rows = await ctx.db
+    .select()
+    .from(nestedStructTable)
+    .where(eq(nestedStructTable.id, 1));
+
+  expect(rows[0]?.profile).toEqual({
+    name: 'Ada',
+    address: { city: 'Brussels', zip: 1000, tags: ['eu', 'be'] },
+  });
 });


### PR DESCRIPTION
## What changed

This fixes nested `duckDbStruct` inserts when a struct field itself contains another DuckDB `STRUCT` value. The struct literal builder now recursively converts nested object values into `struct_pack(...)` expressions and uses the schema hint to recurse through nested list fields as well.

## Why

Before this change, `duckDbStruct` only special-cased array fields. Nested object fields were emitted as plain Drizzle parameters, which left `@duckdb/node-api` trying to bind a JavaScript object without a concrete DuckDB type. Users inserting nested structs could hit `Cannot create values of type ANY. Specify a specific type.` even though the schema contained enough type information.

## Validation

I reproduced the failure with a live in-memory DuckDB insert into `struct(name text, address struct(city text, zip integer, tags text[]))`, then verified the same shape roundtrips after the fix.

Checks run:

- `bun test test/columns.unit.test.ts test/duckdb_custom_types.test.ts`
- `bun test test/columns.unit.test.ts test/duckdb_custom_types.test.ts test/client-execute.test.ts test/duckdb-15-types.test.ts test/json.test.ts test/timestamps.test.ts`
- `bun test`
- `bun run build`
