### PR TITLE
[codex] fix streaming json fallback

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -668,29 +668,47 @@ async function* streamRawBatches(
       const preferJson =
         prefersJsonMaterialization(result) &&
         typeof result.yieldRowsJson === 'function';
-      const rowStream = preferJson
-        ? result.yieldRowsJson!()
-        : result.yieldRowsJs();
-
       let rows: unknown[][] = [];
+      let hasYielded = false;
 
-      try {
-        try {
-          for await (const chunk of rowStream) {
-            for (const row of chunk) {
-              rows.push(row as unknown[]);
-              if (rows.length >= rowsPerChunk) {
-                yield { columns, rows };
-                rows = [];
-              }
+      const drainRows = async function* (
+        rowStream: AsyncIterable<unknown[][]>
+      ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
+        for await (const chunk of rowStream) {
+          for (const row of chunk) {
+            rows.push(row as unknown[]);
+            if (rows.length >= rowsPerChunk) {
+              hasYielded = true;
+              yield { columns, rows };
+              rows = [];
             }
           }
-        } catch (error) {
-          throw wrapUnsupportedNodeApiTypeError(result, error);
         }
 
         if (rows.length > 0) {
+          hasYielded = true;
           yield { columns, rows };
+          rows = [];
+        }
+      };
+
+      try {
+        try {
+          if (preferJson) {
+            try {
+              yield* drainRows(result.yieldRowsJson!());
+              return;
+            } catch (error) {
+              if (hasYielded) {
+                throw error;
+              }
+              rows = [];
+            }
+          }
+
+          yield* drainRows(result.yieldRowsJs());
+        } catch (error) {
+          throw wrapUnsupportedNodeApiTypeError(result, error);
         }
       } finally {
         await closeStreamResult(result);

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -19,6 +19,7 @@ function makeClient(options: {
   columnTypeIds?: number[];
   getRowsError?: Error;
   getRowsJsonError?: Error;
+  streamRowsJsonError?: Error;
   getColumnsObjectError?: Error;
   getColumnsObjectJsonError?: Error;
   onDeduplicatedColumns?: () => void;
@@ -34,6 +35,7 @@ function makeClient(options: {
     columnTypeIds,
     getRowsError,
     getRowsJsonError,
+    streamRowsJsonError,
     getColumnsObjectError,
     getColumnsObjectJsonError,
     onStreamClose,
@@ -107,6 +109,9 @@ function makeClient(options: {
           yield rows;
         },
         async *yieldRowsJson() {
+          if (streamRowsJsonError) {
+            throw streamRowsJsonError;
+          }
           yield jsonRows;
         },
         close() {
@@ -285,6 +290,27 @@ describe('executeInBatches', () => {
     }
 
     expect(chunks).toEqual([[{ ts_ns: '2024-03-01 12:34:56.123456789' }]]);
+  });
+
+  test('falls back to JS streaming when JSON streaming fails before yielding', async () => {
+    const date = new Date('2024-03-01T12:34:56.123Z');
+    const client = makeClient({
+      rows: [[date]],
+      jsonRows: [['2024-03-01 12:34:56.123456789']],
+      columns: ['ts_ns'],
+      deduplicatedColumns: ['ts_ns'],
+      columnTypeIds: [22],
+      streamRowsJsonError: new Error('json stream unavailable'),
+    });
+    const chunks: Array<Array<{ ts_ns: Date }>> = [];
+
+    for await (const chunk of executeInBatches(client, 'select', [], {
+      rowsPerChunk: 1,
+    })) {
+      chunks.push(chunk as Array<{ ts_ns: Date }>);
+    }
+
+    expect(chunks).toEqual([[{ ts_ns: date }]]);
   });
 });
 


### PR DESCRIPTION
## Summary

This fixes a streaming result fallback gap for DuckDB result types that prefer JSON materialization, such as precise timestamp families. Materialized reads already retry the regular JavaScript row reader when the JSON reader is unavailable. The streaming path did not have the same fallback, so `executeInBatches()` and `executeInBatchesRaw()` could fail even when the JS stream could still return rows.

## Cause and effect

The streaming implementation selected `yieldRowsJson()` up front whenever the result metadata indicated that JSON materialization was preferred. If that JSON stream failed before yielding anything, the error was wrapped and surfaced immediately. Users streaming rows from supported fallback types could see avoidable failures in batch APIs while equivalent non-streaming queries succeeded.

## Fix

The row draining logic now tracks whether any chunk has been emitted to the caller. If the preferred JSON stream fails before emitting a user-visible chunk, it resets the local buffer and retries with `yieldRowsJs()`. If a chunk has already been emitted, the error is still surfaced to avoid duplicating rows by restarting the stream from the beginning.

## Validation

- `bun test test/client-execute.test.ts`
- `bun test`
- `bun run build`

Dependency check: npm metadata and `bun outdated` reported no package updates for the tracked dependencies.
