### PR TITLE
[codex] update DuckDB node API test pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install @duckdbfan/drizzle-duckdb @duckdb/node-api
 pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.3-r.3`. The repo now develops against `1.5.3-r.3`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.4-r.1`. The repo now develops against `1.5.4-r.1`, and `1.4.4-r.1` remains supported.
 Tested `drizzle-orm` versions currently span `0.40.1` through `0.45.x`.
 
 ## Quick Start

--- a/bun.lock
+++ b/bun.lock
@@ -8,15 +8,15 @@
         "node-sql-parser": "^5.4.0",
       },
       "devDependencies": {
-        "@duckdb/node-api": "1.5.3-r.3",
+        "@duckdb/node-api": "1.5.4-r.1",
         "@types/bun": "1.3.14",
-        "@types/node": "26.0.0",
+        "@types/node": "26.0.1",
         "@vitest/ui": "4.1.9",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
-        "uuid": "14.0.0",
+        "uuid": "14.0.1",
         "vitest": "4.1.9",
       },
       "peerDependencies": {
@@ -32,25 +32,25 @@
     "esbuild": "0.28.0",
   },
   "packages": {
-    "@duckdb/node-api": ["@duckdb/node-api@1.5.3-r.3", "", { "dependencies": { "@duckdb/node-bindings": "1.5.3-r.3" } }, "sha512-FzuL6sevuFfEFwkgiUMRMUAj4TaVqV//L0oo2FVZ9s9oYpLpALF9qZyQv2ucclTNQZwDCkm8+e6yLMc6t8IjlA=="],
+    "@duckdb/node-api": ["@duckdb/node-api@1.5.4-r.1", "", { "dependencies": { "@duckdb/node-bindings": "1.5.4-r.1" } }, "sha512-3PYk/4//svuYmb9RYVM71cCoNa6ngoYWwrMhJaqbm010txzIMWbJCbxrFeqDl+krdIug+Hc/MNCeS0gHsTXSIw=="],
 
-    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.3-r.3", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.3-r.3", "@duckdb/node-bindings-darwin-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64": "1.5.3-r.3", "@duckdb/node-bindings-linux-arm64-musl": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64": "1.5.3-r.3", "@duckdb/node-bindings-linux-x64-musl": "1.5.3-r.3", "@duckdb/node-bindings-win32-arm64": "1.5.3-r.3", "@duckdb/node-bindings-win32-x64": "1.5.3-r.3" } }, "sha512-Dphw1a9kKXZnCiWX1YCEAJsQ7WJQO2Ikgxy7m8jy0QVXqAwB9esr5NGsuEL3vMKL7velZHeZCjGOMnHZEcIsdg=="],
+    "@duckdb/node-bindings": ["@duckdb/node-bindings@1.5.4-r.1", "", { "dependencies": { "detect-libc": "^2.1.2" }, "optionalDependencies": { "@duckdb/node-bindings-darwin-arm64": "1.5.4-r.1", "@duckdb/node-bindings-darwin-x64": "1.5.4-r.1", "@duckdb/node-bindings-linux-arm64": "1.5.4-r.1", "@duckdb/node-bindings-linux-arm64-musl": "1.5.4-r.1", "@duckdb/node-bindings-linux-x64": "1.5.4-r.1", "@duckdb/node-bindings-linux-x64-musl": "1.5.4-r.1", "@duckdb/node-bindings-win32-arm64": "1.5.4-r.1", "@duckdb/node-bindings-win32-x64": "1.5.4-r.1" } }, "sha512-v834OZZKQ59yAvh8GOEmM+R1foPNgdMGL0VTBgHywgblgQNyq11HvWgT4QGJIUFfo/cQ9WFyf1MFhK0+hV1aiA=="],
 
-    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.3-r.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ttD8QBesgzHu7Sc4qouuIGLM7PWedLW8GvFbnZEyMqk24mQz1HWFgaT0ivw6nDRaDPUQLB9QnAOq8MZUh1zWHQ=="],
+    "@duckdb/node-bindings-darwin-arm64": ["@duckdb/node-bindings-darwin-arm64@1.5.4-r.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fl8EC5xdmI7VAI7bX4W6D7lOGNtxyLvSxGjOY8Ov7viVEKwIcBXXKlMPgh3sw+PiVlwZhKlknuCI8BL5xXpSDg=="],
 
-    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.3-r.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-Vp9MYtoYf6zUWHdCmHXwUcJlHq3YaaIeULWeSiPUM1hsDflLiZKXtz5i250Ulz03VsfWBjpO4wdM99sjjrYKkg=="],
+    "@duckdb/node-bindings-darwin-x64": ["@duckdb/node-bindings-darwin-x64@1.5.4-r.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-E8bECZ6abJqunPqVR1NA0Zho7qxanfDWWFuJrKMsU1NCUqyGLyhXqZwsRHAx7J6jrM+lhQ7wOZj1x/N4OVml3A=="],
 
-    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-3HLcrzQE83947JS51UVR7C9qnXQMltCOk4Dnhiz1CD+9u32DGLMgPTIIxclk7O+Q7EwfqzD8JV86Ud+LT1crcQ=="],
+    "@duckdb/node-bindings-linux-arm64": ["@duckdb/node-bindings-linux-arm64@1.5.4-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-4EsB+cgRqOE++mdPQ2ZoGJCg4ylmuqdbLDtmo3L19B+C5OzGmrhxlKD4o75eGEtfO52M+w+TdL0qhy0H5XvaKQ=="],
 
-    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-IadRyx+98FEynKLXAk2MzReinFgduiDXgNd5Z8c5VKch+8FgBfqkEUYGOnBMMUPT8kuheKdLj23vpWXaCzOgoQ=="],
+    "@duckdb/node-bindings-linux-arm64-musl": ["@duckdb/node-bindings-linux-arm64-musl@1.5.4-r.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-96Pyk5Syy18S5DSN0CKkOQ7/CsyVGRML8ewox1qpFDjYvPH1VsULlQoIRwbpw7mkFEy17wuWmbwzb7oKu/nGMw=="],
 
-    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-TXndAL0ZoETq17Df6wB+SUZjLGDmOsKuDSySxB+wy6sHfpRtbDgQibyXRlajVeUkRDwSzBFC5ymy16YG0Fl4iw=="],
+    "@duckdb/node-bindings-linux-x64": ["@duckdb/node-bindings-linux-x64@1.5.4-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-IldapRydno5kf4VkPCe8yK+j4pCg+j6Qs46UmLnKex/mtIdJa7ifhMYRkvdc5KIAFEC0eEL5c830QeuwcUROyg=="],
 
-    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.3-r.3", "", { "os": "linux", "cpu": "x64" }, "sha512-5bulS16YhftXcarki4tvCufVslntpQDLOEF6RZ+FSMOGiv5d7SDXqklmVRy4DKW3C5ekgN7S2oYzuGL/ss9BuA=="],
+    "@duckdb/node-bindings-linux-x64-musl": ["@duckdb/node-bindings-linux-x64-musl@1.5.4-r.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tWgnttlKfWTktyv+m9YbxaedKBon5wmUoJ9DaIbE3D98KhhUaqmJhnjzso9O8hp6WUeRmwXR//hpT/X6Ft9nYA=="],
 
-    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.3-r.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-55Vu13S0jUudiAGlNWJd7UvlW1iKjwWehD8s93jBCNm0AdE/EJN4nz5rQ0IuWzPWXpMjAYuKu00yE7NdtbTyug=="],
+    "@duckdb/node-bindings-win32-arm64": ["@duckdb/node-bindings-win32-arm64@1.5.4-r.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-77apmuNo51bPZzv8xjdeCp+hlU6JLwMPtS1CMViy83ONTsah+CGnpBx1lCnEqPL5Va0meufZyjSdZCVCijLdDA=="],
 
-    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.3-r.3", "", { "os": "win32", "cpu": "x64" }, "sha512-rlOc9ltWQNHuDq99Ah8XaD80nN1ucrSK5AcH/7ibSp9ogX/jswPYlRVE7ODFJAjnQNf8bVvs++Mp+wyGvuG7ag=="],
+    "@duckdb/node-bindings-win32-x64": ["@duckdb/node-bindings-win32-x64@1.5.4-r.1", "", { "os": "win32", "cpu": "x64" }, "sha512-Wme7dScBGqjn2PUJ+RLFiFAblW1qQRBraX7SJc4uKtftZiUJJWZapEUh+doGfb68Qxvw8JhlMBSdaUsSUDJYsw=="],
 
     "@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" } }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
@@ -110,7 +110,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.0.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA=="],
+    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
@@ -230,7 +230,7 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 

--- a/docs/features/duckdb-types.md
+++ b/docs/features/duckdb-types.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 DuckDB provides several types not found in standard Postgres. This guide covers how to use them with Drizzle.
 
-DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values. For portable geometry output, project with `ST_AsText(...)` or `ST_AsWKB(...)`.
+DuckDB 1.5 adds native `VARIANT` and moves `GEOMETRY` into core DuckDB. With `@duckdb/node-api@1.5.4-r.1`, `VARIANT` values materialize into JavaScript values. For portable geometry output, project with `ST_AsText(...)` or `ST_AsWKB(...)`.
 
 ## Import
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,7 +39,7 @@ pnpm add @duckdbfan/drizzle-duckdb @duckdb/node-api
 yarn add @duckdbfan/drizzle-duckdb @duckdb/node-api
 ```
 
-Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.3-r.3`. The repo now develops against `1.5.3-r.3`, and `1.4.4-r.1` remains supported.
+Supported client versions include `@duckdb/node-api@1.4.4-r.1` and `@duckdb/node-api@1.5.4-r.1`. The repo now develops against `1.5.4-r.1`, and `1.4.4-r.1` remains supported.
 
 ## Requirements
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -49,7 +49,7 @@ const allUsers = await db.select().from(users);
 
 - Do NOT use Postgres json or jsonb columns - use duckDbJson() instead
 - Current DuckDB 1.4.x and 1.5.x builds do not support `SAVEPOINT`. Nested transactions reuse the outer transaction and mark it for rollback on nested errors.
-- DuckDB 1.5 adds `VARIANT` and built-in `GEOMETRY`. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values. Project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output.
+- DuckDB 1.5 adds `VARIANT` and built-in `GEOMETRY`. With `@duckdb/node-api@1.5.4-r.1`, `VARIANT` values materialize into JavaScript values. Project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output.
 - Array operators are automatically rewritten to DuckDB functions
 
 ## Documentation

--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -23,7 +23,7 @@ This page documents known differences between Drizzle DuckDB and Drizzle's stand
 | Concurrent queries                   | Partial | One query per connection; use pooling for parallelism                                                                                    |
 | Prepared statements                  | Partial | Optional per-connection cache via `prepareCache`; no named statements                                                                    |
 | JSON/JSONB columns                   | None    | Use `duckDbJson()` instead                                                                                                               |
-| `VARIANT` / `GEOMETRY` raw JS values | Partial | `VARIANT` materializes with `@duckdb/node-api@1.5.3-r.3`; project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output. |
+| `VARIANT` / `GEOMETRY` raw JS values | Partial | `VARIANT` materializes with `@duckdb/node-api@1.5.4-r.1`; project geometry with `ST_AsText(...)` or `ST_AsWKB(...)` for portable output. |
 | Streaming results                    | Partial | Default materialized; use `executeBatches()` / `executeArrow()` for chunks                                                               |
 | Relational queries                   | Full    | With schema configuration                                                                                                                |
 
@@ -52,7 +52,7 @@ await db.transaction(async (tx) => {
 
 ## DuckDB 1.5 Core Types
 
-DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. With `@duckdb/node-api@1.5.3-r.3`, `VARIANT` values materialize into JavaScript values.
+DuckDB 1.5 adds native `VARIANT` and built-in `GEOMETRY` columns. With `@duckdb/node-api@1.5.4-r.1`, `VARIANT` values materialize into JavaScript values.
 
 Use explicit projections when you need stable text or binary output:
 

--- a/package.json
+++ b/package.json
@@ -29,15 +29,15 @@
     }
   },
   "devDependencies": {
-    "@duckdb/node-api": "1.5.3-r.3",
+    "@duckdb/node-api": "1.5.4-r.1",
     "@types/bun": "1.3.14",
-    "@types/node": "26.0.0",
+    "@types/node": "26.0.1",
     "@vitest/ui": "4.1.9",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
-    "uuid": "14.0.0",
+    "uuid": "14.0.1",
     "vitest": "4.1.9"
   },
   "repository": {

--- a/test/duckdb-15-types.test.ts
+++ b/test/duckdb-15-types.test.ts
@@ -19,7 +19,7 @@ afterAll(() => {
   instance?.closeSync?.();
 });
 
-test('VARIANT columns materialize with node-api 1.5.3', async () => {
+test('VARIANT columns materialize with node-api 1.5.x', async () => {
   try {
     await db.execute(
       sql`create table duckdb_variant_test (id integer, data variant)`


### PR DESCRIPTION
## Summary

This refreshes the development and test pin for DuckDB Node API from `1.5.3-r.3` to `1.5.4-r.1`, along with patch-level dev dependency updates for `@types/node` and `uuid`.

The package peer range already allows DuckDB Node API `1.5.x`, so this does not change the supported public range or drop compatibility with `1.4.4-r.1`. The docs and the DuckDB 1.5 VARIANT regression test name now reflect the newly validated client version.

## User Impact

Users installing compatible `@duckdb/node-api` releases continue to use the same public API. The repository now tests against the latest available `1.5.4-r.1` client so regressions in DuckDB 1.5 type materialization, timestamps, transactions, and package import behavior are caught against the newer runtime.

## Cause and Fix

The repo was still developing against `@duckdb/node-api@1.5.3-r.3` while `1.5.4-r.1` is available. I bumped the dev dependency and lockfile, refreshed small patch dev dependencies, and updated version-specific documentation references. No generated `dist` files were edited by hand.

## Validation

- `bun outdated`
- `bun test test/package-config.test.ts test/node-api.test.ts test/duckdb-15-types.test.ts test/timestamps.test.ts test/transactions.savepoint.test.ts`
- `bun run build`
- `git diff --check`
- `bun test`
