### PR TITLE
[codex] validate Flight config keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,9 +242,11 @@ or empty values for nullable Flight options such as `requirementsTxt`, `config`,
 and `flightSecretNames`.
 
 `config` entries are exposed to Flight code as environment variables using the
-config key. `flightSecretNames` references MotherDuck `TYPE flights` secrets;
-each secret param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named
-`api_secret` with param `API_KEY` becomes `API_SECRET_API_KEY`.
+config key. Config keys must not be empty and cannot contain `=` or NULL bytes;
+config values cannot contain NULL bytes. `flightSecretNames` references
+MotherDuck `TYPE flights` secrets; each secret param is exposed as
+`<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with param `API_KEY`
+becomes `API_SECRET_API_KEY`.
 
 ## Querying
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,14 +10,14 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.3-r.3",
         "@types/bun": "1.3.14",
-        "@types/node": "25.9.1",
-        "@vitest/ui": "4.1.8",
+        "@types/node": "25.9.3",
+        "@vitest/ui": "4.1.9",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.0",
-        "vitest": "4.1.8",
+        "vitest": "4.1.9",
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
@@ -110,25 +110,25 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
+    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.8", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ=="],
+    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.8", "", { "dependencies": { "@vitest/spy": "4.1.8", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.8", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "pathe": "^2.0.3" } }, "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg=="],
+    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "@vitest/utils": "4.1.8", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.8", "", {}, "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA=="],
+    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
 
-    "@vitest/ui": ["@vitest/ui@4.1.8", "", { "dependencies": { "@vitest/utils": "4.1.8", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.8" } }, "sha512-RUS2ZU2TsduVrI+9c12uTNaKrNUTsm6yFt3fueEUB9iKvyC2UP83F+sqIz00HQIah4UOL1TMoDAki8K0NjGvsA=="],
+    "@vitest/ui": ["@vitest/ui@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.8", "", { "dependencies": { "@vitest/pretty-format": "4.1.8", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg=="],
+    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -234,9 +234,11 @@
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 
-    "vitest": ["vitest@4.1.8", "", { "dependencies": { "@vitest/expect": "4.1.8", "@vitest/mocker": "4.1.8", "@vitest/pretty-format": "4.1.8", "@vitest/runner": "4.1.8", "@vitest/snapshot": "4.1.8", "@vitest/spy": "4.1.8", "@vitest/utils": "4.1.8", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.8", "@vitest/browser-preview": "4.1.8", "@vitest/browser-webdriverio": "4.1.8", "@vitest/coverage-istanbul": "4.1.8", "@vitest/coverage-v8": "4.1.8", "@vitest/ui": "4.1.8", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig=="],
+    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "bun-types/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
   }

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -220,9 +220,11 @@ or empty values for nullable Flight options such as `requirementsTxt`, `config`,
 and `flightSecretNames`.
 
 `config` entries are exposed to Flight code as environment variables using the
-config key. `flightSecretNames` references MotherDuck `TYPE flights` secrets;
-each secret param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named
-`api_secret` with param `API_KEY` becomes `API_SECRET_API_KEY`.
+config key. Config keys must not be empty and cannot contain `=` or NULL bytes;
+config values cannot contain NULL bytes. `flightSecretNames` references
+MotherDuck `TYPE flights` secrets; each secret param is exposed as
+`<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with param `API_KEY`
+becomes `API_SECRET_API_KEY`.
 
 ## OLAP builder (grouped measures)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -43,7 +43,7 @@ const allUsers = await db.select().from(users);
 - DuckLake catalog attach support
 - MotherDuck metadata table function helpers: mdAccessTokens(), mdListDives()
 - MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
-- Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
+- Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty and cannot contain = or NULL bytes. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 
 ## Important Notes
 

--- a/package.json
+++ b/package.json
@@ -31,14 +31,14 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.3-r.3",
     "@types/bun": "1.3.14",
-    "@types/node": "25.9.1",
-    "@vitest/ui": "4.1.8",
+    "@types/node": "25.9.3",
+    "@vitest/ui": "4.1.9",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.0",
-    "vitest": "4.1.8"
+    "vitest": "4.1.9"
   },
   "repository": {
     "type": "git",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -276,9 +276,39 @@ function motherDuckMapArg(
     return sql.param(null);
   }
 
+  validateMotherDuckConfigMap(value);
+
   return sql`MAP(${sql.param(Object.keys(value))}, ${sql.param(
     Object.values(value)
   )})`;
+}
+
+function validateMotherDuckConfigMap(
+  value: Record<string, string | null>
+): void {
+  for (const [key, configValue] of Object.entries(value)) {
+    if (key === '') {
+      throw new Error('MotherDuck Flight config keys must not be empty');
+    }
+
+    if (key.includes('=')) {
+      throw new Error(
+        `MotherDuck Flight config key "${key}" must not contain "="`
+      );
+    }
+
+    if (key.includes('\0')) {
+      throw new Error(
+        `MotherDuck Flight config key "${key}" must not contain a NULL byte`
+      );
+    }
+
+    if (configValue?.includes('\0')) {
+      throw new Error(
+        `MotherDuck Flight config value for key "${key}" must not contain a NULL byte`
+      );
+    }
+  }
 }
 
 function motherDuckOptionalMapArg(

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -211,6 +211,77 @@ test('MotherDuck flight helpers emit explicit null optional parameters', () => {
   ]);
 });
 
+test('MotherDuck flight config helpers reject invalid environment keys', () => {
+  const dialect = new DuckDBDialect();
+  const flightId = '80000000-0000-0000-0000-000000000001';
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdCreateFlight({
+        name: 'bad-config',
+        sourceCode: 'print("hello")',
+        config: { '': 'value' },
+      })}
+    `)
+  ).toThrow(/config keys must not be empty/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdRunFlight(flightId, {
+        config: { 'KEY=value': 'bad' },
+      })}
+    `)
+  ).toThrow(/must not contain "="/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdUpdateFlight({
+        flightId,
+        config: { 'BAD\0KEY': 'value' },
+      })}
+    `)
+  ).toThrow(/must not contain a NULL byte/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdUpdateFlight({
+        flightId,
+        config: { GOOD_KEY: 'bad\0value' },
+      })}
+    `)
+  ).toThrow(/value for key "GOOD_KEY" must not contain a NULL byte/i);
+});
+
+test('MotherDuck config validation preserves nulls and SQL wrapper escape hatches', () => {
+  const dialect = new DuckDBDialect();
+  const flightId = '80000000-0000-0000-0000-000000000001';
+
+  const explicitNullValue = dialect.sqlToQuery(sql`
+    from ${mdUpdateFlight({
+      flightId,
+      config: { OPTIONAL_KEY: null },
+    })}
+  `);
+  expect(explicitNullValue.sql).toContain(
+    'from md_update_flight(flight_id = $1, config = MAP($2, $3))'
+  );
+  expect(explicitNullValue.params).toEqual([
+    flightId,
+    ['OPTIONAL_KEY'],
+    [null],
+  ]);
+
+  const sqlWrapperConfig = dialect.sqlToQuery(sql`
+    from ${mdRunFlight(flightId, {
+      config: sql`MAP([''], ['advanced'])`,
+    })}
+  `);
+  expect(sqlWrapperConfig.sql).toContain(
+    "from md_run_flight(flight_id = $1, config = MAP([''], ['advanced']))"
+  );
+  expect(sqlWrapperConfig.params).toEqual([flightId]);
+});
+
 test('MotherDuck job helpers emit named-parameter table functions', () => {
   const dialect = new DuckDBDialect();
   const jobId = '80000000-0000-0000-0000-000000000001';
@@ -288,4 +359,28 @@ test('MotherDuck job helpers emit named-parameter table functions', () => {
   expect(
     dialect.sqlToQuery(sql`from ${mdGetJobVersion(jobId, 1)}`).sql
   ).toContain('from md_get_job_version(job_id = $1, version_number = $2)');
+});
+
+test('deprecated MotherDuck job config helpers share Flight validation', () => {
+  const dialect = new DuckDBDialect();
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdCreateJob({
+        name: 'bad-config',
+        mdTokenName: 'pipeline_token',
+        sourceCode: 'print("hello")',
+        config: { 'BAD=KEY': 'value' },
+      })}
+    `)
+  ).toThrow(/must not contain "="/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdUpdateJob({
+        jobId: '80000000-0000-0000-0000-000000000001',
+        config: { GOOD_KEY: 'bad\0value' },
+      })}
+    `)
+  ).toThrow(/value for key "GOOD_KEY" must not contain a NULL byte/i);
 });


### PR DESCRIPTION
## Summary

This PR makes the MotherDuck Flight helper config map fail fast for keys and values that cannot be used as runtime environment variables. The helper now rejects empty config keys, config keys containing `=`, NULL bytes in config keys, and NULL bytes in config values before emitting SQL.

The user-facing effect is a clearer local error while building the query instead of generating a `md_create_flight`, `md_update_flight`, or `md_run_flight` call that will fail later when the Flight runtime tries to materialize config into environment variables.

The deprecated Job helper names share the same config serialization path, so their create and update helpers now get the same validation while remaining backwards compatible. SQL wrapper config values are still passed through unchanged for advanced callers who intentionally provide their own SQL fragment.

## Root Cause

The helper converted plain JavaScript config objects directly into a DuckDB `MAP(keys, values)` SQL fragment without checking whether those keys and values were valid for Flight runtime environment variables. That allowed malformed keys to be represented in generated SQL even though they cannot run successfully.

## Fix

- Added validation in the shared `motherDuckMapArg` path used by Flight create, update, and run helpers.
- Preserved explicit `null` config values and SQL-wrapper escape hatches.
- Added regression coverage for Flight helpers and deprecated Job helper aliases.
- Documented the config key and value constraints in README, docs, and LLM context.
- Updated dev dependencies to current safe patch versions: `@types/node` `25.9.3`, `vitest` `4.1.9`, and `@vitest/ui` `4.1.9`.

## Validation

- `bun x vitest run test/motherduck-functions.test.ts`
- `bun x vitest run test/introspect.typecheck.test.ts`
- `bun run build`
- Runtime SQL-generation probe for invalid and valid Flight config maps
- `bun test` (`633 pass`, `7 skip`, `0 fail`)
- `bun x prettier --check README.md docs/api/olap-helpers.md package.json src/motherduck.ts test/motherduck-functions.test.ts`
- `git diff --check`
- `bun outdated` reports no remaining package updates
