### PR TITLE
[codex] support more MotherDuck table functions

### DIFF
--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -178,8 +178,15 @@ export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
 export type MotherDuckTableFunction =
   | 'read_parquet'
   | 'parquet_scan'
+  | 'parquet_schema'
+  | 'parquet_metadata'
+  | 'parquet_file_metadata'
+  | 'parquet_kv_metadata'
+  | 'parquet_bloom_probe'
+  | 'parquet_full_metadata'
   | 'read_csv'
   | 'read_csv_auto'
+  | 'sniff_csv'
   | 'read_json'
   | 'read_json_auto'
   | 'read_ndjson'
@@ -189,8 +196,38 @@ export type MotherDuckTableFunction =
   | 'read_ndjson_objects'
   | 'read_text'
   | 'read_blob'
+  | 'read_duckdb'
+  | 'read_avro'
+  | 'glob'
+  | 'dbgen'
+  | 'dsdgen'
   | 'delta_scan'
-  | 'iceberg_scan';
+  | 'delta_list_files'
+  | 'iceberg_snapshots'
+  | 'iceberg_metadata'
+  | 'iceberg_scan'
+  | 'iceberg_partition_stats'
+  | 'iceberg_column_stats'
+  | 'st_read'
+  | 'st_readosm'
+  | 'ducklake_snapshots'
+  | 'ducklake_list_files'
+  | 'ducklake_table_info'
+  | 'ducklake_table_insertions'
+  | 'ducklake_table_deletions'
+  | 'ducklake_current_snapshot'
+  | 'ducklake_last_committed_snapshot'
+  | 'ducklake_merge_adjacent_files'
+  | 'ducklake_cleanup_old_files'
+  | 'ducklake_expire_snapshots'
+  | 'ducklake_set_option'
+  | 'ducklake_options'
+  | 'ducklake_add_data_files'
+  | 'ducklake_delete_orphaned_files'
+  | 'ducklake_set_commit_message'
+  | 'ducklake_rewrite_data_files'
+  | 'ducklake_flush_inlined_data'
+  | 'ducklake_settings';
 
 type MotherDuckSqlArgument =
   | SQLWrapper
@@ -214,8 +251,15 @@ type NamedParameter = {
 const motherDuckTableFunctionNames = new Set<MotherDuckTableFunction>([
   'read_parquet',
   'parquet_scan',
+  'parquet_schema',
+  'parquet_metadata',
+  'parquet_file_metadata',
+  'parquet_kv_metadata',
+  'parquet_bloom_probe',
+  'parquet_full_metadata',
   'read_csv',
   'read_csv_auto',
+  'sniff_csv',
   'read_json',
   'read_json_auto',
   'read_ndjson',
@@ -225,8 +269,38 @@ const motherDuckTableFunctionNames = new Set<MotherDuckTableFunction>([
   'read_ndjson_objects',
   'read_text',
   'read_blob',
+  'read_duckdb',
+  'read_avro',
+  'glob',
+  'dbgen',
+  'dsdgen',
   'delta_scan',
+  'delta_list_files',
+  'iceberg_snapshots',
+  'iceberg_metadata',
   'iceberg_scan',
+  'iceberg_partition_stats',
+  'iceberg_column_stats',
+  'st_read',
+  'st_readosm',
+  'ducklake_snapshots',
+  'ducklake_list_files',
+  'ducklake_table_info',
+  'ducklake_table_insertions',
+  'ducklake_table_deletions',
+  'ducklake_current_snapshot',
+  'ducklake_last_committed_snapshot',
+  'ducklake_merge_adjacent_files',
+  'ducklake_cleanup_old_files',
+  'ducklake_expire_snapshots',
+  'ducklake_set_option',
+  'ducklake_options',
+  'ducklake_add_data_files',
+  'ducklake_delete_orphaned_files',
+  'ducklake_set_commit_message',
+  'ducklake_rewrite_data_files',
+  'ducklake_flush_inlined_data',
+  'ducklake_settings',
 ]);
 
 function motherDuckArg(value: MotherDuckSqlArgument): SQLWrapper {

--- a/test/olap_helpers.test.ts
+++ b/test/olap_helpers.test.ts
@@ -365,9 +365,7 @@ test('MotherDuck scan helpers support remote extension metadata functions', () =
     })
   );
   const parquetMetadata = dialect.sqlToQuery(
-    motherDuckTableFunction('parquet_metadata', [
-      's3://bucket/events.parquet',
-    ])
+    motherDuckTableFunction('parquet_metadata', ['s3://bucket/events.parquet'])
   );
   const spatial = dialect.sqlToQuery(
     motherDuckTableFunction('st_read', ['s3://bucket/map.gpkg'])

--- a/test/olap_helpers.test.ts
+++ b/test/olap_helpers.test.ts
@@ -356,6 +356,43 @@ test('MotherDuck scan helpers emit md_run overrides and named parameters', () =>
   expect(delta.params).toEqual(['s3://bucket/delta', 'remote']);
 });
 
+test('MotherDuck scan helpers support remote extension metadata functions', () => {
+  const dialect = new DuckDBDialect();
+
+  const avro = dialect.sqlToQuery(
+    motherDuckTableFunction('read_avro', ['s3://bucket/events.avro'], {
+      mdRun: 'remote',
+    })
+  );
+  const parquetMetadata = dialect.sqlToQuery(
+    motherDuckTableFunction('parquet_metadata', [
+      's3://bucket/events.parquet',
+    ])
+  );
+  const spatial = dialect.sqlToQuery(
+    motherDuckTableFunction('st_read', ['s3://bucket/map.gpkg'])
+  );
+  const icebergStats = dialect.sqlToQuery(
+    motherDuckTableFunction('iceberg_column_stats', [
+      's3://bucket/warehouse/table',
+    ])
+  );
+  const duckLakeOptions = dialect.sqlToQuery(
+    motherDuckTableFunction('ducklake_options', ['ducklake:md:metadata'])
+  );
+
+  expect(avro.sql).toContain('read_avro($1, md_run = $2)');
+  expect(avro.params).toEqual(['s3://bucket/events.avro', 'remote']);
+  expect(parquetMetadata.sql).toContain('parquet_metadata($1)');
+  expect(parquetMetadata.params).toEqual(['s3://bucket/events.parquet']);
+  expect(spatial.sql).toContain('st_read($1)');
+  expect(spatial.params).toEqual(['s3://bucket/map.gpkg']);
+  expect(icebergStats.sql).toContain('iceberg_column_stats($1)');
+  expect(icebergStats.params).toEqual(['s3://bucket/warehouse/table']);
+  expect(duckLakeOptions.sql).toContain('ducklake_options($1)');
+  expect(duckLakeOptions.params).toEqual(['ducklake:md:metadata']);
+});
+
 test('MotherDuck scan helpers reject unsafe named parameters', () => {
   expect(() =>
     motherDuckTableFunction('read_parquet', ['s3://bucket/file.parquet'], {


### PR DESCRIPTION
## Summary

This expands the typed MotherDuck table-function helper surface so callers can build remote-execution SQL for more public DuckDB extension table functions. The previous allowlist covered common scan helpers, but rejected supported metadata and extension functions such as Avro reads, Parquet metadata, spatial reads, Iceberg metadata, and DuckLake metadata helpers.

The effect for users is that `motherDuckTableFunction()` can now compose these table functions with the same parameter safety and `md_run` handling as the existing scan helpers. Unsupported names and unsafe named parameters are still rejected.

## Root Cause

The helper maintained a narrow explicit allowlist. That was good for safety, but it lagged the public MotherDuck table-function surface and blocked valid table-function names at TypeScript compile time and runtime validation.

## Changes

- Added public DuckDB extension table-function names to the `MotherDuckTableFunction` type and runtime allowlist.
- Added coverage for representative Avro, Parquet metadata, spatial, Iceberg, and DuckLake SQL generation.

## Validation

- `bun test test/olap_helpers.test.ts test/motherduck-functions.test.ts`
- `bun run build`
- `bun test`
- `bun outdated`
- `git diff --check`
