### PR TITLE
[codex] add MotherDuck flight helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.2`. The repo now develops against `1.5.2-r.2`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.3-r.3`. The repo now develops against `1.5.3-r.3`, and `1.4.4-r.1` remains supported.
 Tested `drizzle-orm` versions currently span `0.40.1` through `0.45.x`.
 
 ## Quick Start
@@ -206,18 +206,22 @@ MotherDuck table function helpers are composable SQL fragments:
 
 ```typescript
 import { sql } from 'drizzle-orm';
-import { mdCreateJob, mdJobRuns, mdJobs } from '@duckdbfan/drizzle-duckdb';
+import {
+  mdCreateFlight,
+  mdFlightRuns,
+  mdFlights,
+} from '@duckdbfan/drizzle-duckdb';
 
-const jobs = await db.execute(sql`
-  select job_id, job_name, current_version
-  from ${mdJobs({ limit: 25 })}
+const flights = await db.execute(sql`
+  select flight_id, flight_name, current_version
+  from ${mdFlights({ limit: 25 })}
 `);
 
-const [job] = await db.execute(sql`
-  select job_id, status
-  from ${mdCreateJob({
+const [flight] = await db.execute(sql`
+  select flight_id, status
+  from ${mdCreateFlight({
     name: 'daily-refresh',
-    mdTokenName: 'pipeline_token',
+    accessTokenName: 'pipeline_token',
     sourceCode: 'print("hello")',
     scheduleCron: '0 0 * * *',
   })}
@@ -225,9 +229,12 @@ const [job] = await db.execute(sql`
 
 const runs = await db.execute(sql`
   select run_number, status, created_at
-  from ${mdJobRuns(String(job.job_id))}
+  from ${mdFlightRuns(String(flight.flight_id))}
 `);
 ```
+
+The older `mdJobs()` helper family is still exported for deployments that have
+not moved to Flights yet, but new code should use the Flight helpers.
 
 ## Querying
 

--- a/bun.lock
+++ b/bun.lock
@@ -8,16 +8,16 @@
         "node-sql-parser": "^5.4.0",
       },
       "devDependencies": {
-        "@duckdb/node-api": "1.5.2-r.2",
+        "@duckdb/node-api": "1.5.3-r.3",
         "@types/bun": "1.3.14",
         "@types/node": "25.9.1",
-        "@vitest/ui": "4.1.7",
+        "@vitest/ui": "4.1.8",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.3",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.0",
-        "vitest": "4.1.7",
+        "vitest": "4.1.8",
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
@@ -32,25 +32,25 @@
     "esbuild": "0.28.0",
   },
   "packages": {
-    "@duckdb/node-api": ["@duckdb/node-api@1.5.2-r.2", "", { "dependencies": { "@duckdb/node-bindings": "1.5.2-r.2" } }, "sha512-IqFeTarPL9sImt8R6Y/NbNjTR95c7fksk9uFCpFLV0hxbIzbNCCF//xy2BgBqVJtU7/gk2eIpTJTvtE6FS2eog=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.3-r.3", "", { "dependencies": { "@duckdb/node-bindings": "1.5.3-r.3" } }, "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.2-r.2", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.2-r.2", "@duckdb/node-bindings-darwin-x64": "1.5.2-r.2", "@duckdb/node-bindings-linux-arm64": "1.5.2-r.2", "@duckdb/node-bindings-linux-arm64-musl": "1.5.2-r.2", "@duckdb/node-bindings-linux-x64": "1.5.2-r.2", "@duckdb/node-bindings-linux-x64-musl": "1.5.2-r.2", "@duckdb/node-bindings-win32-arm64": "1.5.2-r.2", "@duckdb/node-bindings-win32-x64": "1.5.2-r.2" } }, "sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.3-r.3", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3", "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3", "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3", "@duckdb/node-bindings-win32-x64": "1.5.3-r.3" } }, "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.2-r.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-wA50u8kQxEXlf2ho1m/n8K4qdIWNNBUZ8xQ02x+9Vc12GAgabSlnXJOaZZFrby5Dj28y+mFBIfAEGftBeQKXaw=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.3-r.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.2-r.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-UJHIhxkHMpdzTnyXVqsGOZotG+TzwAqkX0POM20IkQVtWtFjPS52Kc9Q+qLrS8ZuabmnrFtX9AnlHNyPVqSqMA=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.3-r.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.2-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-cAEALsSxYRzSfUgxAJCNbDZcmdlVQWvEKldd7r8lYWYZ7D2mxBjeLrF0WoL34vl+ZNEgqHAuqiv3I+wMU2dOXA=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ=="],
 
-    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.2-r.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-PVC9feqV+bgsnzGfiCv1pe+9mNqoC8k15/3Qmwhp6+AUloTNtk1ln9wlsHMUzhRfNG2wb2fN8P9PJ5zY5t/J/w=="],
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.2-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-9SgKECgVtkDK6+HLBbDKxW41ORj+BciQjSgERFfhnuPIDYhgx08wTPZcnaU7KxvNdOmndIn5OmjzKZ6Jrvwv0g=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw=="],
 
-    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.2-r.2", "", { "os": "linux", "cpu": "x64" }, "sha512-v2AUKCIHKq9+zFWmx+UdSWyxFLaT5wsWuTNID30pGBqGvwChxLGmm1szbHNxR7nNa00y2SGp9Gxoky0RS7YCwg=="],
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA=="],
 
-    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.2-r.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-g5ZWK07c0Qh7UFhJC37iC5y8oW8ZqxEgpNM2vTFD3ShM9Rn1NDXkxA7zjcheHRI+My5T1JpE9kNpCvhzItJrgw=="],
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.3-r.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.2-r.2", "", { "os": "win32", "cpu": "x64" }, "sha512-VUMbdeXQHWKHEXVWtfVaOSu7Mb4jR9gT56Yzu9FHyLyP9ogY/D6wpeohY5gAHZS9PHQGGq24qRtCn5g6vUolqA=="],
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.3-r.3", "", { "os": "win32", "cpu": "x64" }, "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -114,21 +114,21 @@
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.7", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w=="],
+    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.7", "", { "dependencies": { "@vitest/spy": "4.1.7", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.7", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.7", "", { "dependencies": { "@vitest/utils": "4.1.7", "pathe": "^2.0.3" } }, "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw=="],
+    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "@vitest/utils": "4.1.7", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.7", "", {}, "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q=="],
+    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
 
-    "@vitest/ui": ["@vitest/ui@4.1.7", "", { "dependencies": { "@vitest/utils": "4.1.7", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.7" } }, "sha512-TP6utB2yX6rsJNVRo2qAlsi48i1YwFTrLV2tnTtWqJaYX7m4lRCCLirZBjU6xC5m0RsPHr+L2+N+eIPhgEzFfw=="],
+    "@vitest/ui": ["@vitest/ui@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.8" } }, "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw=="],
+    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -234,7 +234,7 @@
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 
-    "vitest": ["vitest@4.1.7", "", { "dependencies": { "@vitest/expect": "4.1.7", "@vitest/mocker": "4.1.7", "@vitest/pretty-format": "4.1.7", "@vitest/runner": "4.1.7", "@vitest/snapshot": "4.1.7", "@vitest/spy": "4.1.7", "@vitest/utils": "4.1.7", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.7", "@vitest/browser-preview": "4.1.7", "@vitest/browser-webdriverio": "4.1.7", "@vitest/coverage-istanbul": "4.1.7", "@vitest/coverage-v8": "4.1.7", "@vitest/ui": "4.1.7", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA=="],
+    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -179,6 +179,42 @@ const divesWithResources = await db.execute(sql`
 
 `mdListDives()` includes `required_resources` on supported MotherDuck deployments. The column is a list of structs with `name`, `alias`, `url`, `id`, and `resource_type` fields.
 
+## MotherDuck Flight table functions
+
+Use the Flight helper functions when creating, listing, updating, running, or
+inspecting MotherDuck Flights through Drizzle SQL templates:
+
+```typescript
+import {
+  mdCreateFlight,
+  mdFlightRuns,
+  mdFlights,
+} from '@duckdbfan/drizzle-duckdb';
+
+const flights = await db.execute(sql`
+  select flight_id, flight_name, current_version
+  from ${mdFlights({ limit: 25 })}
+`);
+
+const [flight] = await db.execute(sql`
+  select flight_id, status
+  from ${mdCreateFlight({
+    name: 'daily-refresh',
+    accessTokenName: 'pipeline_token',
+    sourceCode: 'print("hello")',
+    scheduleCron: '0 0 * * *',
+  })}
+`);
+
+const runs = await db.execute(sql`
+  select run_number, status, created_at
+  from ${mdFlightRuns(String(flight.flight_id))}
+`);
+```
+
+The older Job helper names are still exported for older MotherDuck deployments,
+but new code should use the Flight helpers.
+
 ## OLAP builder (grouped measures)
 
 ```typescript

--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 DuckDB provides several types not found in standard Postgres. This guide covers how to use them with Drizzle.
 
-DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. Those types are available in the database, but `@duckdb/node-api@1.5.2-r.2` still cannot materialize raw JS values for them reliably. Use explicit projections such as `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)` when querying them.
+DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values. For portable geometry output, project with `ST_AsText(...)` or `ST_AsWKB(...)`.
 
 ## Import
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.2-r.2`. The repo now develops against `1.5.2-r.2`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.3-r.3`. The repo now develops against `1.5.3-r.3`, and `1.4.4-r.1` remains supported.
 
 ## Requirements
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,12 +42,13 @@ const allUsers = await db.select().from(users);
 - MotherDuck cloud support
 - DuckLake catalog attach support
 - MotherDuck metadata table function helpers: mdAccessTokens(), mdListDives()
+- MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
 
 ## Important Notes
 
 - Do NOT use Postgres json or jsonb columns - use duckDbJson() instead
 - Current DuckDB 1.4.x and 1.5.x builds do not support `SAVEPOINT`. Nested transactions reuse the outer transaction and mark it for rollback on nested errors.
-- DuckDB 1.5 adds `VARIANT` and built-in `GEOMETRY`, but raw JS materialization for those types is still limited by `@duckdb/node-api`. Cast them before selecting, for example with `CAST(... AS VARCHAR)`, `variant_extract(...)`, `ST_AsText(...)`, or `ST_AsWKB(...)`.
+- DuckDB 1.5 adds `VARIANT` and built-in `GEOMETRY`. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values. Project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output.
 - Array operators are automatically rewritten to DuckDB functions
 
 ## Documentation

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -11,21 +11,21 @@ This page documents known differences between Drizzle DuckDB and Drizzle's stand
 
 ## Feature Support Matrix
 
-| Feature                              | Status  | Notes                                                                                                               |
-| ------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------- |
-| Select queries                       | Full    | All standard select operations work                                                                                 |
-| Insert/Update/Delete                 | Full    | Including `.returning()`                                                                                            |
-| Joins                                | Full    | All join types supported; same-name columns auto-qualified                                                          |
-| Subqueries                           | Full    |                                                                                                                     |
-| CTEs (WITH clauses)                  | Full    | Join column ambiguity auto-resolved                                                                                 |
-| Aggregations                         | Full    |                                                                                                                     |
-| Transactions                         | Partial | No savepoints in current 1.4.x/1.5.x builds (driver probes once, then falls back)                                   |
-| Concurrent queries                   | Partial | One query per connection; use pooling for parallelism                                                               |
-| Prepared statements                  | Partial | Optional per-connection cache via `prepareCache`; no named statements                                               |
-| JSON/JSONB columns                   | None    | Use `duckDbJson()` instead                                                                                          |
-| `VARIANT` / `GEOMETRY` raw JS values | Partial | DuckDB 1.5 types exist, but `@duckdb/node-api` cannot yet materialize raw values reliably. Cast in the query first. |
-| Streaming results                    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks                                          |
-| Relational queries                   | Full    | With schema configuration                                                                                           |
+| Feature                              | Status  | Notes                                                                                                                                    |
+| ------------------------------------ | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| Select queries                       | Full    | All standard select operations work                                                                                                      |
+| Insert/Update/Delete                 | Full    | Including `.returning()`                                                                                                                 |
+| Joins                                | Full    | All join types supported; same-name columns auto-qualified                                                                               |
+| Subqueries                           | Full    |                                                                                                                                          |
+| CTEs (WITH clauses)                  | Full    | Join column ambiguity auto-resolved                                                                                                      |
+| Aggregations                         | Full    |                                                                                                                                          |
+| Transactions                         | Partial | No savepoints in current 1.4.x/1.5.x builds (driver probes once, then falls back)                                                        |
+| Concurrent queries                   | Partial | One query per connection; use pooling for parallelism                                                                                    |
+| Prepared statements                  | Partial | Optional per-connection cache via `prepareCache`; no named statements                                                                    |
+| JSON/JSONB columns                   | None    | Use `duckDbJson()` instead                                                                                                               |
+| `VARIANT` / `GEOMETRY` raw JS values | Partial | `VARIANT` materializes with `@duckdb/node-api@1.5.3-r.3`; project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output. |
+| Streaming results                    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks                                                               |
+| Relational queries                   | Full    | With schema configuration                                                                                                                |
 
 ## Transactions
 
@@ -52,9 +52,9 @@ await db.transaction(async (tx) => {
 
 ## DuckDB 1.5 Core Types
 
-DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. DuckDB itself supports them, but `@duckdb/node-api@1.5.2-r.2` still throws a low-level conversion error when those raw values are materialized into JavaScript.
+DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values.
 
-Use explicit projections when querying those columns:
+Use explicit projections when you need stable text or binary output:
 
 ```typescript
 await db.execute(sql`
@@ -66,7 +66,7 @@ await db.execute(sql`
 `);
 ```
 
-Until the Node API exposes JS conversions for those types, this driver does not provide first-class column helpers for raw `VARIANT` or `GEOMETRY` values.
+This driver does not provide first-class column helpers for raw `VARIANT` or `GEOMETRY` values yet.
 
 ## JSON Columns
 

--- a/package.json
+++ b/package.json
@@ -29,16 +29,16 @@
     }
   },
   "devDependencies": {
-    "@duckdb/node-api": "1.5.2-r.2",
+    "@duckdb/node-api": "1.5.3-r.3",
     "@types/bun": "1.3.14",
     "@types/node": "25.9.1",
-    "@vitest/ui": "4.1.7",
+    "@vitest/ui": "4.1.8",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.3",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.0",
-    "vitest": "4.1.7"
+    "vitest": "4.1.8"
   },
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -519,7 +519,7 @@ function wrapUnsupportedNodeApiTypeError(
       : '';
 
   const wrapped = new Error(
-    `DuckDB returned a column type that @duckdb/node-api cannot materialize to JavaScript${columnsText}. This currently affects some DuckDB 1.5 types, including VARIANT and GEOMETRY. Cast those columns to a supported representation before selecting them, for example CAST(col AS VARCHAR), variant_extract(...), ST_AsText(...), or ST_AsWKB(...).`
+    `DuckDB returned a column type that @duckdb/node-api cannot materialize to JavaScript${columnsText}. Cast those columns to a supported representation before selecting them, for example CAST(col AS VARCHAR), variant_extract(...), ST_AsText(...), or ST_AsWKB(...).`
   );
   (wrapped as Error & { cause?: unknown }).cause = error;
   return wrapped;

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -16,6 +16,58 @@ export interface MotherDuckRequiredResource {
   resource_type: string | null;
 }
 
+export interface MotherDuckFlightSummaryRow {
+  flight_id: string;
+  flight_name: string;
+  schedule_cron: string | null;
+  schedule_status: string | null;
+  status: string;
+  current_version: number;
+  created_at: Date | string;
+  updated_at: Date | string;
+}
+
+export interface MotherDuckFlightVersionRow {
+  version_id: string;
+  flight_id: string;
+  flight_version: number;
+  created_at: Date | string;
+  access_token_name: string;
+  flight_secret_names: string[];
+  config: Record<string, string> | Map<string, string> | null;
+  source_code: string;
+  requirements_txt: string | null;
+}
+
+export interface MotherDuckFlightRunRow {
+  run_id: string;
+  flight_id: string;
+  flight_name: string;
+  flight_version: number;
+  run_number: number | bigint;
+  is_scheduled: boolean;
+  status: string;
+  created_at: Date | string;
+  started_at: Date | string | null;
+  ended_at: Date | string | null;
+  scheduled_at: Date | string | null;
+  cancelled_at: Date | string | null;
+  exit_code: number | null;
+}
+
+export interface MotherDuckFlightLogsRow {
+  logs: string;
+}
+
+export interface MotherDuckFlightDeleteRow {
+  deleted_count: number | bigint;
+}
+
+export interface MotherDuckFlightCancelRunRow {
+  canceled_count: number | bigint;
+}
+
+/** @deprecated Use MotherDuckFlightSummaryRow. */
 export interface MotherDuckJobSummaryRow {
   job_id: string;
   job_name: string;
@@ -27,6 +79,7 @@ export interface MotherDuckJobSummaryRow {
   updated_at: Date | string;
 }
 
+/** @deprecated Use MotherDuckFlightVersionRow. */
 export interface MotherDuckJobVersionRow {
   version_id: string;
   job_id: string;
@@ -39,6 +92,7 @@ export interface MotherDuckJobVersionRow {
   requirements_txt: string | null;
 }
 
+/** @deprecated Use MotherDuckFlightRunRow. */
 export interface MotherDuckJobRunRow {
   run_id: string;
   job_id: string;
@@ -55,14 +109,17 @@ export interface MotherDuckJobRunRow {
   exit_code: number | null;
 }
 
+/** @deprecated Use MotherDuckFlightLogsRow. */
 export interface MotherDuckJobRunLogsRow {
   logs: string;
 }
 
+/** @deprecated Use MotherDuckFlightDeleteRow. */
 export interface MotherDuckJobDeleteRow {
   deleted_count: number | bigint;
 }
 
+/** @deprecated Use MotherDuckFlightCancelRunRow. */
 export interface MotherDuckJobCancelRunRow {
   canceled_count: number | bigint;
 }
@@ -72,6 +129,28 @@ export interface MotherDuckPaginationOptions {
   offset?: number | SQLWrapper;
 }
 
+export interface MotherDuckCreateFlightOptions {
+  name: string | SQLWrapper;
+  accessTokenName: string | SQLWrapper;
+  sourceCode: string | SQLWrapper;
+  flightSecretNames?: readonly string[] | SQLWrapper;
+  scheduleCron?: string | SQLWrapper;
+  config?: Record<string, string> | SQLWrapper;
+  requirementsTxt?: string | SQLWrapper;
+}
+
+export interface MotherDuckUpdateFlightOptions {
+  flightId: string | SQLWrapper;
+  name?: string | SQLWrapper;
+  scheduleCron?: string | SQLWrapper;
+  config?: Record<string, string> | SQLWrapper;
+  sourceCode?: string | SQLWrapper;
+  requirementsTxt?: string | SQLWrapper;
+  accessTokenName?: string | SQLWrapper;
+  flightSecretNames?: readonly string[] | SQLWrapper;
+}
+
+/** @deprecated Use MotherDuckCreateFlightOptions. */
 export interface MotherDuckCreateJobOptions {
   name: string | SQLWrapper;
   mdTokenName: string | SQLWrapper;
@@ -82,6 +161,7 @@ export interface MotherDuckCreateJobOptions {
   requirementsTxt?: string | SQLWrapper;
 }
 
+/** @deprecated Use MotherDuckUpdateFlightOptions. */
 export interface MotherDuckUpdateJobOptions {
   jobId: string | SQLWrapper;
   name?: string | SQLWrapper;
@@ -259,10 +339,123 @@ export const motherDuckReadJsonAuto = (
   options?: MotherDuckTableFunctionOptions
 ) => motherDuckTableFunction('read_json_auto', [path], options);
 
+export function mdFlights(options: MotherDuckPaginationOptions = {}): SQL {
+  return sql`md_flights(${motherDuckPagedNamedParams(options)})`;
+}
+
+export function mdCreateFlight(options: MotherDuckCreateFlightOptions): SQL {
+  return sql`md_create_flight(${motherDuckNamedParams([
+    { name: 'name', value: options.name },
+    { name: 'access_token_name', value: options.accessTokenName },
+    { name: 'source_code', value: options.sourceCode },
+    { name: 'flight_secret_names', value: options.flightSecretNames },
+    { name: 'schedule_cron', value: options.scheduleCron },
+    {
+      name: 'config',
+      value:
+        options.config === undefined
+          ? undefined
+          : motherDuckMapArg(options.config),
+    },
+    { name: 'requirements_txt', value: options.requirementsTxt },
+  ])})`;
+}
+
+export function mdGetFlight(flightId: string | SQLWrapper): SQL {
+  return sql`md_get_flight(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+  ])})`;
+}
+
+export function mdUpdateFlight(options: MotherDuckUpdateFlightOptions): SQL {
+  return sql`md_update_flight(${motherDuckNamedParams([
+    { name: 'flight_id', value: options.flightId },
+    { name: 'name', value: options.name },
+    { name: 'schedule_cron', value: options.scheduleCron },
+    {
+      name: 'config',
+      value:
+        options.config === undefined
+          ? undefined
+          : motherDuckMapArg(options.config),
+    },
+    { name: 'source_code', value: options.sourceCode },
+    { name: 'requirements_txt', value: options.requirementsTxt },
+    { name: 'access_token_name', value: options.accessTokenName },
+    { name: 'flight_secret_names', value: options.flightSecretNames },
+  ])})`;
+}
+
+export function mdDeleteFlight(flightId: string | SQLWrapper): SQL {
+  return sql`md_delete_flight(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+  ])})`;
+}
+
+export function mdRunFlight(flightId: string | SQLWrapper): SQL {
+  return sql`md_run_flight(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+  ])})`;
+}
+
+export function mdCancelFlightRun(
+  flightId: string | SQLWrapper,
+  runNumber: number | bigint | SQLWrapper
+): SQL {
+  return sql`md_cancel_flight_run(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+    { name: 'run_number', value: runNumber },
+  ])})`;
+}
+
+export function mdFlightRuns(
+  flightId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return sql`md_flight_runs(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+    { name: '"LIMIT"', value: options.limit },
+    { name: '"OFFSET"', value: options.offset },
+  ])})`;
+}
+
+export function mdFlightLogs(
+  flightId: string | SQLWrapper,
+  runNumber: number | bigint | SQLWrapper
+): SQL {
+  return sql`md_flight_logs(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+    { name: 'run_number', value: runNumber },
+  ])})`;
+}
+
+export function mdFlightVersions(
+  flightId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return sql`md_flight_versions(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+    { name: '"LIMIT"', value: options.limit },
+    { name: '"OFFSET"', value: options.offset },
+  ])})`;
+}
+
+export function mdGetFlightVersion(
+  flightId: string | SQLWrapper,
+  versionNumber: number | SQLWrapper
+): SQL {
+  return sql`md_get_flight_version(${motherDuckNamedParams([
+    { name: 'flight_id', value: flightId },
+    { name: 'version_number', value: versionNumber },
+  ])})`;
+}
+
+/** @deprecated Use mdFlights. */
 export function mdJobs(options: MotherDuckPaginationOptions = {}): SQL {
   return sql`md_jobs(${motherDuckPagedNamedParams(options)})`;
 }
 
+/** @deprecated Use mdCreateFlight. */
 export function mdCreateJob(options: MotherDuckCreateJobOptions): SQL {
   return sql`md_create_job(${motherDuckNamedParams([
     { name: 'name', value: options.name },
@@ -281,12 +474,14 @@ export function mdCreateJob(options: MotherDuckCreateJobOptions): SQL {
   ])})`;
 }
 
+/** @deprecated Use mdGetFlight. */
 export function mdGetJob(jobId: string | SQLWrapper): SQL {
   return sql`md_get_job(${motherDuckNamedParams([
     { name: 'job_id', value: jobId },
   ])})`;
 }
 
+/** @deprecated Use mdUpdateFlight. */
 export function mdUpdateJob(options: MotherDuckUpdateJobOptions): SQL {
   return sql`md_update_job(${motherDuckNamedParams([
     { name: 'job_id', value: options.jobId },
@@ -306,18 +501,21 @@ export function mdUpdateJob(options: MotherDuckUpdateJobOptions): SQL {
   ])})`;
 }
 
+/** @deprecated Use mdDeleteFlight. */
 export function mdDeleteJob(jobId: string | SQLWrapper): SQL {
   return sql`md_delete_job(${motherDuckNamedParams([
     { name: 'job_id', value: jobId },
   ])})`;
 }
 
+/** @deprecated Use mdRunFlight. */
 export function mdRunJob(jobId: string | SQLWrapper): SQL {
   return sql`md_run_job(${motherDuckNamedParams([
     { name: 'job_id', value: jobId },
   ])})`;
 }
 
+/** @deprecated Use mdCancelFlightRun. */
 export function mdCancelJobRun(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
@@ -328,6 +526,7 @@ export function mdCancelJobRun(
   ])})`;
 }
 
+/** @deprecated Use mdFlightRuns. */
 export function mdJobRuns(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
@@ -339,6 +538,7 @@ export function mdJobRuns(
   ])})`;
 }
 
+/** @deprecated Use mdFlightLogs. */
 export function mdJobRunLogs(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
@@ -349,6 +549,7 @@ export function mdJobRunLogs(
   ])})`;
 }
 
+/** @deprecated Use mdFlightVersions. */
 export function mdJobVersions(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
@@ -360,6 +561,7 @@ export function mdJobVersions(
   ])})`;
 }
 
+/** @deprecated Use mdGetFlightVersion. */
 export function mdGetJobVersion(
   jobId: string | SQLWrapper,
   versionNumber: number | SQLWrapper

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -420,7 +420,7 @@ describe('executeOnClient', () => {
     ]);
   });
 
-  test('wraps unsupported DuckDB 1.5 type materialization errors', async () => {
+  test('wraps unsupported node-api type materialization errors', async () => {
     for (const typeId of [40, 41]) {
       const client = makeClient({
         columns: ['data'],
@@ -430,7 +430,7 @@ describe('executeOnClient', () => {
       });
 
       await expect(executeOnClient(client, 'select', [])).rejects.toThrow(
-        /column "data".*VARIANT and GEOMETRY.*CAST\(col AS VARCHAR\)/i
+        /column "data".*CAST\(col AS VARCHAR\)/i
       );
     }
   });

--- a/test/duckdb-15-types.test.ts
+++ b/test/duckdb-15-types.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
   instance?.closeSync?.();
 });
 
-test('VARIANT columns surface a descriptive node-api compatibility error', async () => {
+test('VARIANT columns materialize with node-api 1.5.3', async () => {
   try {
     await db.execute(
       sql`create table duckdb_variant_test (id integer, data variant)`
@@ -36,12 +36,10 @@ test('VARIANT columns surface a descriptive node-api compatibility error', async
       (2, {'name': 'Alice'}::variant)
   `);
 
-  await expect(
-    (async () =>
-      await db.execute(sql`select data from duckdb_variant_test order by id`))()
-  ).rejects.toThrow(
-    /@duckdb\/node-api cannot materialize to JavaScript.*VARIANT and GEOMETRY/i
+  const variantRows = await db.execute(
+    sql`select data from duckdb_variant_test order by id`
   );
+  expect(variantRows).toEqual([{ data: 42 }, { data: { name: 'Alice' } }]);
 
   const rows = await db.execute(
     sql`select cast(data as varchar) as data_text from duckdb_variant_test order by id`

--- a/test/migrator.test.ts
+++ b/test/migrator.test.ts
@@ -75,6 +75,11 @@ describe('Migrator Tests', () => {
     );
   });
 
+  beforeEach(async () => {
+    await db.execute(sql`DROP TABLE IF EXISTS users`);
+    await db.execute(sql`DROP SCHEMA IF EXISTS drizzle CASCADE`);
+  });
+
   afterAll(async () => {
     await db.close();
     instance.closeSync?.();
@@ -100,8 +105,6 @@ describe('Migrator Tests', () => {
   });
 
   test('migrate accepts a migrations folder string', async () => {
-    await db.execute(sql`DROP TABLE IF EXISTS users`);
-
     await migrate(db, testMigrationsDir);
 
     const result = await db.execute<{ name: string }>(sql`
@@ -115,7 +118,8 @@ describe('Migrator Tests', () => {
   });
 
   test('migrate creates __drizzle_migrations table', async () => {
-    // After the first migrate, the migrations table should exist
+    await migrate(db, { migrationsFolder: testMigrationsDir });
+
     const result = await db.execute<{ name: string }>(sql`
       SELECT table_name as name
       FROM information_schema.tables

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -2,9 +2,18 @@ import { sql } from 'drizzle-orm';
 import { expect, test } from 'vitest';
 import {
   mdAccessTokens,
+  mdCancelFlightRun,
   mdCancelJobRun,
+  mdCreateFlight,
   mdCreateJob,
+  mdDeleteFlight,
   mdDeleteJob,
+  mdFlightLogs,
+  mdFlightRuns,
+  mdFlights,
+  mdFlightVersions,
+  mdGetFlight,
+  mdGetFlightVersion,
   mdGetJob,
   mdGetJobVersion,
   mdJobRunLogs,
@@ -12,7 +21,9 @@ import {
   mdJobs,
   mdJobVersions,
   mdListDives,
+  mdRunFlight,
   mdRunJob,
+  mdUpdateFlight,
   mdUpdateJob,
 } from '../src/motherduck.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
@@ -37,6 +48,88 @@ test('MotherDuck table function helpers emit callable SQL', () => {
   expect(dives.sql).toContain('from md_list_dives()');
   expect(dives.sql).toContain('required_resources');
   expect(dives.params).toEqual([]);
+});
+
+test('MotherDuck flight helpers emit named-parameter table functions', () => {
+  const dialect = new DuckDBDialect();
+  const flightId = '80000000-0000-0000-0000-000000000001';
+
+  const createFlight = dialect.sqlToQuery(sql`
+    select flight_id, current_version
+    from ${mdCreateFlight({
+      name: 'daily-refresh',
+      accessTokenName: 'pipeline_token',
+      sourceCode: 'print("hello")',
+      flightSecretNames: ['warehouse'],
+      scheduleCron: '0 0 * * *',
+      config: { retries: '3', owner: 'analytics' },
+      requirementsTxt: 'duckdb==1.0.0',
+    })}
+  `);
+
+  expect(createFlight.sql).toContain(
+    'from md_create_flight(name = $1, access_token_name = $2, source_code = $3, flight_secret_names = $4, schedule_cron = $5, config = MAP($6, $7), requirements_txt = $8)'
+  );
+  expect(createFlight.params).toEqual([
+    'daily-refresh',
+    'pipeline_token',
+    'print("hello")',
+    ['warehouse'],
+    '0 0 * * *',
+    ['retries', 'owner'],
+    ['3', 'analytics'],
+    'duckdb==1.0.0',
+  ]);
+
+  const flights = dialect.sqlToQuery(sql`
+    select flight_name
+    from ${mdFlights({ limit: 10, offset: 20 })}
+  `);
+
+  expect(flights.sql).toContain('from md_flights("LIMIT" = $1, "OFFSET" = $2)');
+  expect(flights.params).toEqual([10, 20]);
+
+  const updateFlight = dialect.sqlToQuery(sql`
+    select current_version
+    from ${mdUpdateFlight({
+      flightId,
+      sourceCode: sql`source_code || ${'\n# patched'}`,
+      flightSecretNames: [],
+    })}
+  `);
+
+  expect(updateFlight.sql).toContain(
+    'from md_update_flight(flight_id = $1, source_code = source_code || $2, flight_secret_names = $3)'
+  );
+  expect(updateFlight.params).toEqual([flightId, '\n# patched', []]);
+
+  expect(dialect.sqlToQuery(sql`from ${mdGetFlight(flightId)}`).sql).toContain(
+    'from md_get_flight(flight_id = $1)'
+  );
+  expect(
+    dialect.sqlToQuery(sql`from ${mdDeleteFlight(flightId)}`).sql
+  ).toContain('from md_delete_flight(flight_id = $1)');
+  expect(dialect.sqlToQuery(sql`from ${mdRunFlight(flightId)}`).sql).toContain(
+    'from md_run_flight(flight_id = $1)'
+  );
+  expect(
+    dialect.sqlToQuery(sql`from ${mdCancelFlightRun(flightId, 2)}`).sql
+  ).toContain('from md_cancel_flight_run(flight_id = $1, run_number = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightRuns(flightId, { limit: 1 })}`).sql
+  ).toContain('from md_flight_runs(flight_id = $1, "LIMIT" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightLogs(flightId, 1)}`).sql
+  ).toContain('from md_flight_logs(flight_id = $1, run_number = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightVersions(flightId, { offset: 2 })}`)
+      .sql
+  ).toContain('from md_flight_versions(flight_id = $1, "OFFSET" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdGetFlightVersion(flightId, 1)}`).sql
+  ).toContain(
+    'from md_get_flight_version(flight_id = $1, version_number = $2)'
+  );
 });
 
 test('MotherDuck job helpers emit named-parameter table functions', () => {


### PR DESCRIPTION
## Summary

This adds MotherDuck Flight table-function helpers as the primary API for new code while keeping the existing Job helper family exported and marked deprecated for older deployments. The new helpers emit the Flight function names and parameter names exposed by MotherDuck, including access_token_name, flight_secret_names, and flight_id.

This also updates the development DuckDB Node API to 1.5.3-r.3 and Vitest to 4.1.8. With the newer DuckDB binding, VARIANT values now materialize into JavaScript values, so the compatibility test and docs now describe that behavior instead of expecting a materialization error. The generic unsupported-type error message remains, but no longer calls out fixed type names.

The migrator test suite now resets both user tables and the drizzle migration schema per test. That makes the string-config migration test independent instead of depending on previous test state.

## Validation

- bun --print runtime PoC with @duckdb/node-api 1.5.3-r.3 against :memory:
- bun --print VARIANT materialization PoC
- bun --print GEOMETRY projection PoC
- bun test test/motherduck-functions.test.ts
- bun test test/duckdb-15-types.test.ts
- bun test test/client-execute.test.ts
- bun test test/migrator.test.ts
- bun run build
- bun test
