### PR TITLE
[codex] add array bounds rewrites

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ const db = drizzle(connection, {
 });
 ```
 
-Postgres array operators (`@>`, `<@`, `&&`) are automatically rewritten to DuckDB's `array_has_*` functions via AST transformation.
+Postgres array operators (`@>`, `<@`, `&&`) are automatically rewritten to DuckDB's `array_has_*` functions via AST transformation. First-dimension `array_lower(a, 1)` and `array_upper(a, 1)` calls are also rewritten to DuckDB-compatible `array_length` expressions.
 
 ## Known Limitations
 

--- a/docs/core/arrays.md
+++ b/docs/core/arrays.md
@@ -129,6 +129,13 @@ Drizzle DuckDB automatically rewrites Postgres array operators using AST transfo
 | `<@`     | `array_has_all(values, column)` |
 | `&&`     | `array_has_any(column, values)` |
 
+Postgres first-dimension bounds helpers are also rewritten for DuckDB lists:
+
+| Postgres Function   | DuckDB Equivalent                                   |
+| ------------------- | --------------------------------------------------- |
+| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END` |
+| `array_upper(a, 1)` | `CASE WHEN array_length(a) > 0 THEN array_length(a) ELSE NULL END` |
+
 This means Postgres-style code works seamlessly:
 
 ```typescript

--- a/docs/core/arrays.md
+++ b/docs/core/arrays.md
@@ -131,9 +131,9 @@ Drizzle DuckDB automatically rewrites Postgres array operators using AST transfo
 
 Postgres first-dimension bounds helpers are also rewritten for DuckDB lists:
 
-| Postgres Function   | DuckDB Equivalent                                   |
-| ------------------- | --------------------------------------------------- |
-| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END` |
+| Postgres Function   | DuckDB Equivalent                                                  |
+| ------------------- | ------------------------------------------------------------------ |
+| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END`               |
 | `array_upper(a, 1)` | `CASE WHEN array_length(a) > 0 THEN array_length(a) ELSE NULL END` |
 
 This means Postgres-style code works seamlessly:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -109,6 +109,13 @@ Postgres array operators are automatically rewritten to DuckDB functions via AST
 | `<@` (contained by) | `array_has_all(right, left)` |
 | `&&` (overlaps)     | `array_has_any(left, right)` |
 
+Postgres first-dimension array bounds calls are also rewritten:
+
+| Postgres Function   | Rewritten To |
+| ------------------- | ------------ |
+| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END` |
+| `array_upper(a, 1)` | `CASE WHEN array_length(a) > 0 THEN array_length(a) ELSE NULL END` |
+
 **Example**:
 
 ```typescript

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,9 +111,9 @@ Postgres array operators are automatically rewritten to DuckDB functions via AST
 
 Postgres first-dimension array bounds calls are also rewritten:
 
-| Postgres Function   | Rewritten To |
-| ------------------- | ------------ |
-| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END` |
+| Postgres Function   | Rewritten To                                                       |
+| ------------------- | ------------------------------------------------------------------ |
+| `array_lower(a, 1)` | `CASE WHEN array_length(a) > 0 THEN 1 ELSE NULL END`               |
 | `array_upper(a, 1)` | `CASE WHEN array_length(a) > 0 THEN array_length(a) ELSE NULL END` |
 
 **Example**:

--- a/src/sql/ast-transformer.ts
+++ b/src/sql/ast-transformer.ts
@@ -3,6 +3,7 @@
  *
  * Transforms:
  * - Array operators: @>, <@, && -> array_has_all(), array_has_any()
+ * - Array bounds: array_lower(..., 1), array_upper(..., 1) -> DuckDB expressions
  * - JOIN column qualification: "col" = "col" -> "left"."col" = "right"."col"
  *
  * Performance optimizations:
@@ -61,7 +62,7 @@ function getCachedOrTransform(
 
 const DEBUG_ENV = 'DRIZZLE_DUCKDB_DEBUG_AST';
 
-const ARRAY_OPERATOR_PATTERN = /@>|<@|&&/;
+const ARRAY_OPERATOR_PATTERN = /@>|<@|&&|\barray_(?:lower|upper)\s*\(/i;
 const JOIN_PATTERN = /\bjoin\b/i;
 const UNION_PATTERN = /\bunion\b/i;
 const INTERSECT_PATTERN = /\bintersect\b/i;

--- a/src/sql/visitors/array-operators.ts
+++ b/src/sql/visitors/array-operators.ts
@@ -18,9 +18,7 @@ const OPERATOR_MAP: Record<string, { fn: string; swap?: boolean }> = {
 };
 
 function getFunctionName(expr: Record<string, unknown>): string | undefined {
-  const name = expr.name as
-    | { name?: Array<{ value?: unknown }> }
-    | undefined;
+  const name = expr.name as { name?: Array<{ value?: unknown }> } | undefined;
   const firstNamePart = name?.name?.[0]?.value;
   return typeof firstNamePart === 'string'
     ? firstNamePart.toLowerCase()

--- a/src/sql/visitors/array-operators.ts
+++ b/src/sql/visitors/array-operators.ts
@@ -17,6 +17,95 @@ const OPERATOR_MAP: Record<string, { fn: string; swap?: boolean }> = {
   '&&': { fn: 'array_has_any' },
 };
 
+function getFunctionName(expr: Record<string, unknown>): string | undefined {
+  const name = expr.name as
+    | { name?: Array<{ value?: unknown }> }
+    | undefined;
+  const firstNamePart = name?.name?.[0]?.value;
+  return typeof firstNamePart === 'string'
+    ? firstNamePart.toLowerCase()
+    : undefined;
+}
+
+function getFunctionArgs(expr: Record<string, unknown>): unknown[] | undefined {
+  const args = expr.args as { value?: unknown[] } | undefined;
+  return Array.isArray(args?.value) ? args.value : undefined;
+}
+
+function isFirstArrayDimension(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const expr = value as { type?: unknown; value?: unknown };
+  return expr.type === 'number' && Number(expr.value) === 1;
+}
+
+function arrayLengthExpr(arrayExpr: unknown) {
+  return {
+    type: 'function' as const,
+    name: { name: [{ type: 'default', value: 'array_length' }] },
+    args: {
+      type: 'expr_list' as const,
+      value: [arrayExpr],
+    },
+  };
+}
+
+function arrayBoundsExpr(functionName: string, arrayExpr: unknown) {
+  const lengthExpr = arrayLengthExpr(arrayExpr);
+
+  return {
+    type: 'case' as const,
+    expr: null,
+    args: [
+      {
+        type: 'when' as const,
+        cond: {
+          type: 'binary_expr' as const,
+          operator: '>',
+          left: arrayLengthExpr(arrayExpr),
+          right: { type: 'number' as const, value: 0 },
+        },
+        result:
+          functionName === 'array_lower'
+            ? { type: 'number' as const, value: 1 }
+            : lengthExpr,
+      },
+      {
+        type: 'else' as const,
+        result: { type: 'null' as const, value: null },
+      },
+    ],
+  };
+}
+
+function transformArrayBoundsFunction(
+  expr: Record<string, unknown>,
+  parent?: object,
+  key?: string
+): boolean {
+  const functionName = getFunctionName(expr);
+  if (functionName !== 'array_lower' && functionName !== 'array_upper') {
+    return false;
+  }
+
+  const args = getFunctionArgs(expr);
+  if (!args || args.length !== 2 || !isFirstArrayDimension(args[1])) {
+    return false;
+  }
+
+  if (!parent || !key) {
+    return false;
+  }
+
+  (parent as Record<string, unknown>)[key] = arrayBoundsExpr(
+    functionName,
+    args[0]
+  );
+  return true;
+}
+
 function walkExpression(
   expr: ExpressionValue | null | undefined,
   parent?: object,
@@ -55,6 +144,11 @@ function walkExpression(
         walkExpression(binary.right as ExpressionValue, binary, 'right') ||
         transformed;
     }
+  }
+
+  if ('type' in expr && exprObj.type === 'function') {
+    transformed =
+      transformArrayBoundsFunction(exprObj, parent, key) || transformed;
   }
 
   if ('type' in expr && exprObj.type === 'unary_expr') {

--- a/test/arrays.test.ts
+++ b/test/arrays.test.ts
@@ -91,3 +91,26 @@ test('Postgres array operators are rewritten to DuckDB functions', async () => {
   expect(containsOrm).toEqual([{ id: 1 }, { id: 3 }]);
   expect(overlapsOrm).toEqual([{ id: 1 }, { id: 3 }]);
 });
+
+test('Postgres array bounds functions are rewritten for first dimension', async () => {
+  await ctx.db.execute(sql`
+    insert into ${items} (id, tags, numbers)
+    values (4, [], []), (5, NULL, NULL)
+  `);
+
+  const rows = await ctx.db.execute(sql`
+    select
+      id,
+      array_lower(tags, 1) as lower_bound,
+      array_upper(tags, 1) as upper_bound
+    from ${items}
+    where id in (1, 4, 5)
+    order by id
+  `);
+
+  expect(rows).toEqual([
+    { id: 1, lower_bound: 1, upper_bound: 2n },
+    { id: 4, lower_bound: null, upper_bound: null },
+    { id: 5, lower_bound: null, upper_bound: null },
+  ]);
+});

--- a/test/ast-transformer.test.ts
+++ b/test/ast-transformer.test.ts
@@ -45,6 +45,35 @@ describe('transformSQL', () => {
       expect(result.sql.toLowerCase()).toContain('array_has_all');
       expect(result.sql.toLowerCase()).toContain('array_has_any');
     });
+
+    it('transforms array_lower for the first dimension', () => {
+      const result = transformSQL(
+        'SELECT array_lower(tags, 1) AS lo FROM t WHERE array_lower(tags, 1) = 1'
+      );
+
+      expect(result.transformed).toBe(true);
+      expect(result.sql.toLowerCase()).toContain('case when');
+      expect(result.sql.toLowerCase()).toContain('array_length(tags)');
+      expect(result.sql.toLowerCase()).not.toContain('array_lower');
+    });
+
+    it('transforms array_upper for the first dimension', () => {
+      const result = transformSQL(
+        'SELECT array_upper(tags, 1) AS hi FROM t WHERE array_upper(tags, 1) > 0'
+      );
+
+      expect(result.transformed).toBe(true);
+      expect(result.sql.toLowerCase()).toContain('case when');
+      expect(result.sql.toLowerCase()).toContain('array_length(tags)');
+      expect(result.sql.toLowerCase()).not.toContain('array_upper');
+    });
+
+    it('leaves unsupported array bounds dimensions unchanged', () => {
+      const result = transformSQL('SELECT array_upper(tags, 2) AS hi FROM t');
+
+      expect(result.transformed).toBe(false);
+      expect(result.sql).toBe('SELECT array_upper(tags, 2) AS hi FROM t');
+    });
   });
 
   describe('JOIN column qualification', () => {
@@ -238,6 +267,11 @@ describe('needsTransformation', () => {
 
   it('returns true for queries with &&', () => {
     expect(needsTransformation('SELECT * FROM t WHERE a && b')).toBe(true);
+  });
+
+  it('returns true for array bounds functions', () => {
+    expect(needsTransformation('SELECT array_lower(a, 1) FROM t')).toBe(true);
+    expect(needsTransformation('SELECT array_upper(a, 1) FROM t')).toBe(true);
   });
 
   it('returns true for queries with JOIN', () => {


### PR DESCRIPTION
## Summary

This adds compatibility rewriting for first-dimension Postgres array bounds calls in DuckDB SQL. DuckDB supports one-based list indexing, but it does not expose `array_lower()` or `array_upper()` as scalar functions, so raw Postgres-compatible SQL using those helpers fails at execution time today.

The AST transformer now recognizes `array_lower(value, 1)` and `array_upper(value, 1)` alongside the existing Postgres array operator rewrites. For first-dimension calls, it emits DuckDB-compatible `CASE WHEN array_length(value) > 0 ... ELSE NULL END` expressions so non-empty arrays return the expected lower or upper bound while empty and NULL arrays preserve Postgres-style NULL bounds.

Unsupported dimensions are intentionally left unchanged so DuckDB surfaces the same unsupported-function error instead of silently returning an incorrect result.

## Validation

- `bun test test/ast-transformer.test.ts test/arrays.test.ts`
- `bun run build`
- `bun test`

Full test result: 609 passing, 7 skipped.
