### PR TITLE
[codex] refactor result row mapping

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -16,7 +16,11 @@ import {
   type PreparedStatementCacheConfig,
 } from './options.ts';
 import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
-import type { PgDuckClient, PgDuckQueryResult } from './pgduck.ts';
+import type {
+  PgDuckClient,
+  PgDuckField,
+  PgDuckQueryResult,
+} from './pgduck.ts';
 
 export type DuckDBExecutionClient = DuckDBConnection | PgDuckClient;
 export type DuckDBClientLike = DuckDBExecutionClient | DuckDBConnectionPool;
@@ -619,10 +623,56 @@ async function materializeRows(
   });
 }
 
-function normalizePgDuckResult(result: PgDuckQueryResult | unknown[]) {
+type NormalizedPgDuckResult = {
+  rows: unknown[];
+  fields?: PgDuckField[];
+};
+
+function normalizePgDuckResult(
+  result: PgDuckQueryResult | unknown[]
+): NormalizedPgDuckResult {
   return Array.isArray(result)
     ? { rows: result, fields: undefined }
     : { rows: result.rows, fields: result.fields };
+}
+
+function getPgDuckFieldNames(fields: PgDuckField[] | undefined): string[] {
+  return fields?.map((field) => field.name) ?? [];
+}
+
+function materializedRows(
+  columns: string[],
+  rows: unknown[][]
+): MaterializedRows {
+  return { columns: deduplicateColumns(columns), rows };
+}
+
+function mapObjectRowsToArrays(rows: RowData[], columns: string[]): unknown[][] {
+  return rows.map((row) => columns.map((column) => row[column]));
+}
+
+function materializePgDuckResultRows(
+  result: NormalizedPgDuckResult
+): MaterializedRows {
+  const { rows } = result;
+  const fieldColumns = getPgDuckFieldNames(result.fields);
+
+  if (rows.length === 0) {
+    return materializedRows(fieldColumns, []);
+  }
+
+  const firstRow = rows[0];
+  if (Array.isArray(firstRow)) {
+    return materializedRows(fieldColumns, rows as unknown[][]);
+  }
+
+  const columns =
+    fieldColumns.length > 0 ? fieldColumns : Object.keys(firstRow as RowData);
+
+  return materializedRows(
+    columns,
+    mapObjectRowsToArrays(rows as RowData[], columns)
+  );
 }
 
 async function materializePgDuckRows(
@@ -630,39 +680,15 @@ async function materializePgDuckRows(
   query: string,
   params: unknown[]
 ): Promise<MaterializedRows> {
-  const result = normalizePgDuckResult(
-    await client.query({
-      text: query,
-      values: toPgDuckValues(params),
-      rowMode: 'array',
-    })
+  return materializePgDuckResultRows(
+    normalizePgDuckResult(
+      await client.query({
+        text: query,
+        values: toPgDuckValues(params),
+        rowMode: 'array',
+      })
+    )
   );
-  const rows = result.rows ?? [];
-
-  if (rows.length === 0) {
-    const columns = result.fields?.map((field) => field.name) ?? [];
-    return { columns: deduplicateColumns(columns), rows: [] };
-  }
-
-  const firstRow = rows[0];
-  if (Array.isArray(firstRow)) {
-    const columns = result.fields?.map((field) => field.name) ?? [];
-    return {
-      columns: deduplicateColumns(columns),
-      rows: rows as unknown[][],
-    };
-  }
-
-  const columns =
-    result.fields?.map((field) => field.name) ??
-    Object.keys(firstRow as RowData);
-  const deduplicated = deduplicateColumns(columns);
-  return {
-    columns: deduplicated,
-    rows: (rows as RowData[]).map((row) =>
-      columns.map((column) => row[column])
-    ),
-  };
 }
 
 function clearPreparedCache(connection: DuckDBConnection): void {
@@ -693,6 +719,25 @@ function mapRowsToObjects(columns: string[], rows: unknown[][]): RowData[] {
   }
 
   return mappedRows;
+}
+
+function mapRowsToColumnData(
+  columns: string[],
+  rows: unknown[][]
+): Record<string, unknown[]> {
+  const columnData: Record<string, unknown[]> = {};
+
+  for (const column of columns) {
+    columnData[column] = [];
+  }
+
+  for (const row of rows) {
+    for (let index = 0; index < columns.length; index += 1) {
+      columnData[columns[index] as string]?.push(row[index]);
+    }
+  }
+
+  return columnData;
 }
 
 export async function closeClientConnection(
@@ -904,16 +949,7 @@ export async function executeArrowOnClient(
         query,
         params
       );
-      const columnData: Record<string, unknown[]> = {};
-      for (const column of columns) {
-        columnData[column] = [];
-      }
-      for (const row of rows) {
-        for (let index = 0; index < columns.length; index += 1) {
-          columnData[columns[index] as string]?.push(row[index]);
-        }
-      }
-      return columnData;
+      return mapRowsToColumnData(columns, rows);
     }
 
     const values = toNodeApiValues(params);

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,11 +16,7 @@ import {
   type PreparedStatementCacheConfig,
 } from './options.ts';
 import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
-import type {
-  PgDuckClient,
-  PgDuckField,
-  PgDuckQueryResult,
-} from './pgduck.ts';
+import type { PgDuckClient, PgDuckField, PgDuckQueryResult } from './pgduck.ts';
 
 export type DuckDBExecutionClient = DuckDBConnection | PgDuckClient;
 export type DuckDBClientLike = DuckDBExecutionClient | DuckDBConnectionPool;
@@ -647,7 +643,10 @@ function materializedRows(
   return { columns: deduplicateColumns(columns), rows };
 }
 
-function mapObjectRowsToArrays(rows: RowData[], columns: string[]): unknown[][] {
+function mapObjectRowsToArrays(
+  rows: RowData[],
+  columns: string[]
+): unknown[][] {
   return rows.map((row) => columns.map((column) => row[column]));
 }
 

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -7,6 +7,7 @@ import {
   executeOnClient,
   type DuckDBClientLike,
 } from '../src/client.ts';
+import type { PgDuckClient, PgDuckQueryConfig } from '../src/pgduck.ts';
 
 function makeClient(options: {
   arrowValue?: unknown;
@@ -204,6 +205,24 @@ describe('executeArrowOnClient', () => {
     await executeArrowOnClient(pool, 'select 1', []);
 
     expect(releaseCalls).toBe(1);
+  });
+
+  test('normalizes pg_duckdb object rows to column data', async () => {
+    const calls: PgDuckQueryConfig[] = [];
+    const client: PgDuckClient = {
+      async query(query) {
+        calls.push(query as PgDuckQueryConfig);
+        return {
+          fields: [{ name: 'id' }, { name: 'name' }],
+          rows: [{ id: 1, name: 'Ada' }],
+        };
+      },
+    };
+
+    const data = await executeArrowOnClient(client, 'select', []);
+
+    expect(data).toEqual({ id: [1], name: ['Ada'] });
+    expect(calls[0]).toMatchObject({ text: 'select', rowMode: 'array' });
   });
 });
 


### PR DESCRIPTION
## Summary

This PR does a narrow client-layer refactor around result row materialization.

The issue was that pg_duckdb result handling repeated the same field-name extraction, deduplication, object-row normalization, and column-major conversion work across `materializePgDuckRows()` and the pg_duckdb `executeArrowOnClient()` path. That made small result-shape behavior changes harder to reason about, especially for clients that ignore requested array mode and return object rows.

The cause was incremental support for multiple execution clients: node-api rows, pg_duckdb array rows, pg_duckdb object rows, object results, array results, and columnar fallback all live in the same client module. Some of that logic stayed inline as support was added.

The fix extracts small helpers for normalized pg_duckdb results, field-name lookup, object-row to array-row mapping, and array-row to column-data mapping. The public behavior is unchanged, but the pg_duckdb materialization paths now share one row-shape conversion path.

## Validation

- `bun x vitest run test/client-execute.test.ts`
- `bun run build:declarations`
- `bun run build`
- `bun test`
