### PR TITLE
[codex] refactor pool waiter settlement

### DIFF
--- a/src/pool.ts
+++ b/src/pool.ts
@@ -128,10 +128,21 @@ export function createDuckDBConnectionPool(
     metadata.delete(connection);
   };
 
-  const rejectWaiter = (waiter: WaitingRequest): void => {
+  const resolveWaiter = (
+    waiter: WaitingRequest,
+    connection: DuckDBConnection
+  ): void => {
     clearTimeout(waiter.timeoutId);
-    waiter.reject(new Error(POOL_CLOSED_MESSAGE));
+    waiter.resolve(connection);
   };
+
+  const rejectWaiter = (waiter: WaitingRequest, error: Error): void => {
+    clearTimeout(waiter.timeoutId);
+    waiter.reject(error);
+  };
+
+  const toError = (error: unknown): Error =>
+    error instanceof Error ? error : new Error(String(error));
 
   const hasExceededMaxLifetime = (
     meta: ConnectionMetadata,
@@ -248,13 +259,12 @@ export function createDuckDBConnectionPool(
 
     const waiter = waiting.shift();
     if (waiter) {
-      clearTimeout(waiter.timeoutId);
       const now = Date.now();
       const meta = readMetadata(connection, now);
 
       if (closed) {
         await dropConnection(connection);
-        waiter.reject(new Error(POOL_CLOSED_MESSAGE));
+        rejectWaiter(waiter, new Error(POOL_CLOSED_MESSAGE));
         return;
       }
 
@@ -262,16 +272,16 @@ export function createDuckDBConnectionPool(
         await dropConnection(connection);
         try {
           const replacement = await acquire();
-          waiter.resolve(replacement);
+          resolveWaiter(waiter, replacement);
         } catch (error) {
-          waiter.reject(error as Error);
+          rejectWaiter(waiter, toError(error));
         }
         return;
       }
 
       markConnectionUsed(connection, meta, now);
       leased.add(connection);
-      waiter.resolve(connection);
+      resolveWaiter(waiter, connection);
       return;
     }
 
@@ -301,7 +311,7 @@ export function createDuckDBConnectionPool(
     // Clear all waiting requests with their timeouts
     const waiters = waiting.splice(0, waiting.length);
     for (const waiter of waiters) {
-      rejectWaiter(waiter);
+      rejectWaiter(waiter, new Error(POOL_CLOSED_MESSAGE));
     }
 
     // Close all idle connections (use allSettled to ensure all are attempted)


### PR DESCRIPTION
## Summary

This refactor centralizes how the DuckDB connection pool settles queued acquire requests.

Previously, the release and close paths each cleared waiter timeouts directly before resolving or rejecting queued acquires. That kept the behavior correct, but it spread the timeout cleanup contract across multiple branches in the pool lifecycle.

The user-facing effect is intentionally neutral: queued acquire requests still resolve with a released or replacement connection, and they still reject when the pool closes. The refactor makes those paths share small local helpers so future pool changes are less likely to miss timeout cleanup.

## Root Cause

The pool queue stores a timeout handle with every waiting acquire request. Any code path that settles that waiter must clear the timeout first. The same operation was repeated in release handling and close handling, and one replacement-connection error path still relied on a broad error cast.

## Fix

- Added local `resolveWaiter` and `rejectWaiter` helpers inside `createDuckDBConnectionPool`.
- Routed release, replacement connection, and close paths through those helpers.
- Normalized unknown replacement-acquire failures into `Error` before rejecting a waiter.

## Validation

- `bun x vitest run test/pool.errors.test.ts test/pool.recycle.test.ts test/pool-close.test.ts`
- `bun test`
- `bun run build`
