### PR TITLE
[codex] add motherduck scan helpers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,15 +9,15 @@
       },
       "devDependencies": {
         "@duckdb/node-api": "1.5.2-r.1",
-        "@types/bun": "^1.3.13",
-        "@types/node": "25.6.0",
-        "@vitest/ui": "4.1.5",
+        "@types/bun": "^1.3.14",
+        "@types/node": "25.8.0",
+        "@vitest/ui": "4.1.6",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.3",
-        "tinybench": "6.0.1",
+        "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.0",
-        "vitest": "4.1.5",
+        "vitest": "4.1.6",
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
@@ -98,7 +98,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -106,31 +106,31 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.5", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw=="],
+    "@vitest/expect": ["@vitest/expect@4.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.5", "", { "dependencies": { "@vitest/spy": "4.1.5", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.6", "", { "dependencies": { "@vitest/spy": "4.1.6", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.5", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.6", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "pathe": "^2.0.3" } }, "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ=="],
+    "@vitest/runner": ["@vitest/runner@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "pathe": "^2.0.3" } }, "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "@vitest/utils": "4.1.5", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "@vitest/utils": "4.1.6", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.5", "", {}, "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ=="],
+    "@vitest/spy": ["@vitest/spy@4.1.6", "", {}, "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg=="],
 
-    "@vitest/ui": ["@vitest/ui@4.1.5", "", { "dependencies": { "@vitest/utils": "4.1.5", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.5" } }, "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag=="],
+    "@vitest/ui": ["@vitest/ui@4.1.6", "", { "dependencies": { "@vitest/utils": "4.1.6", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.6" } }, "sha512-wiu5em68DfGv/2HFvI1Njr7JI2CHcBlQvereSzVG8my53PRxjTNOCsD9VOkRKrsJBDHmyuXvosxWZw7T91a2mw=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
+    "@vitest/utils": ["@vitest/utils@4.1.6", "", { "dependencies": { "@vitest/pretty-format": "4.1.6", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -210,7 +210,7 @@
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
 
-    "tinybench": ["tinybench@6.0.1", "", {}, "sha512-cMdWsxmysdg8mNWf1pujiWl3TW0cU6m8QuNw55QlnP3I6N96Grb0wnu5N0syHIu3LbiVZCNqlfWzWDq84HZphA=="],
+    "tinybench": ["tinybench@6.0.2", "", {}, "sha512-FlHoQpcFvCzeXK5kVPvV7IVgW/hs/B36QWTz876iSdeJguBDfdTSRQmYmaHX+fQNt4hp+gEFB2XXw+8hT4/y8A=="],
 
     "tinyexec": ["tinyexec@1.0.4", "", {}, "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw=="],
 
@@ -224,16 +224,20 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
 
-    "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
+    "vitest": ["vitest@4.1.6", "", { "dependencies": { "@vitest/expect": "4.1.6", "@vitest/mocker": "4.1.6", "@vitest/pretty-format": "4.1.6", "@vitest/runner": "4.1.6", "@vitest/snapshot": "4.1.6", "@vitest/spy": "4.1.6", "@vitest/utils": "4.1.6", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.6", "@vitest/browser-preview": "4.1.6", "@vitest/browser-webdriverio": "4.1.6", "@vitest/coverage-istanbul": "4.1.6", "@vitest/coverage-v8": "4.1.6", "@vitest/ui": "4.1.6", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
   }
 }

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -125,6 +125,38 @@ await db.execute(sql`
 `);
 ```
 
+## MotherDuck scan execution overrides
+
+MotherDuck supports `md_run` on file scan functions so you can force supported scans to execute locally, remotely, or leave the optimizer on automatic placement. Use the whitelisted helper when you want Drizzle to parameterize paths and option values:
+
+```typescript
+import { motherDuckReadParquet } from '@duckdbfan/drizzle-duckdb';
+
+await db.execute(sql`
+  select *
+  from ${motherDuckReadParquet('s3://bucket/events/*.parquet', {
+    mdRun: 'remote',
+    named: {
+      hive_partitioning: true,
+      filename: false,
+    },
+  })}
+`);
+```
+
+For other supported scan functions, use `motherDuckTableFunction`:
+
+```typescript
+import { motherDuckTableFunction } from '@duckdbfan/drizzle-duckdb';
+
+await db.execute(sql`
+  select *
+  from ${motherDuckTableFunction('delta_scan', ['s3://bucket/delta'], {
+    mdRun: 'remote',
+  })}
+`);
+```
+
 ## OLAP builder (grouped measures)
 
 ```typescript

--- a/docs/integrations/motherduck.md
+++ b/docs/integrations/motherduck.md
@@ -134,6 +134,7 @@ MotherDuck supports hybrid queries that combine local and cloud data:
 
 ```typescript
 import { sql } from 'drizzle-orm';
+import { motherDuckReadParquet } from '@duckdbfan/drizzle-duckdb';
 
 // Attach a local database
 await db.execute(sql`ATTACH './local.duckdb' AS local_db`);
@@ -143,6 +144,14 @@ const results = await db.execute(sql`
   SELECT c.name, l.value
   FROM my_cloud_db.main.cloud_table c
   JOIN local_db.main.local_table l ON c.id = l.cloud_id
+`);
+
+// Force a supported cloud scan to run remotely
+await db.execute(sql`
+  select *
+  from ${motherDuckReadParquet('s3://bucket/events/*.parquet', {
+    mdRun: 'remote',
+  })}
 `);
 ```
 

--- a/package.json
+++ b/package.json
@@ -30,15 +30,15 @@
   },
   "devDependencies": {
     "@duckdb/node-api": "1.5.2-r.1",
-    "@types/bun": "^1.3.13",
-    "@types/node": "25.6.0",
-    "@vitest/ui": "4.1.5",
+    "@types/bun": "^1.3.14",
+    "@types/node": "25.8.0",
+    "@vitest/ui": "4.1.6",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.3",
-    "tinybench": "6.0.1",
+    "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.0",
-    "vitest": "4.1.5"
+    "vitest": "4.1.6"
   },
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from './olap.ts';
 export * from './value-wrappers.ts';
 export * from './options.ts';
 export * from './operators.ts';
+export * from './motherduck.ts';
 export {
   configureDuckLake,
   wrapDuckLakePool,

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -1,0 +1,120 @@
+import { sql, type SQLWrapper } from 'drizzle-orm';
+import { isSQLWrapper, type SQL } from 'drizzle-orm/sql/sql';
+
+export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
+
+export type MotherDuckTableFunction =
+  | 'read_parquet'
+  | 'parquet_scan'
+  | 'read_csv'
+  | 'read_csv_auto'
+  | 'read_json'
+  | 'read_json_auto'
+  | 'read_ndjson'
+  | 'read_ndjson_auto'
+  | 'read_json_objects'
+  | 'read_json_objects_auto'
+  | 'read_ndjson_objects'
+  | 'read_text'
+  | 'read_blob'
+  | 'delta_scan'
+  | 'iceberg_scan';
+
+type MotherDuckSqlArgument =
+  | SQLWrapper
+  | string
+  | number
+  | boolean
+  | readonly unknown[];
+
+export interface MotherDuckTableFunctionOptions {
+  mdRun?: MotherDuckRunMode;
+  named?: Record<string, MotherDuckSqlArgument | undefined>;
+}
+
+const motherDuckTableFunctionNames = new Set<MotherDuckTableFunction>([
+  'read_parquet',
+  'parquet_scan',
+  'read_csv',
+  'read_csv_auto',
+  'read_json',
+  'read_json_auto',
+  'read_ndjson',
+  'read_ndjson_auto',
+  'read_json_objects',
+  'read_json_objects_auto',
+  'read_ndjson_objects',
+  'read_text',
+  'read_blob',
+  'delta_scan',
+  'iceberg_scan',
+]);
+
+function tableFunctionArg(value: MotherDuckSqlArgument): SQLWrapper {
+  return isSQLWrapper(value) ? value : sql.param(value);
+}
+
+function assertTableFunctionName(
+  name: MotherDuckTableFunction
+): MotherDuckTableFunction {
+  if (!motherDuckTableFunctionNames.has(name)) {
+    throw new Error(`Unsupported MotherDuck table function "${name}"`);
+  }
+  return name;
+}
+
+function assertNamedParameterName(name: string): string {
+  if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+    throw new Error(`Invalid MotherDuck table function parameter "${name}"`);
+  }
+  return name;
+}
+
+function assertRunMode(mode: MotherDuckRunMode): MotherDuckRunMode {
+  if (mode !== 'auto' && mode !== 'local' && mode !== 'remote') {
+    throw new Error(`Invalid MotherDuck mdRun mode "${String(mode)}"`);
+  }
+  return mode;
+}
+
+export function motherDuckTableFunction(
+  name: MotherDuckTableFunction,
+  args: readonly MotherDuckSqlArgument[] = [],
+  options: MotherDuckTableFunctionOptions = {}
+): SQL {
+  const chunks: SQL[] = args.map((arg) => sql`${tableFunctionArg(arg)}`);
+
+  for (const [paramName, value] of Object.entries(options.named ?? {})) {
+    if (value !== undefined) {
+      chunks.push(
+        sql`${sql.raw(assertNamedParameterName(paramName))} = ${tableFunctionArg(
+          value
+        )}`
+      );
+    }
+  }
+
+  if (options.mdRun) {
+    chunks.push(sql`md_run = ${assertRunMode(options.mdRun)}`);
+  }
+
+  return sql`${sql.raw(assertTableFunctionName(name))}(${sql.join(
+    chunks,
+    sql`, `
+  )})`;
+}
+
+export const motherDuckReadParquet = (
+  path: MotherDuckSqlArgument,
+  options?: MotherDuckTableFunctionOptions
+) => motherDuckTableFunction('read_parquet', [path], options);
+
+export const motherDuckReadCsvAuto = (
+  path: MotherDuckSqlArgument,
+  options?: MotherDuckTableFunctionOptions
+) => motherDuckTableFunction('read_csv_auto', [path], options);
+
+export const motherDuckReadJsonAuto = (
+  path: MotherDuckSqlArgument,
+  options?: MotherDuckTableFunctionOptions
+) => motherDuckTableFunction('read_json_auto', [path], options);

--- a/test/olap_helpers.test.ts
+++ b/test/olap_helpers.test.ts
@@ -14,6 +14,10 @@ import {
   lanceVectorSearch,
   lead,
   median,
+  motherDuckReadCsvAuto,
+  motherDuckReadJsonAuto,
+  motherDuckReadParquet,
+  motherDuckTableFunction,
   olap,
   percentileCont,
   rank,
@@ -302,6 +306,72 @@ test('MotherDuck Lance helpers emit table functions with named parameters', () =
     0.75,
     8,
   ]);
+});
+
+test('MotherDuck scan helpers emit md_run overrides and named parameters', () => {
+  const dialect = new DuckDBDialect();
+
+  const parquet = dialect.sqlToQuery(
+    motherDuckReadParquet('s3://bucket/events/*.parquet', {
+      mdRun: 'remote',
+      named: {
+        hive_partitioning: true,
+        filename: false,
+      },
+    })
+  );
+  const csv = dialect.sqlToQuery(
+    motherDuckReadCsvAuto('https://example.com/data.csv', {
+      mdRun: 'local',
+      named: {
+        header: true,
+      },
+    })
+  );
+  const json = dialect.sqlToQuery(
+    motherDuckReadJsonAuto(sql`read_json_source`, {
+      mdRun: 'auto',
+    })
+  );
+  const delta = dialect.sqlToQuery(
+    motherDuckTableFunction('delta_scan', ['s3://bucket/delta'], {
+      mdRun: 'remote',
+    })
+  );
+
+  expect(parquet.sql).toContain(
+    'read_parquet($1, hive_partitioning = $2, filename = $3, md_run = $4)'
+  );
+  expect(parquet.params).toEqual([
+    's3://bucket/events/*.parquet',
+    true,
+    false,
+    'remote',
+  ]);
+  expect(csv.sql).toContain('read_csv_auto($1, header = $2, md_run = $3)');
+  expect(csv.params).toEqual(['https://example.com/data.csv', true, 'local']);
+  expect(json.sql).toContain('read_json_auto(read_json_source, md_run = $1)');
+  expect(json.params).toEqual(['auto']);
+  expect(delta.sql).toContain('delta_scan($1, md_run = $2)');
+  expect(delta.params).toEqual(['s3://bucket/delta', 'remote']);
+});
+
+test('MotherDuck scan helpers reject unsafe named parameters', () => {
+  expect(() =>
+    motherDuckTableFunction('read_parquet', ['s3://bucket/file.parquet'], {
+      named: {
+        'header); drop table t; --': true,
+      },
+    }).getSQL()
+  ).toThrow('Invalid MotherDuck table function parameter');
+});
+
+test('MotherDuck scan helpers reject invalid md_run modes', () => {
+  expect(() =>
+    motherDuckTableFunction('read_parquet', ['s3://bucket/file.parquet'], {
+      mdRun: 'remote); drop table t; --' as 'remote',
+    }).getSQL()
+  ).toThrow('Invalid MotherDuck mdRun mode');
 });
 
 test('OlapBuilder throws when from() not called', () => {


### PR DESCRIPTION
## Summary

Adds a small MotherDuck scan helper surface for composing supported file table functions with the public `md_run` execution-placement override. The helper whitelists scan function names, parameterizes positional and named values through Drizzle SQL, and validates named parameter identifiers plus `mdRun` modes so JavaScript callers get clear errors.

This also documents the helper in the OLAP API and MotherDuck integration docs, and refreshes patch-level dev tooling packages that were reported by `bun outdated`.

## Validation

- `bun x vitest run test/olap_helpers.test.ts`
- Runtime PoC with `read_csv_auto($1, header = $2)` against local DuckDB returned `[{"id":"1","name":"Alice"},{"id":"2","name":"Bob"}]`
- `bun run build`
- `bun test` (617 pass, 7 skip)
- `bun x prettier --check src/motherduck.ts test/olap_helpers.test.ts docs/api/olap-helpers.md docs/integrations/motherduck.md package.json`
- `git diff --check`
- `bun outdated` showed no remaining update table after the package refresh
