### PR TITLE
[codex] document node-api 1.5.2-r.2

### DIFF
--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 DuckDB provides several types not found in standard Postgres. This guide covers how to use them with Drizzle.
 
-DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.2-r.1` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
+DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.2-r.2` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
 
 ## Import
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.1`. The repo now develops against `1.5.2-r.1`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.2`. The repo now develops against `1.5.2-r.2`, and `1.4.4-r.1` remains supported.
 
 ## Requirements
 

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -52,7 +52,7 @@ await db.transaction(async (tx) => {
 
 ## DuckDB 1.5 Core Types
 
-DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.2-r.1` still throws a low-level conversion error when those raw values are materialized into JavaScript.
+DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.2-r.2` still throws a low-level conversion error when those raw values are materialized into JavaScript.
 
 Use explicit projections when querying those columns:
 


### PR DESCRIPTION
## Summary

This updates the docs that still described the development client as `@duckdb/node-api@1.5.2-r.1`. The package and README already use `1.5.2-r.2`, so the installation and DuckDB 1.5 type limitation pages were stale.

The mismatch can lead MotherDuck users to install or reason about the wrong patch release while debugging DuckDB 1.5 behavior. The underlying compatibility note remains the same: raw `VARIANT` and `GEOMETRY` values still need explicit projections before JavaScript materialization.

I also tested the current latest `@duckdb/node-api` release and did not update the dependency because the MotherDuck integration tests reject DuckDB v1.5.3 today. The safe repository state remains pinned to `1.5.2-r.2`.

## Validation

- `bun --print` runtime smoke: confirmed the installed Node API reports DuckDB `v1.5.2`
- `bun test test/duckdb-15-types.test.ts test/node-api.test.ts test/motherduck-functions.test.ts test/package-config.test.ts`
- `bun test`
- `bun run build`
- `npm pack --dry-run`
- `git diff --check`
- `pre-commit run --all-files`
