### PR TITLE
[codex] add dive version resources type

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ The Dives helper family covers the public preview table functions for listing,
 reading, creating, updating, deleting, and versioning Dives: `mdListDives()`,
 `mdGetDive()`, `mdCreateDive()`, `mdUpdateDiveMetadata()`,
 `mdUpdateDiveContent()`, `mdDeleteDive()`, `mdListDiveVersions()`, and
-`mdGetDiveVersion()`.
+`mdGetDiveVersion()`. Dive listing and version rows include
+`required_resources` on supported MotherDuck deployments.
 
 The older `mdJobs()` helper family is still exported for deployments that have
 not moved to Flights yet, but new code should use the Flight helpers.

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -212,9 +212,10 @@ const versions = await db.execute(sql`
 the past. `mdListDives()` accepts pagination plus `includeOrgShares` for Dives
 shared with the organization. The Dives helper family covers listing, reading,
 creating, updating metadata or content, deleting, listing versions, and reading
-a specific version. `mdListDives()` includes `required_resources` on supported
-MotherDuck deployments. The column is a list of structs with `name`, `alias`,
-`url`, `id`, and `resource_type` fields.
+a specific version. `mdListDives()`, `mdListDiveVersions()`, and
+`mdGetDiveVersion()` include `required_resources` on supported MotherDuck
+deployments. The column is a list of structs with `name`, `alias`, `url`, `id`,
+and `resource_type` fields.
 
 ## MotherDuck Flight table functions
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -41,8 +41,8 @@ const allUsers = await db.select().from(users);
 - Migrations and schema introspection
 - MotherDuck cloud support
 - DuckLake catalog attach support
-- MotherDuck metadata and Dives table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives(), mdGetDive(), mdCreateDive(), mdUpdateDiveMetadata(), mdUpdateDiveContent(), mdDeleteDive(), mdListDiveVersions(), mdGetDiveVersion()
-- MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdFlightRuns()
+- MotherDuck metadata and Dives table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives(), mdGetDive(), mdCreateDive(), mdUpdateDiveMetadata(), mdUpdateDiveContent(), mdDeleteDive(), mdListDiveVersions(), mdGetDiveVersion(). Dive listing and version rows may include required_resources.
+- MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdGetFlight(), mdUpdateFlight(), mdDeleteFlight(), mdRunFlight(), mdCancelFlightRun(), mdFlightRuns(), mdFlightLogs(), mdFlightVersions(), mdGetFlightVersion()
 - Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty and cannot contain = or NULL bytes. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 
 ## Important Notes

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -55,6 +55,7 @@ export interface MotherDuckDiveVersionSummaryRow {
   description: string | null;
   created_at: Date | string;
   api_version: number;
+  required_resources?: MotherDuckRequiredResource[] | null;
 }
 
 export interface MotherDuckDiveVersionDetailRow extends MotherDuckDiveVersionSummaryRow {

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -32,6 +32,7 @@ import {
   mdUpdateDiveMetadata,
   mdUpdateFlight,
   mdUpdateJob,
+  type MotherDuckDiveVersionSummaryRow,
 } from '../src/motherduck.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
 
@@ -150,6 +151,28 @@ test('MotherDuck Dive helpers emit named-parameter table functions', () => {
   expect(
     dialect.sqlToQuery(sql`from ${mdGetDiveVersion(diveId, 0)}`).sql
   ).toContain('from md_get_dive_version(id = $1, version = $2)');
+});
+
+test('MotherDuck Dive version row types include required resources', () => {
+  const row: MotherDuckDiveVersionSummaryRow = {
+    id: '90000000-0000-0000-0000-000000000001',
+    version: 1,
+    storage_url: 's3://example/dive/1',
+    description: null,
+    created_at: '2026-07-03T00:00:00Z',
+    api_version: 1,
+    required_resources: [
+      {
+        name: 'analytics',
+        alias: 'analytics',
+        url: 'md:analytics',
+        id: '90000000-0000-0000-0000-000000000002',
+        resource_type: 'database',
+      },
+    ],
+  };
+
+  expect(row.required_resources?.[0]?.resource_type).toBe('database');
 });
 
 test('MotherDuck access token helper can filter expired tokens', () => {


### PR DESCRIPTION
## Issue

MotherDuck Dive version table functions expose `required_resources`, but the exported TypeScript row contract only modeled that column on Dive listing and detail rows. Users selecting version resources had to work outside the package types even though the public table functions return the field.

## Cause and effect

The Dives helper surface was added with row types for summary, detail, and version rows, but the version summary type missed the same required-resource metadata shape. That left docs and LLM context under-describing the public result set for version helpers.

## Fix

This updates `MotherDuckDiveVersionSummaryRow`, and therefore `MotherDuckDiveVersionDetailRow`, with optional `required_resources` metadata. It also adds a compile-backed regression test and refreshes the README, API docs, and LLM context so the public helper docs match the result schema.

## Validation

- Refreshed `/Users/leov/workspace/motherduck/mono` before the review and kept that context private.
- Live MotherDuck smoke: `md_access_tokens()` and `md_list_dives()` were callable.
- Live MotherDuck schema smoke: `DESCRIBE SELECT * FROM md_list_dive_versions(...)` showed `required_resources` on version rows.
- Dependency review: `bun outdated` only offered `prettier@3.9.4`; tested and rejected because it still fails the repo formatting gate across existing files.
- `bun test test/motherduck-functions.test.ts test/olap_helpers.test.ts`
- `bunx prettier --check README.md docs/api/olap-helpers.md src/motherduck.ts test/motherduck-functions.test.ts`
- `bun run build`
- `git diff --check`
- `bun test` (636 passed, 7 skipped)
