### PR TITLE
[codex] refactor result row mapping

### DIFF
--- a/src/sql/result-mapper.ts
+++ b/src/sql/result-mapper.ts
@@ -30,6 +30,7 @@ type DecoderInput<TDecoder extends DriverValueDecoder<unknown, unknown>> =
   Parameters<TDecoder['mapFromDriverValue']>[0];
 
 type NullifyMap = Record<string, string | false>;
+type ResultRow = Record<string, unknown>;
 
 const passthroughDecoder: DriverValueDecoder<unknown, unknown> = {
   mapFromDriverValue: (value) => value,
@@ -315,39 +316,59 @@ function mapDriverValue(
   return decoder.mapFromDriverValue(toDecoderInput(decoder, rawValue));
 }
 
+function mapFieldValue(
+  decoder: DriverValueDecoder<unknown, unknown>,
+  rawValue: unknown
+): unknown {
+  const normalized = normalizeInet(rawValue);
+  return normalized === null ? null : mapDriverValue(decoder, normalized);
+}
+
+function assignResultPath(
+  result: ResultRow,
+  path: string[],
+  value: unknown
+): void {
+  if (path.length === 0) {
+    return;
+  }
+
+  let node = result;
+  for (
+    let pathChunkIndex = 0;
+    pathChunkIndex < path.length - 1;
+    pathChunkIndex += 1
+  ) {
+    const pathChunk = path[pathChunkIndex] as string;
+
+    if (!(pathChunk in node)) {
+      node[pathChunk] = {};
+    }
+
+    node = node[pathChunk] as ResultRow;
+  }
+
+  node[path[path.length - 1] as string] = value;
+}
+
 export function mapResultRow<TResult>(
   columns: SelectedFieldsOrdered<AnyColumn>,
   row: unknown[],
   joinsNotNullableMap: Record<string, boolean> | undefined
 ): TResult {
   const nullifyMap: NullifyMap = {};
+  const result: ResultRow = {};
 
-  const result = columns.reduce<Record<string, any>>(
-    (acc, { path, field }, columnIndex) => {
-      const decoder = resolveFieldDecoder(field);
-      let node = acc;
-      for (const [pathChunkIndex, pathChunk] of path.entries()) {
-        if (pathChunkIndex < path.length - 1) {
-          if (!(pathChunk in node)) {
-            node[pathChunk] = {};
-          }
-          node = node[pathChunk];
-          continue;
-        }
+  for (const [columnIndex, { path, field }] of columns.entries()) {
+    const decoder = resolveFieldDecoder(field);
+    const value = mapFieldValue(decoder, row[columnIndex]!);
 
-        const rawValue = normalizeInet(row[columnIndex]!);
+    assignResultPath(result, path, value);
 
-        const value = (node[pathChunk] =
-          rawValue === null ? null : mapDriverValue(decoder, rawValue));
-
-        if (joinsNotNullableMap) {
-          trackJoinedObjectNullability(nullifyMap, field, path, value);
-        }
-      }
-      return acc;
-    },
-    {}
-  );
+    if (joinsNotNullableMap) {
+      trackJoinedObjectNullability(nullifyMap, field, path, value);
+    }
+  }
 
   if (joinsNotNullableMap && Object.keys(nullifyMap).length > 0) {
     for (const [objectName, tableName] of Object.entries(nullifyMap)) {


### PR DESCRIPTION
## Summary

This PR keeps the result row mapping behavior unchanged while making the implementation smaller and easier to audit.

The existing `mapResultRow` function performed three jobs in one reducer: normalizing and decoding each field value, walking the selected field path to assign nested result objects, and tracking joined-object nullability. That made the hot path harder to read and kept the accumulator typed as `Record<string, any>`.

The refactor extracts `mapFieldValue` for the DuckDB-specific inet normalization plus Drizzle decoder mapping, and `assignResultPath` for nested result object assignment. `mapResultRow` now has a direct loop over selected columns and keeps the join-nullification logic visible at the call site.

## User impact

There is no intended SQL or runtime behavior change. Users should see the same mapped rows, including nested selection objects and nullified joined objects, with a smaller implementation surface for future DuckDB result-shape fixes.

## Root cause

The old reducer mixed value decoding, nested object construction, and join nullability bookkeeping in one block. That duplication of responsibilities made the code more fragile than necessary for a central result-mapping path.

## Fix

- Added a typed `ResultRow` alias for nested mapping state.
- Extracted `mapFieldValue` to isolate driver-value normalization and decoder mapping.
- Extracted `assignResultPath` to centralize selected-field path assignment.
- Replaced the reducer in `mapResultRow` with a straightforward column loop.

## Validation

- `bun x prettier --write src/sql/result-mapper.ts`
- `bun x vitest run test/result-mapper.unit.test.ts`
- `bun run build:declarations`
- `bun run build`
- `bun test`
- `git diff --check`
