### PR TITLE
[codex] refactor batch row chunking

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -823,15 +823,31 @@ async function* chunkRowStream(
   columns: string[],
   rowsPerChunk: number
 ): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
-  let rows: unknown[][] = [];
+  yield* chunkRows(flattenRowChunks(rowStream), columns, rowsPerChunk);
+}
 
+async function* flattenRowChunks(
+  rowStream: AsyncIterable<unknown[][]>
+): AsyncGenerator<unknown[], void, void> {
   for await (const chunk of rowStream) {
     for (const row of chunk) {
-      rows.push(row as unknown[]);
-      if (rows.length >= rowsPerChunk) {
-        yield { columns, rows };
-        rows = [];
-      }
+      yield row as unknown[];
+    }
+  }
+}
+
+async function* chunkRows(
+  rowStream: AsyncIterable<unknown[]> | Iterable<unknown[]>,
+  columns: string[],
+  rowsPerChunk: number
+): AsyncGenerator<ExecuteBatchesRawChunk, void, void> {
+  let rows: unknown[][] = [];
+
+  for await (const row of rowStream) {
+    rows.push(row);
+    if (rows.length >= rowsPerChunk) {
+      yield { columns, rows };
+      rows = [];
     }
   }
 
@@ -857,12 +873,7 @@ async function* streamRawBatches(
           query,
           params
         );
-        for (let index = 0; index < rows.length; index += rowsPerChunk) {
-          yield {
-            columns,
-            rows: rows.slice(index, index + rowsPerChunk),
-          };
-        }
+        yield* chunkRows(rows, columns, rowsPerChunk);
         return;
       }
 

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -456,6 +456,33 @@ describe('executeArraysOnClient', () => {
 });
 
 describe('executeInBatchesRaw', () => {
+  test('chunks pg_duckdb materialized rows through the shared batch path', async () => {
+    let rowMode: unknown;
+    const client: PgDuckClient = {
+      async query(query) {
+        rowMode = typeof query === 'string' ? undefined : query.rowMode;
+        return {
+          fields: [{ name: 'id' }],
+          rows: [[1], [2], [3], [4], [5]],
+        };
+      },
+    };
+    const chunks: Array<{ columns: string[]; rows: unknown[][] }> = [];
+
+    for await (const chunk of executeInBatchesRaw(client, 'select', [], {
+      rowsPerChunk: 2,
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(rowMode).toBe('array');
+    expect(chunks).toEqual([
+      { columns: ['id'], rows: [[1], [2]] },
+      { columns: ['id'], rows: [[3], [4]] },
+      { columns: ['id'], rows: [[5]] },
+    ]);
+  });
+
   test('normalizes node-api duplicate column suffixes when provided', async () => {
     let calls = 0;
     const client = makeClient({


### PR DESCRIPTION
## Summary

This PR performs a small targeted refactor in the batch execution path. The node-api streaming path already used a reusable row chunker, while the pg_duckdb path manually sliced materialized rows inside `streamRawBatches`.

## Issue

Both execution paths need to honor `rowsPerChunk`, but the pg_duckdb path had a separate loop for materialized rows. That made future changes to chunking behavior easier to miss for one client family.

## Cause And Effect

The pg_duckdb implementation materializes rows before yielding chunks because Postgres wire clients do not expose the same streaming API as `@duckdb/node-api`. The effect on users was not a functional bug, but the two code paths carried the same batching concern in different shapes.

## Fix

The refactor splits row chunking into a shared `chunkRows` helper and keeps `chunkRowStream` as the adapter for node-api chunk streams. The pg_duckdb path now feeds its materialized rows through the shared helper instead of slicing inline.

## Validation

- `bun x vitest run test/client-execute.test.ts`
- `bun run build`
- `bun test`
- `git diff --check`
