### PR TITLE
[codex] share top-level type splitter

### DIFF
--- a/src/columns.ts
+++ b/src/columns.ts
@@ -16,6 +16,7 @@ import {
   type TimestampValueWrapper,
 } from './value-wrappers-core.ts';
 import { coerceArrayString as parseArrayString } from './array-literals.ts';
+import { splitTopLevel } from './sql/split-top-level.ts';
 
 export { coerceArrayString } from './array-literals.ts';
 
@@ -82,30 +83,6 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function isStructType(typeHint: string | undefined): typeHint is StructColType {
   return /^STRUCT\s*\(/i.test(typeHint?.trim() ?? '');
-}
-
-function splitTopLevel(input: string, delimiter: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let current = '';
-
-  for (let index = 0; index < input.length; index += 1) {
-    const char = input[index]!;
-    if (char === '(') depth += 1;
-    if (char === ')') depth = Math.max(0, depth - 1);
-    if (char === delimiter && depth === 0) {
-      parts.push(current);
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-
-  if (current) {
-    parts.push(current);
-  }
-
-  return parts;
 }
 
 function parseStructSchema(

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -1,6 +1,9 @@
 import { sql, type SQL } from 'drizzle-orm';
 import type { RowData } from './client.ts';
 import type { DuckDBDatabase } from './driver.ts';
+import { splitTopLevel } from './sql/split-top-level.ts';
+
+export { splitTopLevel } from './sql/split-top-level.ts';
 
 const SYSTEM_SCHEMAS = new Set(['information_schema', 'pg_catalog']);
 
@@ -938,27 +941,6 @@ export function parseMapValue(raw: string): string {
     return 'TEXT';
   }
   return normalizeTypeLiteral(parts[1] ?? 'TEXT');
-}
-
-export function splitTopLevel(input: string, delimiter: string): string[] {
-  const parts: string[] = [];
-  let depth = 0;
-  let current = '';
-  for (let i = 0; i < input.length; i += 1) {
-    const char = input[i]!;
-    if (char === '(') depth += 1;
-    if (char === ')') depth = Math.max(0, depth - 1);
-    if (char === delimiter && depth === 0) {
-      parts.push(current);
-      current = '';
-      continue;
-    }
-    current += char;
-  }
-  if (current) {
-    parts.push(current);
-  }
-  return parts;
 }
 
 function tableKey(schema: string, table: string): string {

--- a/src/sql/split-top-level.ts
+++ b/src/sql/split-top-level.ts
@@ -1,0 +1,23 @@
+export function splitTopLevel(input: string, delimiter: string): string[] {
+  const parts: string[] = [];
+  let depth = 0;
+  let current = '';
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (char === '(') depth += 1;
+    if (char === ')') depth = Math.max(0, depth - 1);
+    if (char === delimiter && depth === 0) {
+      parts.push(current);
+      current = '';
+      continue;
+    }
+    current += char;
+  }
+
+  if (current) {
+    parts.push(current);
+  }
+
+  return parts;
+}


### PR DESCRIPTION
## Summary

This PR extracts the duplicated top-level delimiter splitter used by DuckDB type parsing into a shared internal helper.

`src/columns.ts` used one copy while parsing struct schema hints for column literal coercion. `src/introspect.ts` used another copy while parsing introspected `STRUCT` and `MAP` type literals. The two functions were effectively identical, so a future parser tweak could easily land in one path and miss the other.

The fix adds `src/sql/split-top-level.ts` and routes both call sites through it. `src/introspect.ts` still re-exports `splitTopLevel`, so existing unit tests and any current internal callers keep the same import path.

## User impact

There is no intended behavior change. This is a small maintainability refactor for DuckDB nested type parsing, covering structs, maps, and nested parenthesized type fragments.

## Validation

- `bun x vitest run test/introspect.unit.test.ts test/columns.unit.test.ts`
- `bun run build`
- `bun test`
- `git diff --check`
