### PR TITLE
[codex] add dive function helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,10 +208,33 @@ MotherDuck table function helpers are composable SQL fragments:
 import { sql } from 'drizzle-orm';
 import {
   mdAccessTokens,
+  mdCreateDive,
   mdCreateFlight,
   mdFlights,
+  mdGetDive,
+  mdListDives,
   mdRunFlight,
 } from '@duckdbfan/drizzle-duckdb';
+
+const dives = await db.execute(sql`
+  select id, title, owner_name, updated_at
+  from ${mdListDives({ limit: 10, includeOrgShares: true })}
+  order by updated_at desc
+`);
+
+const [dive] = await db.execute(sql`
+  select id, title, current_version
+  from ${mdCreateDive({
+    title: 'Revenue Trends',
+    content: 'export default function Dive() { return null }',
+    description: 'Monthly revenue dashboard',
+  })}
+`);
+
+const [diveContent] = await db.execute(sql`
+  select title, content
+  from ${mdGetDive(String(dive.id))}
+`);
 
 const flights = await db.execute(sql`
   select flight_id, flight_name, current_version
@@ -239,6 +262,12 @@ const runs = await db.execute(sql`
   })}
 `);
 ```
+
+The Dives helper family covers the public preview table functions for listing,
+reading, creating, updating, deleting, and versioning Dives: `mdListDives()`,
+`mdGetDive()`, `mdCreateDive()`, `mdUpdateDiveMetadata()`,
+`mdUpdateDiveContent()`, `mdDeleteDive()`, `mdListDiveVersions()`, and
+`mdGetDiveVersion()`.
 
 The older `mdJobs()` helper family is still exported for deployments that have
 not moved to Flights yet, but new code should use the Flight helpers.

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
         "@types/node": "26.1.0",
         "@vitest/ui": "4.1.9",
         "drizzle-orm": "0.45.2",
-        "prettier": "3.9.4",
+        "prettier": "3.8.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.1",
@@ -200,7 +200,7 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
+    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
 
     "rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,10 +10,10 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.4-r.1",
         "@types/bun": "1.3.14",
-        "@types/node": "26.0.1",
+        "@types/node": "26.1.0",
         "@vitest/ui": "4.1.9",
         "drizzle-orm": "0.45.2",
-        "prettier": "3.8.4",
+        "prettier": "3.9.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.1",
@@ -110,7 +110,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+    "@types/node": ["@types/node@26.1.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
@@ -200,7 +200,7 @@
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
-    "prettier": ["prettier@3.8.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q=="],
+    "prettier": ["prettier@3.9.4", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg=="],
 
     "rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -159,10 +159,17 @@ await db.execute(sql`
 
 ## MotherDuck metadata table functions
 
-Use `mdAccessTokens()` and `mdListDives()` when querying the matching MotherDuck table functions through Drizzle SQL templates:
+Use `mdAccessTokens()` and the Dives helpers when querying the matching
+MotherDuck table functions through Drizzle SQL templates:
 
 ```typescript
-import { mdAccessTokens, mdListDives } from '@duckdbfan/drizzle-duckdb';
+import {
+  mdAccessTokens,
+  mdCreateDive,
+  mdGetDive,
+  mdListDives,
+  mdListDiveVersions,
+} from '@duckdbfan/drizzle-duckdb';
 
 const tokens = await db.execute(sql`
   select token_name, token_type, created_ts, expire_at
@@ -176,13 +183,38 @@ const activeTokens = await db.execute(sql`
 `);
 
 const divesWithResources = await db.execute(sql`
-  select id, required_resources
-  from ${mdListDives()}
+  select id, title, owner_name, updated_at, required_resources
+  from ${mdListDives({ limit: 25, includeOrgShares: true })}
   where len(required_resources) > 0
+`);
+
+const [dive] = await db.execute(sql`
+  select id, title, current_version
+  from ${mdCreateDive({
+    title: 'Revenue Trends',
+    content: 'export default function Dive() { return null }',
+    description: 'Monthly revenue dashboard',
+  })}
+`);
+
+const [diveContent] = await db.execute(sql`
+  select title, content
+  from ${mdGetDive(String(dive.id))}
+`);
+
+const versions = await db.execute(sql`
+  select version, description, created_at
+  from ${mdListDiveVersions(String(dive.id), { limit: 5 })}
 `);
 ```
 
-`mdAccessTokens({ activeOnly: true })` filters out rows whose `expire_at` is in the past. `mdListDives()` includes `required_resources` on supported MotherDuck deployments. The column is a list of structs with `name`, `alias`, `url`, `id`, and `resource_type` fields.
+`mdAccessTokens({ activeOnly: true })` filters out rows whose `expire_at` is in
+the past. `mdListDives()` accepts pagination plus `includeOrgShares` for Dives
+shared with the organization. The Dives helper family covers listing, reading,
+creating, updating metadata or content, deleting, listing versions, and reading
+a specific version. `mdListDives()` includes `required_resources` on supported
+MotherDuck deployments. The column is a list of structs with `name`, `alias`,
+`url`, `id`, and `resource_type` fields.
 
 ## MotherDuck Flight table functions
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -41,7 +41,7 @@ const allUsers = await db.select().from(users);
 - Migrations and schema introspection
 - MotherDuck cloud support
 - DuckLake catalog attach support
-- MotherDuck metadata table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives()
+- MotherDuck metadata and Dives table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives(), mdGetDive(), mdCreateDive(), mdUpdateDiveMetadata(), mdUpdateDiveContent(), mdDeleteDive(), mdListDiveVersions(), mdGetDiveVersion()
 - MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
 - Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty and cannot contain = or NULL bytes. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.4-r.1",
     "@types/bun": "1.3.14",
-    "@types/node": "26.0.1",
+    "@types/node": "26.1.0",
     "@vitest/ui": "4.1.9",
     "drizzle-orm": "0.45.2",
-    "prettier": "3.8.4",
+    "prettier": "3.9.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "26.1.0",
     "@vitest/ui": "4.1.9",
     "drizzle-orm": "0.45.2",
-    "prettier": "3.9.4",
+    "prettier": "3.8.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.1",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -21,6 +21,50 @@ export interface MotherDuckRequiredResource {
   resource_type: string | null;
 }
 
+export interface MotherDuckDiveSummaryRow {
+  id: string;
+  title: string;
+  description: string | null;
+  owner_id: string;
+  current_version: number;
+  created_at: Date | string;
+  updated_at: Date | string;
+  owner_name: string;
+  required_resources?: MotherDuckRequiredResource[] | null;
+}
+
+export interface MotherDuckDiveDetailRow extends MotherDuckDiveSummaryRow {
+  version_id: string;
+  version_storage_url: string;
+  version_description: string | null;
+  version_created_at: Date | string;
+  version_api_version: number;
+  content: string;
+  version_required_resources?: MotherDuckRequiredResource[] | null;
+}
+
+export type MotherDuckDiveCreateRow = Omit<
+  MotherDuckDiveDetailRow,
+  'content' | 'required_resources' | 'version_required_resources'
+>;
+
+export interface MotherDuckDiveVersionSummaryRow {
+  id: string;
+  version: number;
+  storage_url: string;
+  description: string | null;
+  created_at: Date | string;
+  api_version: number;
+}
+
+export interface MotherDuckDiveVersionDetailRow extends MotherDuckDiveVersionSummaryRow {
+  content: string;
+}
+
+export interface MotherDuckDiveDeleteRow {
+  success: boolean;
+}
+
 export interface MotherDuckFlightSummaryRow {
   flight_id: string;
   flight_name: string;
@@ -135,6 +179,30 @@ export interface MotherDuckPaginationOptions {
   offset?: number | SQLWrapper;
 }
 
+export interface MotherDuckListDivesOptions extends MotherDuckPaginationOptions {
+  includeOrgShares?: boolean | SQLWrapper;
+}
+
+export interface MotherDuckCreateDiveOptions {
+  title: string | SQLWrapper;
+  content: string | SQLWrapper;
+  description?: string | SQLWrapper | null;
+  apiVersion?: number | SQLWrapper;
+}
+
+export interface MotherDuckUpdateDiveMetadataOptions {
+  id: string | SQLWrapper;
+  title?: string | SQLWrapper | null;
+  description?: string | SQLWrapper | null;
+}
+
+export interface MotherDuckUpdateDiveContentOptions {
+  id: string | SQLWrapper;
+  content: string | SQLWrapper;
+  description?: string | SQLWrapper | null;
+  apiVersion?: number | SQLWrapper;
+}
+
 export interface MotherDuckCreateFlightOptions {
   name: string | SQLWrapper;
   accessTokenName?: string | SQLWrapper;
@@ -186,13 +254,7 @@ export interface MotherDuckUpdateJobOptions {
 export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
 
 type MotherDuckSqlArgument =
-  | SQLWrapper
-  | string
-  | number
-  | bigint
-  | boolean
-  | readonly unknown[]
-  | null;
+  SQLWrapper | string | number | bigint | boolean | readonly unknown[] | null;
 
 export interface MotherDuckTableFunctionOptions {
   mdRun?: MotherDuckRunMode;
@@ -350,6 +412,15 @@ function motherDuckPagedParams(
   ];
 }
 
+function motherDuckDivePagedParams(
+  options: MotherDuckListDivesOptions = {}
+): NamedParameter[] {
+  return [
+    ...motherDuckPagedParams(options),
+    { name: 'include_org_shares', value: options.includeOrgShares },
+  ];
+}
+
 function motherDuckIdParams(
   idName: string,
   idValue: string | SQLWrapper
@@ -390,6 +461,16 @@ function motherDuckIdVersionParams(
   ];
 }
 
+function motherDuckIdVersionParam(
+  idValue: string | SQLWrapper,
+  version: number | SQLWrapper
+): NamedParameter[] {
+  return [
+    ...motherDuckIdParams('id', idValue),
+    { name: 'version', value: version },
+  ];
+}
+
 function assertTableFunctionName(
   name: MotherDuckTableFunction
 ): MotherDuckTableFunction {
@@ -426,8 +507,72 @@ export function mdAccessTokens(
   return sql`(select token_name, token_type, created_ts, expire_at from md_access_tokens() where expire_at is null or expire_at > ${asOf}) as active_access_tokens`;
 }
 
-export function mdListDives(): SQL {
-  return sql`md_list_dives()`;
+export function mdListDives(options: MotherDuckListDivesOptions = {}): SQL {
+  return motherDuckNamedFunction(
+    'md_list_dives',
+    motherDuckDivePagedParams(options)
+  );
+}
+
+export function mdGetDive(id: string | SQLWrapper): SQL {
+  return motherDuckNamedFunction('md_get_dive', motherDuckIdParams('id', id));
+}
+
+export function mdCreateDive(options: MotherDuckCreateDiveOptions): SQL {
+  return motherDuckNamedFunction('md_create_dive', [
+    { name: 'title', value: options.title },
+    { name: 'content', value: options.content },
+    { name: 'description', value: options.description },
+    { name: 'api_version', value: options.apiVersion },
+  ]);
+}
+
+export function mdUpdateDiveMetadata(
+  options: MotherDuckUpdateDiveMetadataOptions
+): SQL {
+  return motherDuckNamedFunction('md_update_dive_metadata', [
+    { name: 'id', value: options.id },
+    { name: 'title', value: options.title },
+    { name: 'description', value: options.description },
+  ]);
+}
+
+export function mdUpdateDiveContent(
+  options: MotherDuckUpdateDiveContentOptions
+): SQL {
+  return motherDuckNamedFunction('md_update_dive_content', [
+    { name: 'id', value: options.id },
+    { name: 'content', value: options.content },
+    { name: 'description', value: options.description },
+    { name: 'api_version', value: options.apiVersion },
+  ]);
+}
+
+export function mdDeleteDive(id: string | SQLWrapper): SQL {
+  return motherDuckNamedFunction(
+    'md_delete_dive',
+    motherDuckIdParams('id', id)
+  );
+}
+
+export function mdListDiveVersions(
+  id: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return motherDuckNamedFunction(
+    'md_list_dive_versions',
+    motherDuckIdPagedParams('id', id, options)
+  );
+}
+
+export function mdGetDiveVersion(
+  id: string | SQLWrapper,
+  version: number | SQLWrapper
+): SQL {
+  return motherDuckNamedFunction(
+    'md_get_dive_version',
+    motherDuckIdVersionParam(id, version)
+  );
 }
 
 export function motherDuckTableFunction(

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -254,7 +254,13 @@ export interface MotherDuckUpdateJobOptions {
 export type MotherDuckRunMode = 'auto' | 'local' | 'remote';
 
 type MotherDuckSqlArgument =
-  SQLWrapper | string | number | bigint | boolean | readonly unknown[] | null;
+  | SQLWrapper
+  | string
+  | number
+  | bigint
+  | boolean
+  | readonly unknown[]
+  | null;
 
 export interface MotherDuckTableFunctionOptions {
   mdRun?: MotherDuckRunMode;

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -4,14 +4,18 @@ import {
   mdAccessTokens,
   mdCancelFlightRun,
   mdCancelJobRun,
+  mdCreateDive,
   mdCreateFlight,
   mdCreateJob,
+  mdDeleteDive,
   mdDeleteFlight,
   mdDeleteJob,
   mdFlightLogs,
   mdFlightRuns,
   mdFlights,
   mdFlightVersions,
+  mdGetDive,
+  mdGetDiveVersion,
   mdGetFlight,
   mdGetFlightVersion,
   mdGetJob,
@@ -20,9 +24,12 @@ import {
   mdJobRuns,
   mdJobs,
   mdJobVersions,
+  mdListDiveVersions,
   mdListDives,
   mdRunFlight,
   mdRunJob,
+  mdUpdateDiveContent,
+  mdUpdateDiveMetadata,
   mdUpdateFlight,
   mdUpdateJob,
 } from '../src/motherduck.ts';
@@ -48,6 +55,101 @@ test('MotherDuck table function helpers emit callable SQL', () => {
   expect(dives.sql).toContain('from md_list_dives()');
   expect(dives.sql).toContain('required_resources');
   expect(dives.params).toEqual([]);
+});
+
+test('MotherDuck Dive helpers emit named-parameter table functions', () => {
+  const dialect = new DuckDBDialect();
+  const diveId = '90000000-0000-0000-0000-000000000001';
+
+  const sharedDives = dialect.sqlToQuery(sql`
+    select id, title
+    from ${mdListDives({ limit: 10, offset: 20, includeOrgShares: true })}
+  `);
+
+  expect(sharedDives.sql).toContain(
+    'from md_list_dives("LIMIT" = $1, "OFFSET" = $2, include_org_shares = $3)'
+  );
+  expect(sharedDives.params).toEqual([10, 20, true]);
+
+  const createDive = dialect.sqlToQuery(sql`
+    select id, current_version
+    from ${mdCreateDive({
+      title: 'Revenue Trends',
+      content: 'export default function Dive() { return null }',
+      description: 'Monthly revenue dashboard',
+      apiVersion: 1,
+    })}
+  `);
+
+  expect(createDive.sql).toContain(
+    'from md_create_dive(title = $1, content = $2, description = $3, api_version = $4)'
+  );
+  expect(createDive.params).toEqual([
+    'Revenue Trends',
+    'export default function Dive() { return null }',
+    'Monthly revenue dashboard',
+    1,
+  ]);
+
+  const createDiveWithRequiredOnly = dialect.sqlToQuery(sql`
+    from ${mdCreateDive({
+      title: 'Minimal Dive',
+      content: 'export default function Dive() { return null }',
+    })}
+  `);
+
+  expect(createDiveWithRequiredOnly.sql).toContain(
+    'from md_create_dive(title = $1, content = $2)'
+  );
+  expect(createDiveWithRequiredOnly.params).toEqual([
+    'Minimal Dive',
+    'export default function Dive() { return null }',
+  ]);
+
+  expect(dialect.sqlToQuery(sql`from ${mdGetDive(diveId)}`).sql).toContain(
+    'from md_get_dive(id = $1)'
+  );
+
+  const updateMetadata = dialect.sqlToQuery(sql`
+    from ${mdUpdateDiveMetadata({
+      id: diveId,
+      title: 'Q1 Revenue Dashboard',
+      description: null,
+    })}
+  `);
+  expect(updateMetadata.sql).toContain(
+    'from md_update_dive_metadata(id = $1, title = $2, description = $3)'
+  );
+  expect(updateMetadata.params).toEqual([diveId, 'Q1 Revenue Dashboard', null]);
+
+  const updateContent = dialect.sqlToQuery(sql`
+    from ${mdUpdateDiveContent({
+      id: diveId,
+      content: sql`${'export default function Dive() { return null }'}`,
+      description: 'Refresh chart copy',
+      apiVersion: 1,
+    })}
+  `);
+  expect(updateContent.sql).toContain(
+    'from md_update_dive_content(id = $1, content = $2, description = $3, api_version = $4)'
+  );
+  expect(updateContent.params).toEqual([
+    diveId,
+    'export default function Dive() { return null }',
+    'Refresh chart copy',
+    1,
+  ]);
+
+  expect(dialect.sqlToQuery(sql`from ${mdDeleteDive(diveId)}`).sql).toContain(
+    'from md_delete_dive(id = $1)'
+  );
+  expect(
+    dialect.sqlToQuery(sql`from ${mdListDiveVersions(diveId, { limit: 5 })}`)
+      .sql
+  ).toContain('from md_list_dive_versions(id = $1, "LIMIT" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdGetDiveVersion(diveId, 0)}`).sql
+  ).toContain('from md_get_dive_version(id = $1, version = $2)');
 });
 
 test('MotherDuck access token helper can filter expired tokens', () => {


### PR DESCRIPTION
## Summary

This adds Drizzle SQL helper coverage for the public MotherDuck Dives table functions. The package already exposed `mdListDives()`, but callers still had to hand-write SQL for reading a Dive, creating one, updating metadata or content, deleting it, and reading version history.

## Issue

Dives are exposed as SQL table functions, so Drizzle users expect the same composable helper style that already exists for MotherDuck access tokens and Flights. Without these helpers, users have to mix raw table-function calls into code that otherwise uses typed, parameterized fragments from this package.

## Cause and effect

The existing MotherDuck helper surface had grown around access tokens, file scans, and Flights. The Dives surface only covered listing, so newer Dives workflows were not represented in the package API. That left useful public functionality harder to discover and easier to call with unparameterized SQL.

## Fix

This PR adds row and option types plus helper functions for:

- `mdListDives()` with pagination and `includeOrgShares`
- `mdGetDive()`
- `mdCreateDive()`
- `mdUpdateDiveMetadata()`
- `mdUpdateDiveContent()`
- `mdDeleteDive()`
- `mdListDiveVersions()`
- `mdGetDiveVersion()`

It also updates the README, API docs, and LLM context with the new helper names, and safely refreshes dev-only pins for `@types/node` and `prettier` after testing.

## Validation

- `bun x vitest run test/motherduck-functions.test.ts`
- `bun x vitest run test/introspect.typecheck.test.ts`
- `bun x prettier --check README.md docs/api/olap-helpers.md package.json src/motherduck.ts test/motherduck-functions.test.ts`
- `git diff --check`
- `bun run build`
- `bun test` (`635 pass`, `7 skip`, `0 fail`)
- Live MotherDuck read-only smoke through these helpers: list Dives, get a Dive, list versions
- Live MotherDuck write smoke through these helpers: create a temporary Dive, update metadata, update content, list versions, read a listed version, delete the temporary Dive
