### PR TITLE
[codex] support Flight run config

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ MotherDuck table function helpers are composable SQL fragments:
 import { sql } from 'drizzle-orm';
 import {
   mdCreateFlight,
-  mdFlightRuns,
   mdFlights,
+  mdRunFlight,
 } from '@duckdbfan/drizzle-duckdb';
 
 const flights = await db.execute(sql`
@@ -221,7 +221,6 @@ const [flight] = await db.execute(sql`
   select flight_id, status
   from ${mdCreateFlight({
     name: 'daily-refresh',
-    accessTokenName: 'pipeline_token',
     sourceCode: 'print("hello")',
     scheduleCron: '0 0 * * *',
   })}
@@ -229,7 +228,9 @@ const [flight] = await db.execute(sql`
 
 const runs = await db.execute(sql`
   select run_number, status, created_at
-  from ${mdFlightRuns(String(flight.flight_id))}
+  from ${mdRunFlight(String(flight.flight_id), {
+    config: { region: 'eu-west-1' },
+  })}
 `);
 ```
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@types/node": "25.9.1",
         "@vitest/ui": "4.1.8",
         "drizzle-orm": "0.45.2",
-        "prettier": "3.8.3",
+        "prettier": "3.8.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.0",
@@ -200,7 +200,7 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
     "rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/node": "25.9.1",
     "@vitest/ui": "4.1.8",
     "drizzle-orm": "0.45.2",
-    "prettier": "3.8.3",
+    "prettier": "3.8.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.0",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -44,6 +44,7 @@ export interface MotherDuckFlightRunRow {
   flight_id: string;
   flight_name: string;
   flight_version: number;
+  config: Record<string, string> | Map<string, string> | null;
   run_number: number | bigint;
   is_scheduled: boolean;
   status: string;
@@ -131,7 +132,7 @@ export interface MotherDuckPaginationOptions {
 
 export interface MotherDuckCreateFlightOptions {
   name: string | SQLWrapper;
-  accessTokenName: string | SQLWrapper;
+  accessTokenName?: string | SQLWrapper;
   sourceCode: string | SQLWrapper;
   flightSecretNames?: readonly (string | null)[] | SQLWrapper | null;
   scheduleCron?: string | SQLWrapper | null;
@@ -148,6 +149,10 @@ export interface MotherDuckUpdateFlightOptions {
   requirementsTxt?: string | SQLWrapper | null;
   accessTokenName?: string | SQLWrapper | null;
   flightSecretNames?: readonly (string | null)[] | SQLWrapper | null;
+}
+
+export interface MotherDuckRunFlightOptions {
+  config?: Record<string, string | null> | SQLWrapper | null;
 }
 
 /** @deprecated Use MotherDuckCreateFlightOptions. */
@@ -479,9 +484,13 @@ export function mdDeleteFlight(flightId: string | SQLWrapper): SQL {
   ]);
 }
 
-export function mdRunFlight(flightId: string | SQLWrapper): SQL {
+export function mdRunFlight(
+  flightId: string | SQLWrapper,
+  options: MotherDuckRunFlightOptions = {}
+): SQL {
   return motherDuckNamedFunction('md_run_flight', [
     { name: 'flight_id', value: flightId },
+    { name: 'config', value: motherDuckOptionalMapArg(options.config) },
   ]);
 }
 

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -81,6 +81,22 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
     'duckdb==1.0.0',
   ]);
 
+  const createFlightWithoutToken = dialect.sqlToQuery(sql`
+    select flight_id
+    from ${mdCreateFlight({
+      name: 'tokenless-refresh',
+      sourceCode: 'print("hello")',
+    })}
+  `);
+
+  expect(createFlightWithoutToken.sql).toContain(
+    'from md_create_flight(name = $1, source_code = $2)'
+  );
+  expect(createFlightWithoutToken.params).toEqual([
+    'tokenless-refresh',
+    'print("hello")',
+  ]);
+
   const flights = dialect.sqlToQuery(sql`
     select flight_name
     from ${mdFlights({ limit: 10, offset: 20 })}
@@ -112,6 +128,19 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
   expect(dialect.sqlToQuery(sql`from ${mdRunFlight(flightId)}`).sql).toContain(
     'from md_run_flight(flight_id = $1)'
   );
+  const runWithConfig = dialect.sqlToQuery(sql`
+    from ${mdRunFlight(flightId, {
+      config: { region: 'eu-west-1', dry_run: 'true' },
+    })}
+  `);
+  expect(runWithConfig.sql).toContain(
+    'from md_run_flight(flight_id = $1, config = MAP($2, $3))'
+  );
+  expect(runWithConfig.params).toEqual([
+    flightId,
+    ['region', 'dry_run'],
+    ['eu-west-1', 'true'],
+  ]);
   expect(
     dialect.sqlToQuery(sql`from ${mdCancelFlightRun(flightId, 2)}`).sql
   ).toContain('from md_cancel_flight_run(flight_id = $1, run_number = $2)');


### PR DESCRIPTION
## Summary

This updates the MotherDuck Flight helper surface to match the current public table function behavior.

- Makes `accessTokenName` optional for `mdCreateFlight`, so tokenless Flight creation emits only the required named parameters.
- Adds optional run-level `config` support to `mdRunFlight`, using the same map serialization as create and update helpers.
- Adds `config` to `MotherDuckFlightRunRow` and refreshes the README helper example.
- Updates Prettier from 3.8.3 to 3.8.4. The available `@types/node` patch was tested but not kept because it made the generated-schema typecheck exceed the existing test timeout.

## Validation

- `bun x vitest run test/motherduck-functions.test.ts`
- `bun x vitest run test/introspect.typecheck.test.ts`
- `bun run build`
- `bun test`
- `bun outdated`
