### PR TITLE
feat(pgduck): add pg_duckdb support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,43 @@ const connection = await instance.connect();
 const db = drizzle(connection);
 ```
 
+### pg_duckdb
+
+For PostgreSQL servers with the
+[`pg_duckdb`](https://github.com/duckdb/pg_duckdb) extension installed, use a
+Postgres wire client such as `pg`:
+
+```typescript
+import pg from 'pg';
+import { sql } from 'drizzle-orm';
+import { drizzle } from '@duckdbfan/drizzle-duckdb';
+
+const client = new pg.Client({
+  connectionString: process.env.DATABASE_URL,
+});
+await client.connect();
+
+const db = drizzle(client);
+
+await db.execute(sql`SET duckdb.force_execution = true`);
+```
+
+When using a `pg.Pool`, wrap it so transactions pin one backend connection:
+
+```typescript
+import pg from 'pg';
+import {
+  createPgDuckConnectionPool,
+  drizzle,
+} from '@duckdbfan/drizzle-duckdb';
+
+const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+});
+
+const db = drizzle(createPgDuckConnectionPool(pool));
+```
+
 ### With Logging
 
 ```typescript

--- a/src/client.ts
+++ b/src/client.ts
@@ -8,21 +8,23 @@ import {
 } from '@duckdb/node-api';
 import {
   DUCKDB_VALUE_MARKER,
-  wrapperToNodeApiValue,
   type AnyDuckDBValueWrapper,
+  wrapperToNodeApiValue,
 } from './value-wrappers.ts';
 import {
   normalizePositiveInteger,
   type PreparedStatementCacheConfig,
 } from './options.ts';
 import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
+import type { PgDuckClient, PgDuckQueryResult } from './pgduck.ts';
 
-export type DuckDBClientLike = DuckDBConnection | DuckDBConnectionPool;
+export type DuckDBExecutionClient = DuckDBConnection | PgDuckClient;
+export type DuckDBClientLike = DuckDBExecutionClient | DuckDBConnectionPool;
 export type RowData = Record<string, unknown>;
 
 export interface DuckDBConnectionPool {
-  acquire(): Promise<DuckDBConnection>;
-  release(connection: DuckDBConnection): void | Promise<void>;
+  acquire(): Promise<DuckDBExecutionClient>;
+  release(connection: DuckDBExecutionClient): void | Promise<void>;
   close?(): Promise<void> | void;
 }
 
@@ -107,9 +109,19 @@ async function readPreferredResult<T>({
   }
 }
 
+function isPgDuckClient(client: DuckDBExecutionClient): client is PgDuckClient {
+  return typeof (client as PgDuckClient).query === 'function';
+}
+
+function isNodeApiConnection(
+  client: DuckDBExecutionClient
+): client is DuckDBConnection {
+  return typeof (client as DuckDBConnection).run === 'function';
+}
+
 async function withConnection<T>(
   client: DuckDBClientLike,
-  callback: (connection: DuckDBConnection) => Promise<T>
+  callback: (connection: DuckDBExecutionClient) => Promise<T>
 ): Promise<T> {
   if (!isPool(client)) {
     return await callback(client);
@@ -125,7 +137,7 @@ async function withConnection<T>(
 
 async function* withConnectionStream<T>(
   client: DuckDBClientLike,
-  callback: (connection: DuckDBConnection) => AsyncGenerator<T, void, void>
+  callback: (connection: DuckDBExecutionClient) => AsyncGenerator<T, void, void>
 ): AsyncGenerator<T, void, void> {
   if (!isPool(client)) {
     yield* callback(client);
@@ -216,6 +228,68 @@ function toNodeApiValues(params: unknown[]): DuckDBValue[] | undefined {
   return params.length > 0
     ? (params.map((param) => toNodeApiValue(param)) as DuckDBValue[])
     : undefined;
+}
+
+function wrapperToPgDuckValue(wrapper: AnyDuckDBValueWrapper): unknown {
+  switch (wrapper.kind) {
+    case 'list':
+    case 'array':
+      return wrapper.data.map((item) => toPgDuckValue(item));
+    case 'struct':
+    case 'map':
+      return Object.fromEntries(
+        Object.entries(wrapper.data).map(([key, value]) => [
+          key,
+          toPgDuckValue(value),
+        ])
+      );
+    case 'json':
+      return JSON.stringify(wrapper.data);
+    case 'timestamp':
+      return wrapper.data;
+    case 'blob':
+      return wrapper.data instanceof Buffer
+        ? wrapper.data
+        : Buffer.from(wrapper.data);
+    default: {
+      const _exhaustive: never = wrapper;
+      throw new Error(
+        `Unknown wrapper kind: ${(_exhaustive as AnyDuckDBValueWrapper).kind}`
+      );
+    }
+  }
+}
+
+function toPgDuckValue(value: unknown): unknown {
+  if (value == null) return null;
+
+  if (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'bigint' ||
+    typeof value === 'boolean' ||
+    value instanceof Date
+  ) {
+    return value;
+  }
+
+  if (typeof value === 'object' && DUCKDB_VALUE_MARKER in value) {
+    return wrapperToPgDuckValue(value as AnyDuckDBValueWrapper);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => toPgDuckValue(item));
+  }
+
+  if (value instanceof Uint8Array) {
+    return value instanceof Buffer ? value : Buffer.from(value);
+  }
+
+  return value;
+}
+
+function toPgDuckValues(params: unknown[]): unknown[] {
+  return params.map((param) => toPgDuckValue(param));
 }
 
 function deduplicateColumns(columns: string[]): string[] {
@@ -525,6 +599,10 @@ async function materializeRows(
   options: ExecuteClientOptions = {}
 ): Promise<MaterializedRows> {
   return await withConnection(client, async (connection) => {
+    if (isPgDuckClient(connection)) {
+      return await materializePgDuckRows(connection, query, params);
+    }
+
     const values = toNodeApiValues(params);
 
     if (options.prepareCache && typeof connection.prepare === 'function') {
@@ -539,6 +617,52 @@ async function materializeRows(
     const result = await connection.run(query, values);
     return await materializeResultRows(result);
   });
+}
+
+function normalizePgDuckResult(result: PgDuckQueryResult | unknown[]) {
+  return Array.isArray(result)
+    ? { rows: result, fields: undefined }
+    : { rows: result.rows, fields: result.fields };
+}
+
+async function materializePgDuckRows(
+  client: PgDuckClient,
+  query: string,
+  params: unknown[]
+): Promise<MaterializedRows> {
+  const result = normalizePgDuckResult(
+    await client.query({
+      text: query,
+      values: toPgDuckValues(params),
+      rowMode: 'array',
+    })
+  );
+  const rows = result.rows ?? [];
+
+  if (rows.length === 0) {
+    const columns = result.fields?.map((field) => field.name) ?? [];
+    return { columns: deduplicateColumns(columns), rows: [] };
+  }
+
+  const firstRow = rows[0];
+  if (Array.isArray(firstRow)) {
+    const columns = result.fields?.map((field) => field.name) ?? [];
+    return {
+      columns: deduplicateColumns(columns),
+      rows: rows as unknown[][],
+    };
+  }
+
+  const columns =
+    result.fields?.map((field) => field.name) ??
+    Object.keys(firstRow as RowData);
+  const deduplicated = deduplicateColumns(columns);
+  return {
+    columns: deduplicated,
+    rows: (rows as RowData[]).map((row) =>
+      columns.map((column) => row[column])
+    ),
+  };
 }
 
 function clearPreparedCache(connection: DuckDBConnection): void {
@@ -572,9 +696,11 @@ function mapRowsToObjects(columns: string[], rows: unknown[][]): RowData[] {
 }
 
 export async function closeClientConnection(
-  connection: DuckDBConnection
+  connection: DuckDBExecutionClient
 ): Promise<void> {
-  clearPreparedCache(connection);
+  if (isNodeApiConnection(connection)) {
+    clearPreparedCache(connection);
+  }
 
   await closeDuckDbResource(connection as DisconnectableResource, true);
 }
@@ -658,6 +784,22 @@ async function* streamRawBatches(
     client,
     async function* (connection): AsyncGenerator<ExecuteBatchesRawChunk> {
       const rowsPerChunk = resolveRowsPerChunk(options);
+
+      if (isPgDuckClient(connection)) {
+        const { columns, rows } = await materializePgDuckRows(
+          connection,
+          query,
+          params
+        );
+        for (let index = 0; index < rows.length; index += rowsPerChunk) {
+          yield {
+            columns,
+            rows: rows.slice(index, index + rowsPerChunk),
+          };
+        }
+        return;
+      }
+
       const values = toNodeApiValues(params);
 
       const result = (await connection.stream(
@@ -750,6 +892,24 @@ export async function executeArrowOnClient(
   params: unknown[]
 ): Promise<unknown> {
   return await withConnection(client, async (connection) => {
+    if (isPgDuckClient(connection)) {
+      const { columns, rows } = await materializePgDuckRows(
+        connection,
+        query,
+        params
+      );
+      const columnData: Record<string, unknown[]> = {};
+      for (const column of columns) {
+        columnData[column] = [];
+      }
+      for (const row of rows) {
+        for (let index = 0; index < columns.length; index += 1) {
+          columnData[columns[index] as string]?.push(row[index]);
+        }
+      }
+      return columnData;
+    }
+
     const values = toNodeApiValues(params);
     const result = await connection.run(query, values);
 

--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -1,5 +1,5 @@
 import type { DuckDBConnection } from '@duckdb/node-api';
-import type { DuckDBConnectionPool } from './client.ts';
+import type { DuckDBConnectionPool, DuckDBExecutionClient } from './client.ts';
 import {
   resolvePoolSize,
   type DuckDBPoolConfig,
@@ -165,6 +165,12 @@ export async function configureDuckLake(
   }
 }
 
+function isDuckDBConnection(
+  connection: DuckDBExecutionClient
+): connection is DuckDBConnection {
+  return typeof (connection as DuckDBConnection).run === 'function';
+}
+
 export function wrapDuckLakePool(
   pool: DuckDBConnectionPool,
   config: DuckLakeConfig
@@ -177,6 +183,13 @@ export function wrapDuckLakePool(
   const wrapped: DuckDBConnectionPool & { size?: number } = {
     async acquire() {
       const connection = await pool.acquire();
+      if (!isDuckDBConnection(connection)) {
+        await pool.release(connection);
+        throw new Error(
+          'DuckLake configuration requires an @duckdb/node-api connection pool and cannot be used with pg_duckdb clients.'
+        );
+      }
+
       if (configuredConnections.has(connection)) {
         return connection;
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './olap.ts';
 export * from './value-wrappers.ts';
 export * from './options.ts';
 export * from './operators.ts';
+export * from './pgduck.ts';
 export {
   configureDuckLake,
   wrapDuckLakePool,

--- a/src/pgduck.ts
+++ b/src/pgduck.ts
@@ -1,0 +1,57 @@
+import type { DuckDBConnectionPool } from './client.ts';
+
+export interface PgDuckField {
+  name: string;
+}
+
+export interface PgDuckQueryConfig {
+  text: string;
+  values?: unknown[];
+  rowMode?: 'array';
+}
+
+export interface PgDuckQueryResult<TRow = unknown> {
+  rows: TRow[];
+  fields?: PgDuckField[];
+  rowCount?: number | null;
+}
+
+export interface PgDuckClient {
+  query(
+    query: string | PgDuckQueryConfig,
+    values?: unknown[]
+  ): Promise<PgDuckQueryResult | unknown[]>;
+  close?(): Promise<void> | void;
+  end?(): Promise<void> | void;
+}
+
+export interface PgDuckPoolClient extends PgDuckClient {
+  release(): void;
+}
+
+export interface PgDuckPool {
+  connect(): Promise<PgDuckPoolClient>;
+  close?(): Promise<void> | void;
+  end?(): Promise<void> | void;
+}
+
+export function createPgDuckConnectionPool(
+  pool: PgDuckPool
+): DuckDBConnectionPool {
+  return {
+    acquire: () => pool.connect(),
+    release(connection) {
+      (connection as PgDuckPoolClient).release();
+    },
+    async close() {
+      if (typeof pool.end === 'function') {
+        await pool.end();
+        return;
+      }
+
+      if (typeof pool.close === 'function') {
+        await pool.close();
+      }
+    },
+  };
+}

--- a/src/session.ts
+++ b/src/session.ts
@@ -21,6 +21,7 @@ import type { DuckDBDialect } from './dialect.ts';
 import type {
   DuckDBClientLike,
   DuckDBConnectionPool,
+  DuckDBExecutionClient,
   RowData,
 } from './client.ts';
 import {
@@ -34,7 +35,6 @@ import {
   type ExecuteInBatchesOptions,
 } from './client.ts';
 import { isPool } from './client.ts';
-import type { DuckDBConnection } from '@duckdb/node-api';
 import type { PreparedStatementCacheConfig } from './options.ts';
 
 export type { DuckDBClientLike, RowData } from './client.ts';
@@ -277,7 +277,7 @@ export class DuckDBSession<
     transaction: (tx: DuckDBTransaction<TFullSchema, TSchema>) => Promise<T>,
     config?: PgTransactionConfig
   ): Promise<T> {
-    let pinnedConnection: DuckDBConnection | undefined;
+    let pinnedConnection: DuckDBExecutionClient | undefined;
     let pool: DuckDBConnectionPool | undefined;
 
     let clientForTx: DuckDBClientLike = this.client;

--- a/test/pgduck.test.ts
+++ b/test/pgduck.test.ts
@@ -1,0 +1,82 @@
+import { sql } from 'drizzle-orm';
+import { integer, pgTable, text } from 'drizzle-orm/pg-core';
+import { describe, expect, test } from 'vitest';
+import { drizzle } from '../src/driver.ts';
+import {
+  createPgDuckConnectionPool,
+  type PgDuckClient,
+  type PgDuckPool,
+  type PgDuckQueryConfig,
+} from '../src/pgduck.ts';
+
+const users = pgTable('users', {
+  id: integer('id'),
+  name: text('name'),
+});
+
+function queryText(query: string | PgDuckQueryConfig): string {
+  return typeof query === 'string' ? query : query.text;
+}
+
+function queryValues(query: string | PgDuckQueryConfig, values?: unknown[]) {
+  return typeof query === 'string' ? values : query.values;
+}
+
+describe('pg_duckdb client support', () => {
+  test('executes Drizzle queries through a Postgres wire client', async () => {
+    const calls: Array<{ text: string; values: unknown[] | undefined }> = [];
+    const client: PgDuckClient = {
+      async query(query, values) {
+        calls.push({
+          text: queryText(query),
+          values: queryValues(query, values),
+        });
+
+        return {
+          fields: [{ name: 'id' }, { name: 'name' }],
+          rows: [[1, 'Ada']],
+        };
+      },
+    };
+
+    const db = drizzle(client);
+    const result = await db
+      .select({ id: users.id, name: users.name })
+      .from(users)
+      .where(sql`${users.id} = ${1}`);
+
+    expect(result).toEqual([{ id: 1, name: 'Ada' }]);
+    expect(calls[0]).toMatchObject({
+      text: 'select "id" as "id", "name" as "name" from "users" where "users"."id" = $1',
+      values: [1],
+    });
+  });
+
+  test('pins pg_duckdb pool clients for transactions', async () => {
+    const calls: string[] = [];
+    let releaseCalls = 0;
+    const poolClient: PgDuckClient & { release(): void } = {
+      async query(query) {
+        calls.push(queryText(query));
+        return { fields: [], rows: [] };
+      },
+      release() {
+        releaseCalls += 1;
+      },
+    };
+    const pool: PgDuckPool = {
+      async connect() {
+        return poolClient;
+      },
+    };
+
+    const db = drizzle(createPgDuckConnectionPool(pool));
+
+    await db.transaction(async (tx) => {
+      await tx.execute(sql`select 1`);
+    });
+
+    expect(calls).toEqual(['BEGIN TRANSACTION;', 'select 1', 'commit']);
+    expect(releaseCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
Adds pg_duckdb support so drizzle-duckdb can run through Postgres wire clients while preserving the DuckDB dialect behavior. Closes #83.

### Codex description

- add pg_duckdb client and pool adapter types for Postgres wire clients
- route pg_duckdb query results through the existing execution and mapping paths
- document pg.Client and pg.Pool usage and cover transaction pinning with tests