### PR TITLE
[codex] refactor streaming row chunking

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -648,6 +648,28 @@ function resolveRowsPerChunk(
   return normalizePositiveInteger(options?.rowsPerChunk, 100_000);
 }
 
+async function* chunkRowStream(
+  rowStream: AsyncIterable<unknown[][]>,
+  columns: string[],
+  rowsPerChunk: number
+): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
+  let rows: unknown[][] = [];
+
+  for await (const chunk of rowStream) {
+    for (const row of chunk) {
+      rows.push(row as unknown[]);
+      if (rows.length >= rowsPerChunk) {
+        yield { columns, rows };
+        rows = [];
+      }
+    }
+  }
+
+  if (rows.length > 0) {
+    yield { columns, rows };
+  }
+}
+
 async function* streamRawBatches(
   client: DuckDBClientLike,
   query: string,
@@ -668,45 +690,29 @@ async function* streamRawBatches(
       const preferJson =
         prefersJsonMaterialization(result) &&
         typeof result.yieldRowsJson === 'function';
-      let rows: unknown[][] = [];
-      let hasYielded = false;
-
-      const drainRows = async function* (
-        rowStream: AsyncIterable<unknown[][]>
-      ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
-        for await (const chunk of rowStream) {
-          for (const row of chunk) {
-            rows.push(row as unknown[]);
-            if (rows.length >= rowsPerChunk) {
-              hasYielded = true;
-              yield { columns, rows };
-              rows = [];
-            }
-          }
-        }
-
-        if (rows.length > 0) {
-          hasYielded = true;
-          yield { columns, rows };
-          rows = [];
-        }
-      };
 
       try {
         try {
           if (preferJson) {
+            let yieldedJsonRows = false;
             try {
-              yield* drainRows(result.yieldRowsJson!());
+              for await (const chunk of chunkRowStream(
+                result.yieldRowsJson!(),
+                columns,
+                rowsPerChunk
+              )) {
+                yieldedJsonRows = true;
+                yield chunk;
+              }
               return;
             } catch (error) {
-              if (hasYielded) {
+              if (yieldedJsonRows) {
                 throw error;
               }
-              rows = [];
             }
           }
 
-          yield* drainRows(result.yieldRowsJs());
+          yield* chunkRowStream(result.yieldRowsJs(), columns, rowsPerChunk);
         } catch (error) {
           throw wrapUnsupportedNodeApiTypeError(result, error);
         }

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -20,6 +20,8 @@ function makeClient(options: {
   getRowsError?: Error;
   getRowsJsonError?: Error;
   streamRowsJsonError?: Error;
+  streamRowsJsonErrorAfterFirstChunk?: Error;
+  streamRowsJsonChunks?: unknown[][][];
   getColumnsObjectError?: Error;
   getColumnsObjectJsonError?: Error;
   onDeduplicatedColumns?: () => void;
@@ -36,6 +38,8 @@ function makeClient(options: {
     getRowsError,
     getRowsJsonError,
     streamRowsJsonError,
+    streamRowsJsonErrorAfterFirstChunk,
+    streamRowsJsonChunks,
     getColumnsObjectError,
     getColumnsObjectJsonError,
     onStreamClose,
@@ -112,7 +116,13 @@ function makeClient(options: {
           if (streamRowsJsonError) {
             throw streamRowsJsonError;
           }
-          yield jsonRows;
+          const chunks = streamRowsJsonChunks ?? [jsonRows];
+          for (let index = 0; index < chunks.length; index += 1) {
+            yield chunks[index] as unknown[][];
+            if (index === 0 && streamRowsJsonErrorAfterFirstChunk) {
+              throw streamRowsJsonErrorAfterFirstChunk;
+            }
+          }
         },
         close() {
           onStreamClose?.();
@@ -311,6 +321,31 @@ describe('executeInBatches', () => {
     }
 
     expect(chunks).toEqual([[{ ts_ns: date }]]);
+  });
+
+  test('throws JSON streaming errors after yielding a chunk', async () => {
+    const error = new Error('json stream failed after yielding');
+    const client = makeClient({
+      rows: [[new Date('2024-03-01T12:34:56.123Z')]],
+      streamRowsJsonChunks: [[['2024-03-01 12:34:56.123456789']]],
+      columns: ['ts_ns'],
+      deduplicatedColumns: ['ts_ns'],
+      columnTypeIds: [22],
+      streamRowsJsonErrorAfterFirstChunk: error,
+    });
+    const chunks: Array<Array<{ ts_ns: string }>> = [];
+
+    await expect(
+      (async () => {
+        for await (const chunk of executeInBatches(client, 'select', [], {
+          rowsPerChunk: 1,
+        })) {
+          chunks.push(chunk as Array<{ ts_ns: string }>);
+        }
+      })()
+    ).rejects.toThrow(error);
+
+    expect(chunks).toEqual([[{ ts_ns: '2024-03-01 12:34:56.123456789' }]]);
   });
 });
 


### PR DESCRIPTION
## Summary

This PR refactors the streaming execution path in `src/client.ts` by extracting the repeated row chunking loop from `streamRawBatches` into a small `chunkRowStream` helper.

The old implementation kept chunk buffering inside the JSON fallback branch, so the streaming code had to manage row buffering, chunk emission, fallback, and cleanup in one nested block. That made a subtle behavior easy to miss: JSON streaming may fall back to JS streaming only if it fails before yielding any chunk. Once rows have been emitted to the caller, later JSON stream failures must surface instead of switching row formats mid-stream.

## User impact

There is no intended API or SQL behavior change. `executeBatches` and `executeBatchesRaw` keep the same chunking semantics, connection release behavior, duplicate column handling, and JSON materialization fallback rules. The refactor makes that boundary easier to maintain.

## Validation

- `bun install`
- `bun test test/client-execute.test.ts`
- `bun run build`
- `bun test`
