### PR TITLE
[codex] support null flight options

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,10 @@ const runs = await db.execute(sql`
 
 The older `mdJobs()` helper family is still exported for deployments that have
 not moved to Flights yet, but new code should use the Flight helpers.
+For optional Flight fields, `undefined` omits the named parameter and `null`
+emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
+or empty values for nullable Flight options such as `requirementsTxt`, `config`,
+and `flightSecretNames`.
 
 ## Querying
 

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -133,21 +133,21 @@ export interface MotherDuckCreateFlightOptions {
   name: string | SQLWrapper;
   accessTokenName: string | SQLWrapper;
   sourceCode: string | SQLWrapper;
-  flightSecretNames?: readonly string[] | SQLWrapper;
-  scheduleCron?: string | SQLWrapper;
-  config?: Record<string, string> | SQLWrapper;
-  requirementsTxt?: string | SQLWrapper;
+  flightSecretNames?: readonly (string | null)[] | SQLWrapper | null;
+  scheduleCron?: string | SQLWrapper | null;
+  config?: Record<string, string | null> | SQLWrapper | null;
+  requirementsTxt?: string | SQLWrapper | null;
 }
 
 export interface MotherDuckUpdateFlightOptions {
   flightId: string | SQLWrapper;
-  name?: string | SQLWrapper;
-  scheduleCron?: string | SQLWrapper;
-  config?: Record<string, string> | SQLWrapper;
-  sourceCode?: string | SQLWrapper;
-  requirementsTxt?: string | SQLWrapper;
-  accessTokenName?: string | SQLWrapper;
-  flightSecretNames?: readonly string[] | SQLWrapper;
+  name?: string | SQLWrapper | null;
+  scheduleCron?: string | SQLWrapper | null;
+  config?: Record<string, string | null> | SQLWrapper | null;
+  sourceCode?: string | SQLWrapper | null;
+  requirementsTxt?: string | SQLWrapper | null;
+  accessTokenName?: string | SQLWrapper | null;
+  flightSecretNames?: readonly (string | null)[] | SQLWrapper | null;
 }
 
 /** @deprecated Use MotherDuckCreateFlightOptions. */
@@ -155,22 +155,22 @@ export interface MotherDuckCreateJobOptions {
   name: string | SQLWrapper;
   mdTokenName: string | SQLWrapper;
   sourceCode: string | SQLWrapper;
-  mdSecretNames?: readonly string[] | SQLWrapper;
-  scheduleCron?: string | SQLWrapper;
-  config?: Record<string, string> | SQLWrapper;
-  requirementsTxt?: string | SQLWrapper;
+  mdSecretNames?: readonly (string | null)[] | SQLWrapper | null;
+  scheduleCron?: string | SQLWrapper | null;
+  config?: Record<string, string | null> | SQLWrapper | null;
+  requirementsTxt?: string | SQLWrapper | null;
 }
 
 /** @deprecated Use MotherDuckUpdateFlightOptions. */
 export interface MotherDuckUpdateJobOptions {
   jobId: string | SQLWrapper;
-  name?: string | SQLWrapper;
-  scheduleCron?: string | SQLWrapper;
-  config?: Record<string, string> | SQLWrapper;
-  sourceCode?: string | SQLWrapper;
-  requirementsTxt?: string | SQLWrapper;
-  mdTokenName?: string | SQLWrapper;
-  mdSecretNames?: readonly string[] | SQLWrapper;
+  name?: string | SQLWrapper | null;
+  scheduleCron?: string | SQLWrapper | null;
+  config?: Record<string, string | null> | SQLWrapper | null;
+  sourceCode?: string | SQLWrapper | null;
+  requirementsTxt?: string | SQLWrapper | null;
+  mdTokenName?: string | SQLWrapper | null;
+  mdSecretNames?: readonly (string | null)[] | SQLWrapper | null;
 }
 
 export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
@@ -234,10 +234,14 @@ function motherDuckArg(value: MotherDuckSqlArgument): SQLWrapper {
 }
 
 function motherDuckMapArg(
-  value: Record<string, string> | SQLWrapper
+  value: Record<string, string | null> | SQLWrapper | null
 ): SQLWrapper {
-  if (isSQLWrapper(value)) {
+  if (value !== null && isSQLWrapper(value)) {
     return value;
+  }
+
+  if (value === null) {
+    return sql.param(null);
   }
 
   return sql`MAP(${sql.param(Object.keys(value))}, ${sql.param(

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -132,6 +132,56 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
   );
 });
 
+test('MotherDuck flight helpers emit explicit null optional parameters', () => {
+  const dialect = new DuckDBDialect();
+  const flightId = '80000000-0000-0000-0000-000000000001';
+
+  const createFlight = dialect.sqlToQuery(sql`
+    from ${mdCreateFlight({
+      name: 'null-options',
+      accessTokenName: 'pipeline_token',
+      sourceCode: 'print("hello")',
+      flightSecretNames: null,
+      scheduleCron: null,
+      config: { keep: 'value', clear: null },
+      requirementsTxt: null,
+    })}
+  `);
+
+  expect(createFlight.sql).toContain(
+    'from md_create_flight(name = $1, access_token_name = $2, source_code = $3, flight_secret_names = $4, schedule_cron = $5, config = MAP($6, $7), requirements_txt = $8)'
+  );
+  expect(createFlight.params).toEqual([
+    'null-options',
+    'pipeline_token',
+    'print("hello")',
+    null,
+    null,
+    ['keep', 'clear'],
+    ['value', null],
+    null,
+  ]);
+
+  const updateFlight = dialect.sqlToQuery(sql`
+    from ${mdUpdateFlight({
+      flightId,
+      config: null,
+      flightSecretNames: [null, 'warehouse'],
+      requirementsTxt: null,
+    })}
+  `);
+
+  expect(updateFlight.sql).toContain(
+    'from md_update_flight(flight_id = $1, config = $2, requirements_txt = $3, flight_secret_names = $4)'
+  );
+  expect(updateFlight.params).toEqual([
+    flightId,
+    null,
+    null,
+    [null, 'warehouse'],
+  ]);
+});
+
 test('MotherDuck job helpers emit named-parameter table functions', () => {
   const dialect = new DuckDBDialect();
   const jobId = '80000000-0000-0000-0000-000000000001';


### PR DESCRIPTION
## Summary

This updates the MotherDuck Flight helper option types and SQL generation so callers can pass explicit `null` for nullable optional fields. `undefined` still omits a named parameter, while `null` now emits a bound SQL `NULL`.

## Issue

The Flight table functions distinguish between an omitted named parameter and an explicit `NULL`. Omitted values leave fields untouched in update calls, while `NULL` can clear or reset nullable options such as requirements, config, schedules, and secret-name lists. The previous helper types allowed omission but did not model explicit `NULL` for those options, and `config: null` could not be emitted because config records were always converted through `MAP(...)`.

## Fix

The Flight and legacy Job helper option types now accept `null` for nullable optional arguments. Config maps also allow null values, preserving the generated `MAP(keys, values)` shape for object configs while emitting a plain bound `NULL` when the whole config is null.

The README now documents the `undefined` versus `null` behavior for Flight helpers.

## Validation

- `bun install`
- `bun test test/motherduck-functions.test.ts`
- `bun run build:declarations`
- `bun run build`
- `bun test`
