### PR TITLE
[codex] fix pgduck client close

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -70,6 +70,7 @@ type ResultJsonRowsLike = {
 type ClosableResource = {
   close?: () => Promise<void> | void;
   closeSync?: () => void;
+  end?: () => Promise<void> | void;
 };
 
 type DisconnectableResource = ClosableResource & {
@@ -767,6 +768,11 @@ async function closeDuckDbResource(
 
   if (typeof resource.closeSync === 'function') {
     resource.closeSync();
+    return;
+  }
+
+  if (typeof resource.end === 'function') {
+    await resource.end();
     return;
   }
 

--- a/test/client-close.test.ts
+++ b/test/client-close.test.ts
@@ -1,6 +1,7 @@
 import type { DuckDBConnection, DuckDBInstance } from '@duckdb/node-api';
 import { expect, test, vi } from 'vitest';
 import { closeClientConnection, closeDuckDbInstance } from '../src/client.ts';
+import type { PgDuckClient } from '../src/pgduck.ts';
 
 test('closeClientConnection prefers async close when available', async () => {
   const close = vi.fn(async () => undefined);
@@ -26,6 +27,18 @@ test('closeClientConnection falls back to disconnectSync', async () => {
   } as unknown as DuckDBConnection);
 
   expect(disconnectSync).toHaveBeenCalledTimes(1);
+});
+
+test('closeClientConnection closes pg-style clients with end', async () => {
+  const end = vi.fn(async () => undefined);
+  const client: PgDuckClient = {
+    query: vi.fn(async () => ({ rows: [] })),
+    end,
+  };
+
+  await closeClientConnection(client);
+
+  expect(end).toHaveBeenCalledTimes(1);
 });
 
 test('closeDuckDbInstance prefers async close when available', async () => {

--- a/test/driver-factory.test.ts
+++ b/test/driver-factory.test.ts
@@ -6,6 +6,7 @@ import { POOL_PRESETS, resolvePoolSize } from '../src/pool.ts';
 import { DuckDBDatabase } from '../src/driver.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
 import { DuckDBSession } from '../src/session.ts';
+import type { PgDuckClient } from '../src/pgduck.ts';
 
 describe('Driver Factory Tests', () => {
   let db: DuckDBDatabase | null = null;
@@ -185,6 +186,19 @@ describe('Driver Factory Tests', () => {
 
       await expect(dbWithFailingClient.close()).rejects.toBe(closeError);
       expect(instanceClosed).toBe(1);
+    });
+
+    test('close() ends direct pg-style clients', async () => {
+      const end = vi.fn(async () => undefined);
+      const pgClient: PgDuckClient = {
+        query: vi.fn(async () => ({ rows: [] })),
+        end,
+      };
+      const dbWithPgClient = drizzle(pgClient);
+
+      await dbWithPgClient.close();
+
+      expect(end).toHaveBeenCalledTimes(1);
     });
 
     test('connection-string setup closes resources when DuckLake setup fails', async () => {


### PR DESCRIPTION
## Summary

This fixes a close-path leak for direct pg-style clients used with the pg_duckdb adapter surface. The client type already supported an `end()` method, but `db.close()` only tried `close`, `closeSync`, and `disconnectSync`, so clients that exposed only `end()` were left open.

The fix adds `end()` to the shared close helper after the DuckDB-specific close methods. Existing DuckDB close behavior remains unchanged, and direct pg-style clients are now shut down through their public close API.

## Validation

- `bun run build`
- `bun test`
- Runtime PoC: `drizzle({ query: async () => ({ rows: [] }), end }).close()` calls `end()` once
