### PR TITLE
refactor: share array predicate normalization

### DIFF
--- a/src/columns.ts
+++ b/src/columns.ts
@@ -77,6 +77,8 @@ type ArrayDriverValue =
   | ListValueWrapper
   | ArrayValueWrapper;
 
+export type ArrayPredicateValue<T> = T[] | SQLWrapper;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -182,6 +184,12 @@ export function buildListLiteral(values: unknown[], elementType?: string): SQL {
   }
   const chunks = values.map((v) => valueToSqlLiteral(v, elementType));
   return sql`list_value(${sql.join(chunks, sql.raw(', '))})`;
+}
+
+export function normalizeArrayPredicateValue<T>(
+  values: ArrayPredicateValue<T>
+): SQL | SQLWrapper {
+  return Array.isArray(values) ? buildListLiteral(values) : values;
 }
 
 function valueToSqlLiteral(value: unknown, typeHint?: string): SQL {
@@ -578,24 +586,24 @@ export const duckDbTime = (name: string, options: TimeOptions = {}) =>
 
 export function duckDbArrayContains(
   column: SQLWrapper,
-  values: unknown[] | SQLWrapper
+  values: ArrayPredicateValue<unknown>
 ): SQL {
-  const rhs = Array.isArray(values) ? buildListLiteral(values) : values;
+  const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_all(${column}, ${rhs})`;
 }
 
 export function duckDbArrayContained(
   column: SQLWrapper,
-  values: unknown[] | SQLWrapper
+  values: ArrayPredicateValue<unknown>
 ): SQL {
-  const rhs = Array.isArray(values) ? buildListLiteral(values) : values;
+  const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_all(${rhs}, ${column})`;
 }
 
 export function duckDbArrayOverlaps(
   column: SQLWrapper,
-  values: unknown[] | SQLWrapper
+  values: ArrayPredicateValue<unknown>
 ): SQL {
-  const rhs = Array.isArray(values) ? buildListLiteral(values) : values;
+  const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_any(${column}, ${rhs})`;
 }

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -4,15 +4,10 @@
  */
 
 import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
-import { buildListLiteral } from './columns.ts';
-
-type ArrayPredicateValue<T> = T[] | SQLWrapper;
-
-function normalizeArrayPredicateValue<T>(
-  values: ArrayPredicateValue<T>
-): SQL | SQLWrapper {
-  return Array.isArray(values) ? buildListLiteral(values) : values;
-}
+import {
+  normalizeArrayPredicateValue,
+  type ArrayPredicateValue,
+} from './columns.ts';
 
 export function arrayHasAll<T>(
   column: SQLWrapper,


### PR DESCRIPTION
Share array predicate value normalization between the column helpers and native array operators so list literal handling stays in one place.

### Codex description

- add a reusable array predicate value normalizer in `src/columns.ts`
- route DuckDB array helpers and native array operators through the shared normalizer