### PR TITLE
[codex] filter active access tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ MotherDuck table function helpers are composable SQL fragments:
 ```typescript
 import { sql } from 'drizzle-orm';
 import {
+  mdAccessTokens,
   mdCreateFlight,
   mdFlights,
   mdRunFlight,
@@ -215,6 +216,11 @@ import {
 const flights = await db.execute(sql`
   select flight_id, flight_name, current_version
   from ${mdFlights({ limit: 25 })}
+`);
+
+const activeTokens = await db.execute(sql`
+  select token_name, token_type
+  from ${mdAccessTokens({ activeOnly: true })}
 `);
 
 const [flight] = await db.execute(sql`

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.3-r.3",
         "@types/bun": "1.3.14",
-        "@types/node": "25.9.3",
+        "@types/node": "26.0.0",
         "@vitest/ui": "4.1.9",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
@@ -110,7 +110,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@25.9.3", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg=="],
+    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
@@ -228,7 +228,7 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
@@ -241,5 +241,7 @@
     "bun-types/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -170,6 +170,11 @@ const tokens = await db.execute(sql`
   order by token_name
 `);
 
+const activeTokens = await db.execute(sql`
+  select token_name, token_type
+  from ${mdAccessTokens({ activeOnly: true })}
+`);
+
 const divesWithResources = await db.execute(sql`
   select id, required_resources
   from ${mdListDives()}
@@ -177,7 +182,7 @@ const divesWithResources = await db.execute(sql`
 `);
 ```
 
-`mdListDives()` includes `required_resources` on supported MotherDuck deployments. The column is a list of structs with `name`, `alias`, `url`, `id`, and `resource_type` fields.
+`mdAccessTokens({ activeOnly: true })` filters out rows whose `expire_at` is in the past. `mdListDives()` includes `required_resources` on supported MotherDuck deployments. The column is a list of structs with `name`, `alias`, `url`, `id`, and `resource_type` fields.
 
 ## MotherDuck Flight table functions
 
@@ -186,6 +191,7 @@ inspecting MotherDuck Flights through Drizzle SQL templates:
 
 ```typescript
 import {
+  mdAccessTokens,
   mdCreateFlight,
   mdFlightRuns,
   mdFlights,
@@ -194,6 +200,11 @@ import {
 const flights = await db.execute(sql`
   select flight_id, flight_name, current_version
   from ${mdFlights({ limit: 25 })}
+`);
+
+const activeTokens = await db.execute(sql`
+  select token_name, token_type
+  from ${mdAccessTokens({ activeOnly: true })}
 `);
 
 const [flight] = await db.execute(sql`

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -41,7 +41,7 @@ const allUsers = await db.select().from(users);
 - Migrations and schema introspection
 - MotherDuck cloud support
 - DuckLake catalog attach support
-- MotherDuck metadata table function helpers: mdAccessTokens(), mdListDives()
+- MotherDuck metadata table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives()
 - MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
 - Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty and cannot contain = or NULL bytes. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.3-r.3",
     "@types/bun": "1.3.14",
-    "@types/node": "25.9.3",
+    "@types/node": "26.0.0",
     "@vitest/ui": "4.1.9",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -8,6 +8,11 @@ export interface MotherDuckAccessTokenRow {
   expire_at: Date | string | null;
 }
 
+export interface MotherDuckAccessTokenOptions {
+  activeOnly?: boolean;
+  asOf?: string | SQLWrapper;
+}
+
 export interface MotherDuckRequiredResource {
   name: string | null;
   alias: string | null;
@@ -408,8 +413,17 @@ function assertRunMode(mode: MotherDuckRunMode): MotherDuckRunMode {
   return mode;
 }
 
-export function mdAccessTokens(): SQL {
-  return sql`md_access_tokens()`;
+export function mdAccessTokens(
+  options: MotherDuckAccessTokenOptions = {}
+): SQL {
+  if (!options.activeOnly) {
+    return sql`md_access_tokens()`;
+  }
+
+  const asOf =
+    options.asOf === undefined ? sql`now()` : motherDuckArg(options.asOf);
+
+  return sql`(select token_name, token_type, created_ts, expire_at from md_access_tokens() where expire_at is null or expire_at > ${asOf}) as active_access_tokens`;
 }
 
 export function mdListDives(): SQL {

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -50,6 +50,24 @@ test('MotherDuck table function helpers emit callable SQL', () => {
   expect(dives.params).toEqual([]);
 });
 
+test('MotherDuck access token helper can filter expired tokens', () => {
+  const dialect = new DuckDBDialect();
+
+  const activeTokens = dialect.sqlToQuery(sql`
+    select token_name
+    from ${mdAccessTokens({
+      activeOnly: true,
+      asOf: '2026-06-19T00:00:00.000Z',
+    })}
+    order by token_name
+  `);
+
+  expect(activeTokens.sql).toContain(
+    'from (select token_name, token_type, created_ts, expire_at from md_access_tokens() where expire_at is null or expire_at > $1) as active_access_tokens'
+  );
+  expect(activeTokens.params).toEqual(['2026-06-19T00:00:00.000Z']);
+});
+
 test('MotherDuck flight helpers emit named-parameter table functions', () => {
   const dialect = new DuckDBDialect();
   const flightId = '80000000-0000-0000-0000-000000000001';


### PR DESCRIPTION
## Summary

Adds an opt-in active-token filter to the MotherDuck access token helper and refreshes the remaining outdated Node type package.

## Issue

`mdAccessTokens()` exposed the raw `md_access_tokens()` table function only. Callers that wanted to present token choices for Flight creation or updates had to remember to filter expired rows themselves, which is easy to miss because expired access tokens still appear in the metadata result set but cannot authenticate a Flight run.

## Cause and effect

The raw helper is still useful for auditing all token rows, but UI and automation paths usually need only active token labels. Without a first-class helper option, each caller had to duplicate the `expire_at is null or expire_at > now()` predicate, and inconsistent filtering could offer an expired token to users.

## Fix

`mdAccessTokens({ activeOnly: true })` now emits a subquery over the public `md_access_tokens()` columns and filters out rows whose `expire_at` is in the past. The default `mdAccessTokens()` output remains unchanged for backward compatibility. The helper also accepts `asOf` for deterministic tests or caller-provided SQL expressions.

Docs and LLM context now show the active-token option, and `@types/node` is updated from `25.9.3` to `26.0.0` after passing the build and test suite.

I also tested `@duckdb/node-api@1.5.4-r.1`, but did not keep it because the full test suite showed MotherDuck integration rejects DuckDB v1.5.4 while the current supported MotherDuck extension is still v1.5.3.

## Validation

- `bun test test/motherduck-functions.test.ts test/duckdb-15-types.test.ts test/node-api.test.ts`
- `bun run build:declarations`
- `bun run build`
- `bun test`
- Runtime DuckDB predicate proof with in-memory token rows returned only future and non-expiring tokens
- `git diff --check`
