### PR TITLE
[codex] document flight secret env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,
 and `flightSecretNames`.
 
+`config` entries are exposed to Flight code as environment variables using the
+config key. `flightSecretNames` references MotherDuck `TYPE flights` secrets;
+each secret param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named
+`api_secret` with param `API_KEY` becomes `API_SECRET_API_KEY`.
+
 ## Querying
 
 All standard Drizzle query methods work:

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -214,6 +214,15 @@ const runs = await db.execute(sql`
 
 The older Job helper names are still exported for older MotherDuck deployments,
 but new code should use the Flight helpers.
+For optional Flight fields, `undefined` omits the named parameter and `null`
+emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
+or empty values for nullable Flight options such as `requirementsTxt`, `config`,
+and `flightSecretNames`.
+
+`config` entries are exposed to Flight code as environment variables using the
+config key. `flightSecretNames` references MotherDuck `TYPE flights` secrets;
+each secret param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named
+`api_secret` with param `API_KEY` becomes `API_SECRET_API_KEY`.
 
 ## OLAP builder (grouped measures)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -43,6 +43,7 @@ const allUsers = await db.select().from(users);
 - DuckLake catalog attach support
 - MotherDuck metadata table function helpers: mdAccessTokens(), mdListDives()
 - MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
+- Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 
 ## Important Notes
 


### PR DESCRIPTION
## Summary

This documents how MotherDuck Flight helper options map to runtime inputs.

## Issue

The README already showed how to call the Flight table function helpers, but it did not spell out how `flightSecretNames` becomes environment variables inside Flight code. The API docs also lacked the `undefined` versus `null` distinction that was added for nullable Flight helper options.

## Fix

The README and API docs now state that `undefined` omits an optional Flight named parameter, while `null` emits SQL `NULL`. They also explain that `config` entries are exposed by key and that params from referenced `TYPE flights` secrets are exposed as `<SECRET_NAME>_<KEY>` environment variables, with a concrete `api_secret` example.

The LLM context file now carries the same compact guidance.

## Validation

- `git diff --check`
- `bun run build`
