### PR TITLE
[codex] Release v1.5.2-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.1.2",
+  "version": "1.5.2-2",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Bump package version to `1.5.2-2` for the next dual npm release.
- Release range: `v1.5.2-1..main`, covering merged PRs #72, #73, #74, #76, #77, #78, #79, #80, and #81.

## Verification

- `bun install --frozen-lockfile`
- `bun run build`
- `bun test`
- `pre-commit run --all-files`
- `npm pack --dry-run`
- `bun run publish:dual --dry-run`
