### PR TITLE
[codex] add motherduck job helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.1`. The repo now develops against `1.5.2-r.1`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.2`. The repo now develops against `1.5.2-r.2`, and `1.4.4-r.1` remains supported.
 Tested `drizzle-orm` versions currently span `0.40.1` through `0.45.x`.
 
 ## Quick Start
@@ -199,6 +199,35 @@ See the [column types](https://leonardovida.github.io/drizzle-duckdb/api/columns
 ## Postgres Schema Compatibility
 
 Use `pgTable`, `pgSchema`, and other `drizzle-orm/pg-core` builders as you do with Postgres. The dialect keeps table definitions and relations intact while adapting queries to DuckDB.
+
+## MotherDuck Helpers
+
+MotherDuck table function helpers are composable SQL fragments:
+
+```typescript
+import { sql } from 'drizzle-orm';
+import { mdCreateJob, mdJobRuns, mdJobs } from '@duckdbfan/drizzle-duckdb';
+
+const jobs = await db.execute(sql`
+  select job_id, job_name, current_version
+  from ${mdJobs({ limit: 25 })}
+`);
+
+const [job] = await db.execute(sql`
+  select job_id, status
+  from ${mdCreateJob({
+    name: 'daily-refresh',
+    mdTokenName: 'pipeline_token',
+    sourceCode: 'print("hello")',
+    scheduleCron: '0 0 * * *',
+  })}
+`);
+
+const runs = await db.execute(sql`
+  select run_number, status, created_at
+  from ${mdJobRuns(String(job.job_id))}
+`);
+```
 
 ## Querying
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,9 +8,9 @@
         "node-sql-parser": "^5.4.0",
       },
       "devDependencies": {
-        "@duckdb/node-api": "1.5.2-r.1",
-        "@types/bun": "^1.3.14",
-        "@types/node": "25.8.0",
+        "@duckdb/node-api": "1.5.2-r.2",
+        "@types/bun": "1.3.14",
+        "@types/node": "25.9.0",
         "@vitest/ui": "4.1.6",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.3",
@@ -32,21 +32,25 @@
     "esbuild": "0.28.0",
   },
   "packages": {
-    "@duckdb/node-api": ["@duckdb/node-api@1.5.2-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.2-r.1" } }, "sha512-OzBBnS0JGXMoS5mzKNY/Ylr7SshcRQiLFIoxQ4AlePwJ2fNeDL/fbHu/knjxUrXwW1fJBTUgwWftmxDdnZZb3A=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.2-r.2", "", { "dependencies": { "@duckdb/node-bindings": "1.5.2-r.2" } }, "sha512-IqFeTarPL9sImt8R6Y/NbNjTR95c7fksk9uFCpFLV0hxbIzbNCCF//xy2BgBqVJtU7/gk2eIpTJTvtE6FS2eog=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.2-r.1", "", { "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.1", "@duckdb/node-bindings-darwin-x64": "1.5.2-r.1", "@duckdb/node-bindings-linux-arm64": "1.5.2-r.1", "@duckdb/node-bindings-linux-x64": "1.5.2-r.1", "@duckdb/node-bindings-win32-arm64": "1.5.2-r.1", "@duckdb/node-bindings-win32-x64": "1.5.2-r.1" } }, "sha512-bUg3bLVj70YVku6fKyQJS8ASORl7kM7YFVFznsEB9pWbtazPj+ME2x2FUk0WiTzjJdutjzSSGXF066mB4bGGZA=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.2-r.2", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.2", "@duckdb/node-bindings-darwin-x64": "1.5.2-r.2", "@duckdb/node-bindings-linux-arm64": "1.5.2-r.2", "@duckdb/node-bindings-linux-arm64-musl": "1.5.2-r.2", "@duckdb/node-bindings-linux-x64": "1.5.2-r.2", "@duckdb/node-bindings-linux-x64-musl": "1.5.2-r.2", "@duckdb/node-bindings-win32-arm64": "1.5.2-r.2", "@duckdb/node-bindings-win32-x64": "1.5.2-r.2" } }, "sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.2-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-v35FyKOb8EJCvaiPF7k0gvKiJTXR7PPQDNoWR0Gu+YSX5O9b+DIguzt1348Of3HebHy6ATSMzlUekaVA9YXu+g=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.2-r.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wA50u8kQxEXlf2ho1m/n8K4qdIWNNBUZ8xQ02x+9Vc12GAgabSlnXJOaZZFrby5Dj28y+mFBIfAEGftBeQKXaw=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.2-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-SU9dIJ1BluKkkGxi4UsP4keqkkstB2YDySF9KcYu3EZKIVM3FTv2zc7XO38dXnHOq6+F3WqhWWZvD+XU945p7A=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.2-r.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UJHIhxkHMpdzTnyXVqsGOZotG+TzwAqkX0POM20IkQVtWtFjPS52Kc9Q+qLrS8ZuabmnrFtX9AnlHNyPVqSqMA=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.2-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-3Tra9xM3aM3denaER4KhJ6//6PpmPbik9ECBQ+sh9PyKaEgHw/0kAcKnLm5EzWUnXF0qYmZlewvkCrse8KmOYw=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.2-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cAEALsSxYRzSfUgxAJCNbDZcmdlVQWvEKldd7r8lYWYZ7D2mxBjeLrF0WoL34vl+ZNEgqHAuqiv3I+wMU2dOXA=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.2-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-pcQvZRHiIfJ9cq8parkSQczQHEml/IeGfnDCMAbEgD6+jaV9Y9Y5Ph1kP9aR+bm6him1S5ZIEr3kZbihjKnWbA=="],
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.2-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-PVC9feqV+bgsnzGfiCv1pe+9mNqoC8k15/3Qmwhp6+AUloTNtk1ln9wlsHMUzhRfNG2wb2fN8P9PJ5zY5t/J/w=="],
 
-    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.2-r.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-Ji8tym+N3LkrhVt0Up3bsacD/kpg4/JXFJQqxswiYvBaNCQOk+D+aiVS0GN5pcqvmnG7V7TpsDRzkLEFaWp1vw=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.2-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9SgKECgVtkDK6+HLBbDKxW41ORj+BciQjSgERFfhnuPIDYhgx08wTPZcnaU7KxvNdOmndIn5OmjzKZ6Jrvwv0g=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.2-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5XqcqC+4R8ghBEEbnc2a0sqfz1zyPBRb9YcmIWfiuDoCYSYFbKhmHcEyNftZDHcwCoLOHXnUin45jraex4STqQ=="],
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.2-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-v2AUKCIHKq9+zFWmx+UdSWyxFLaT5wsWuTNID30pGBqGvwChxLGmm1szbHNxR7nNa00y2SGp9Gxoky0RS7YCwg=="],
+
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.2-r.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-g5ZWK07c0Qh7UFhJC37iC5y8oW8ZqxEgpNM2vTFD3ShM9Rn1NDXkxA7zjcheHRI+My5T1JpE9kNpCvhzItJrgw=="],
+
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.2-r.2", "", { "os": "win32", "cpu": "x64" }, "sha512-VUMbdeXQHWKHEXVWtfVaOSu7Mb4jR9gT56Yzu9FHyLyP9ogY/D6wpeohY5gAHZS9PHQGGq24qRtCn5g6vUolqA=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -106,7 +110,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+    "@types/node": ["@types/node@25.9.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
@@ -148,7 +152,7 @@
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "fflate": ["fflate@0.8.2", "", {}, "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="],
+    "fflate": ["fflate@0.8.3", "", {}, "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA=="],
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     }
   },
   "devDependencies": {
-    "@duckdb/node-api": "1.5.2-r.1",
-    "@types/bun": "^1.3.14",
-    "@types/node": "25.8.0",
+    "@duckdb/node-api": "1.5.2-r.2",
+    "@types/bun": "1.3.14",
+    "@types/node": "25.9.0",
     "@vitest/ui": "4.1.6",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.3",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -16,12 +16,81 @@ export interface MotherDuckRequiredResource {
   resource_type: string | null;
 }
 
-export function mdAccessTokens(): SQL {
-  return sql`md_access_tokens()`;
+export interface MotherDuckJobSummaryRow {
+  job_id: string;
+  job_name: string;
+  schedule_cron: string | null;
+  schedule_status: string | null;
+  status: string;
+  current_version: number;
+  created_at: Date | string;
+  updated_at: Date | string;
 }
 
-export function mdListDives(): SQL {
-  return sql`md_list_dives()`;
+export interface MotherDuckJobVersionRow {
+  version_id: string;
+  job_id: string;
+  version: number;
+  created_at: Date | string;
+  md_token_name: string;
+  md_secret_names: string[];
+  config: Record<string, string> | Map<string, string> | null;
+  source_code: string;
+  requirements_txt: string | null;
+}
+
+export interface MotherDuckJobRunRow {
+  run_id: string;
+  job_id: string;
+  job_name: string;
+  job_version: number;
+  run_number: number | bigint;
+  is_scheduled: boolean;
+  status: string;
+  created_at: Date | string;
+  started_at: Date | string | null;
+  ended_at: Date | string | null;
+  scheduled_at: Date | string | null;
+  cancelled_at: Date | string | null;
+  exit_code: number | null;
+}
+
+export interface MotherDuckJobRunLogsRow {
+  logs: string;
+}
+
+export interface MotherDuckJobDeleteRow {
+  deleted_count: number | bigint;
+}
+
+export interface MotherDuckJobCancelRunRow {
+  canceled_count: number | bigint;
+}
+
+export interface MotherDuckPaginationOptions {
+  limit?: number | SQLWrapper;
+  offset?: number | SQLWrapper;
+}
+
+export interface MotherDuckCreateJobOptions {
+  name: string | SQLWrapper;
+  mdTokenName: string | SQLWrapper;
+  sourceCode: string | SQLWrapper;
+  mdSecretNames?: readonly string[] | SQLWrapper;
+  scheduleCron?: string | SQLWrapper;
+  config?: Record<string, string> | SQLWrapper;
+  requirementsTxt?: string | SQLWrapper;
+}
+
+export interface MotherDuckUpdateJobOptions {
+  jobId: string | SQLWrapper;
+  name?: string | SQLWrapper;
+  scheduleCron?: string | SQLWrapper;
+  config?: Record<string, string> | SQLWrapper;
+  sourceCode?: string | SQLWrapper;
+  requirementsTxt?: string | SQLWrapper;
+  mdTokenName?: string | SQLWrapper;
+  mdSecretNames?: readonly string[] | SQLWrapper;
 }
 
 export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
@@ -47,13 +116,20 @@ type MotherDuckSqlArgument =
   | SQLWrapper
   | string
   | number
+  | bigint
   | boolean
-  | readonly unknown[];
+  | readonly unknown[]
+  | null;
 
 export interface MotherDuckTableFunctionOptions {
   mdRun?: MotherDuckRunMode;
   named?: Record<string, MotherDuckSqlArgument | undefined>;
 }
+
+type NamedParameter = {
+  name: string;
+  value: MotherDuckSqlArgument | undefined;
+};
 
 const motherDuckTableFunctionNames = new Set<MotherDuckTableFunction>([
   'read_parquet',
@@ -73,8 +149,41 @@ const motherDuckTableFunctionNames = new Set<MotherDuckTableFunction>([
   'iceberg_scan',
 ]);
 
-function tableFunctionArg(value: MotherDuckSqlArgument): SQLWrapper {
-  return isSQLWrapper(value) ? value : sql.param(value);
+function motherDuckArg(value: MotherDuckSqlArgument): SQLWrapper {
+  return value !== null && isSQLWrapper(value) ? value : sql.param(value);
+}
+
+function motherDuckMapArg(
+  value: Record<string, string> | SQLWrapper
+): SQLWrapper {
+  if (isSQLWrapper(value)) {
+    return value;
+  }
+
+  return sql`MAP(${sql.param(Object.keys(value))}, ${sql.param(
+    Object.values(value)
+  )})`;
+}
+
+function motherDuckNamedParams(parameters: NamedParameter[]): SQL {
+  const chunks: SQL[] = [];
+
+  for (const { name, value } of parameters) {
+    if (value !== undefined) {
+      chunks.push(sql`${sql.raw(name)} = ${motherDuckArg(value)}`);
+    }
+  }
+
+  return sql.join(chunks, sql`, `);
+}
+
+function motherDuckPagedNamedParams(
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return motherDuckNamedParams([
+    { name: '"LIMIT"', value: options.limit },
+    { name: '"OFFSET"', value: options.offset },
+  ]);
 }
 
 function assertTableFunctionName(
@@ -100,17 +209,25 @@ function assertRunMode(mode: MotherDuckRunMode): MotherDuckRunMode {
   return mode;
 }
 
+export function mdAccessTokens(): SQL {
+  return sql`md_access_tokens()`;
+}
+
+export function mdListDives(): SQL {
+  return sql`md_list_dives()`;
+}
+
 export function motherDuckTableFunction(
   name: MotherDuckTableFunction,
   args: readonly MotherDuckSqlArgument[] = [],
   options: MotherDuckTableFunctionOptions = {}
 ): SQL {
-  const chunks: SQL[] = args.map((arg) => sql`${tableFunctionArg(arg)}`);
+  const chunks: SQL[] = args.map((arg) => sql`${motherDuckArg(arg)}`);
 
   for (const [paramName, value] of Object.entries(options.named ?? {})) {
     if (value !== undefined) {
       chunks.push(
-        sql`${sql.raw(assertNamedParameterName(paramName))} = ${tableFunctionArg(
+        sql`${sql.raw(assertNamedParameterName(paramName))} = ${motherDuckArg(
           value
         )}`
       );
@@ -118,7 +235,7 @@ export function motherDuckTableFunction(
   }
 
   if (options.mdRun) {
-    chunks.push(sql`md_run = ${assertRunMode(options.mdRun)}`);
+    chunks.push(sql`md_run = ${motherDuckArg(assertRunMode(options.mdRun))}`);
   }
 
   return sql`${sql.raw(assertTableFunctionName(name))}(${sql.join(
@@ -141,3 +258,114 @@ export const motherDuckReadJsonAuto = (
   path: MotherDuckSqlArgument,
   options?: MotherDuckTableFunctionOptions
 ) => motherDuckTableFunction('read_json_auto', [path], options);
+
+export function mdJobs(options: MotherDuckPaginationOptions = {}): SQL {
+  return sql`md_jobs(${motherDuckPagedNamedParams(options)})`;
+}
+
+export function mdCreateJob(options: MotherDuckCreateJobOptions): SQL {
+  return sql`md_create_job(${motherDuckNamedParams([
+    { name: 'name', value: options.name },
+    { name: 'md_token_name', value: options.mdTokenName },
+    { name: 'source_code', value: options.sourceCode },
+    { name: 'md_secret_names', value: options.mdSecretNames },
+    { name: 'schedule_cron', value: options.scheduleCron },
+    {
+      name: 'config',
+      value:
+        options.config === undefined
+          ? undefined
+          : motherDuckMapArg(options.config),
+    },
+    { name: 'requirements_txt', value: options.requirementsTxt },
+  ])})`;
+}
+
+export function mdGetJob(jobId: string | SQLWrapper): SQL {
+  return sql`md_get_job(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+  ])})`;
+}
+
+export function mdUpdateJob(options: MotherDuckUpdateJobOptions): SQL {
+  return sql`md_update_job(${motherDuckNamedParams([
+    { name: 'job_id', value: options.jobId },
+    { name: 'name', value: options.name },
+    { name: 'schedule_cron', value: options.scheduleCron },
+    {
+      name: 'config',
+      value:
+        options.config === undefined
+          ? undefined
+          : motherDuckMapArg(options.config),
+    },
+    { name: 'source_code', value: options.sourceCode },
+    { name: 'requirements_txt', value: options.requirementsTxt },
+    { name: 'md_token_name', value: options.mdTokenName },
+    { name: 'md_secret_names', value: options.mdSecretNames },
+  ])})`;
+}
+
+export function mdDeleteJob(jobId: string | SQLWrapper): SQL {
+  return sql`md_delete_job(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+  ])})`;
+}
+
+export function mdRunJob(jobId: string | SQLWrapper): SQL {
+  return sql`md_run_job(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+  ])})`;
+}
+
+export function mdCancelJobRun(
+  jobId: string | SQLWrapper,
+  runNumber: number | bigint | SQLWrapper
+): SQL {
+  return sql`md_cancel_job_run(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+    { name: 'run_number', value: runNumber },
+  ])})`;
+}
+
+export function mdJobRuns(
+  jobId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return sql`md_job_runs(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+    { name: '"LIMIT"', value: options.limit },
+    { name: '"OFFSET"', value: options.offset },
+  ])})`;
+}
+
+export function mdJobRunLogs(
+  jobId: string | SQLWrapper,
+  runNumber: number | bigint | SQLWrapper
+): SQL {
+  return sql`md_job_run_logs(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+    { name: 'run_number', value: runNumber },
+  ])})`;
+}
+
+export function mdJobVersions(
+  jobId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return sql`md_job_versions(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+    { name: '"LIMIT"', value: options.limit },
+    { name: '"OFFSET"', value: options.offset },
+  ])})`;
+}
+
+export function mdGetJobVersion(
+  jobId: string | SQLWrapper,
+  versionNumber: number | SQLWrapper
+): SQL {
+  return sql`md_get_job_version(${motherDuckNamedParams([
+    { name: 'job_id', value: jobId },
+    { name: 'version_number', value: versionNumber },
+  ])})`;
+}

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -1,6 +1,20 @@
 import { sql } from 'drizzle-orm';
 import { expect, test } from 'vitest';
-import { mdAccessTokens, mdListDives } from '../src/motherduck.ts';
+import {
+  mdAccessTokens,
+  mdCancelJobRun,
+  mdCreateJob,
+  mdDeleteJob,
+  mdGetJob,
+  mdGetJobVersion,
+  mdJobRunLogs,
+  mdJobRuns,
+  mdJobs,
+  mdJobVersions,
+  mdListDives,
+  mdRunJob,
+  mdUpdateJob,
+} from '../src/motherduck.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
 
 test('MotherDuck table function helpers emit callable SQL', () => {
@@ -23,4 +37,83 @@ test('MotherDuck table function helpers emit callable SQL', () => {
   expect(dives.sql).toContain('from md_list_dives()');
   expect(dives.sql).toContain('required_resources');
   expect(dives.params).toEqual([]);
+});
+
+test('MotherDuck job helpers emit named-parameter table functions', () => {
+  const dialect = new DuckDBDialect();
+  const jobId = '80000000-0000-0000-0000-000000000001';
+
+  const createJob = dialect.sqlToQuery(sql`
+    select job_id, current_version
+    from ${mdCreateJob({
+      name: 'daily-refresh',
+      mdTokenName: 'pipeline_token',
+      sourceCode: 'print("hello")',
+      mdSecretNames: ['warehouse'],
+      scheduleCron: '0 0 * * *',
+      config: { retries: '3', owner: 'analytics' },
+      requirementsTxt: 'duckdb==1.0.0',
+    })}
+  `);
+
+  expect(createJob.sql).toContain(
+    'from md_create_job(name = $1, md_token_name = $2, source_code = $3, md_secret_names = $4, schedule_cron = $5, config = MAP($6, $7), requirements_txt = $8)'
+  );
+  expect(createJob.params).toEqual([
+    'daily-refresh',
+    'pipeline_token',
+    'print("hello")',
+    ['warehouse'],
+    '0 0 * * *',
+    ['retries', 'owner'],
+    ['3', 'analytics'],
+    'duckdb==1.0.0',
+  ]);
+
+  const jobs = dialect.sqlToQuery(sql`
+    select job_name
+    from ${mdJobs({ limit: 10, offset: 20 })}
+  `);
+
+  expect(jobs.sql).toContain('from md_jobs("LIMIT" = $1, "OFFSET" = $2)');
+  expect(jobs.params).toEqual([10, 20]);
+
+  const updateJob = dialect.sqlToQuery(sql`
+    select current_version
+    from ${mdUpdateJob({
+      jobId,
+      sourceCode: sql`source_code || ${'\n# patched'}`,
+      mdSecretNames: [],
+    })}
+  `);
+
+  expect(updateJob.sql).toContain(
+    'from md_update_job(job_id = $1, source_code = source_code || $2, md_secret_names = $3)'
+  );
+  expect(updateJob.params).toEqual([jobId, '\n# patched', []]);
+
+  expect(dialect.sqlToQuery(sql`from ${mdGetJob(jobId)}`).sql).toContain(
+    'from md_get_job(job_id = $1)'
+  );
+  expect(dialect.sqlToQuery(sql`from ${mdDeleteJob(jobId)}`).sql).toContain(
+    'from md_delete_job(job_id = $1)'
+  );
+  expect(dialect.sqlToQuery(sql`from ${mdRunJob(jobId)}`).sql).toContain(
+    'from md_run_job(job_id = $1)'
+  );
+  expect(
+    dialect.sqlToQuery(sql`from ${mdCancelJobRun(jobId, 2)}`).sql
+  ).toContain('from md_cancel_job_run(job_id = $1, run_number = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdJobRuns(jobId, { limit: 1 })}`).sql
+  ).toContain('from md_job_runs(job_id = $1, "LIMIT" = $2)');
+  expect(dialect.sqlToQuery(sql`from ${mdJobRunLogs(jobId, 1)}`).sql).toContain(
+    'from md_job_run_logs(job_id = $1, run_number = $2)'
+  );
+  expect(
+    dialect.sqlToQuery(sql`from ${mdJobVersions(jobId, { offset: 2 })}`).sql
+  ).toContain('from md_job_versions(job_id = $1, "OFFSET" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdGetJobVersion(jobId, 1)}`).sql
+  ).toContain('from md_get_job_version(job_id = $1, version_number = $2)');
 });


### PR DESCRIPTION
## Summary

This maintenance pass adds typed, composable SQL helpers for the public MotherDuck Jobs table functions and refreshes the local DuckDB node API development dependency from `1.5.2-r.1` to `1.5.2-r.2`.

The issue is that the package already exposed MotherDuck table-function helpers for access tokens and dives, but new Jobs workflows still required users to hand-write the table function names and named parameters. That made job creation, listing, version lookup, run listing, log lookup, cancellation, and deletion more error-prone from Drizzle SQL fragments.

The fix keeps the existing thin-helper style. `src/motherduck.ts` now exports row shape types, pagination options, create/update option types, and helpers for `md_jobs`, `md_create_job`, `md_get_job`, `md_update_job`, `md_delete_job`, `md_run_job`, `md_cancel_job_run`, `md_job_runs`, `md_job_run_logs`, `md_job_versions`, and `md_get_job_version`. The helpers emit named-parameter table-function calls and preserve caller-provided `SQLWrapper` fragments where needed. For job `config`, plain records are converted to DuckDB `MAP(list, list)` parameters instead of interpolated SQL tuples.

I also updated the README to document the current `@duckdb/node-api@1.5.2-r.2` development version and show the new MotherDuck helper usage.

## Validation

- `bun outdated`
- `bun test test/motherduck-functions.test.ts`
- `bun run build:declarations`
- `bun run build`
- `bun test test/node-api.test.ts test/duckdb-15-types.test.ts test/client-execute.test.ts test/motherduck-functions.test.ts`
- `bun --eval` PoC proving the Drizzle/node-api path can bind two list parameters into `MAP($1, $2)`
- `bun test` (619 pass, 7 skip)
- `git diff --check`
