### PR TITLE
[codex] fix MotherDuck Flight helper SQL names

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,9 @@ import {
   mdAccessTokens,
   mdCreateDive,
   mdCreateFlight,
-  mdFlights,
   mdGetDive,
   mdListDives,
+  mdListFlights,
   mdRunFlight,
 } from '@duckdbfan/drizzle-duckdb';
 
@@ -238,7 +238,7 @@ const [diveContent] = await db.execute(sql`
 
 const flights = await db.execute(sql`
   select flight_id, flight_name, current_version
-  from ${mdFlights({ limit: 25 })}
+  from ${mdListFlights({ limit: 25 })}
 `);
 
 const activeTokens = await db.execute(sql`
@@ -271,18 +271,21 @@ reading, creating, updating, deleting, and versioning Dives: `mdListDives()`,
 `required_resources` on supported MotherDuck deployments.
 
 The older `mdJobs()` helper family is still exported for deployments that have
-not moved to Flights yet, but new code should use the Flight helpers.
+not moved to Flights yet. The earlier `mdFlights()`, `mdFlightRuns()`,
+`mdFlightLogs()`, and `mdFlightVersions()` TypeScript helper names remain as
+deprecated aliases, but new code should use the verb-style Flight helpers.
 For optional Flight fields, `undefined` omits the named parameter and `null`
 emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,
 and `flightSecretNames`.
 
 `config` entries are exposed to Flight code as environment variables using the
-config key. Config keys must not be empty and cannot contain `=` or NULL bytes;
-config values cannot contain NULL bytes. `flightSecretNames` references
-MotherDuck `TYPE flights` secrets; each secret param is exposed as
-`<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with param `API_KEY`
-becomes `API_SECRET_API_KEY`.
+config key. Config keys must not be empty, cannot contain `=` or NULL bytes, and
+cannot use reserved runtime names such as `MOTHERDUCK_TOKEN` or
+`MOTHERDUCK_FLIGHTS_RUN`. Config values cannot contain NULL bytes.
+`flightSecretNames` references MotherDuck `TYPE flights` secrets; each secret
+param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with
+param `API_KEY` becomes `API_SECRET_API_KEY`.
 
 ## Querying
 

--- a/bun.lock
+++ b/bun.lock
@@ -11,13 +11,13 @@
         "@duckdb/node-api": "1.5.4-r.1",
         "@types/bun": "1.3.14",
         "@types/node": "26.1.0",
-        "@vitest/ui": "4.1.9",
+        "@vitest/ui": "4.1.10",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
         "tinybench": "6.0.2",
         "typescript": "6.0.3",
         "uuid": "14.0.1",
-        "vitest": "4.1.9",
+        "vitest": "4.1.10",
       },
       "peerDependencies": {
         "@duckdb/node-api": ">=1.4.4-r.1 <1.6.0",
@@ -114,21 +114,21 @@
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
-    "@vitest/expect": ["@vitest/expect@4.1.9", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA=="],
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
 
-    "@vitest/mocker": ["@vitest/mocker@4.1.9", "", { "dependencies": { "@vitest/spy": "4.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw=="],
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
 
-    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.9", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A=="],
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
 
-    "@vitest/runner": ["@vitest/runner@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "pathe": "^2.0.3" } }, "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg=="],
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
 
-    "@vitest/snapshot": ["@vitest/snapshot@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "@vitest/utils": "4.1.9", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA=="],
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
 
-    "@vitest/spy": ["@vitest/spy@4.1.9", "", {}, "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA=="],
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
 
-    "@vitest/ui": ["@vitest/ui@4.1.9", "", { "dependencies": { "@vitest/utils": "4.1.9", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.9" } }, "sha512-U/cRvtqfEPj27FI1n9cyUvi4vXXdcLhjJiI+InYKdk8hP4VrS6RXOjGL7rfFaeBc37iRKANsR6eEzIoC7lmgBQ=="],
+    "@vitest/ui": ["@vitest/ui@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "fflate": "^0.8.2", "flatted": "^3.4.2", "pathe": "^2.0.3", "sirv": "^3.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0" }, "peerDependencies": { "vitest": "4.1.10" } }, "sha512-EOUqfXHTXtpSHsyLHH40ts3Ue+hRhSGwzwzMlK0dTEOLSDYyOXLyr5JDGmHQWhN2DYI30gw6dVx3cdgM9FZl+Q=="],
 
-    "@vitest/utils": ["@vitest/utils@4.1.9", "", { "dependencies": { "@vitest/pretty-format": "4.1.9", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA=="],
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -234,7 +234,7 @@
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 
-    "vitest": ["vitest@4.1.9", "", { "dependencies": { "@vitest/expect": "4.1.9", "@vitest/mocker": "4.1.9", "@vitest/pretty-format": "4.1.9", "@vitest/runner": "4.1.9", "@vitest/snapshot": "4.1.9", "@vitest/spy": "4.1.9", "@vitest/utils": "4.1.9", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.9", "@vitest/browser-preview": "4.1.9", "@vitest/browser-webdriverio": "4.1.9", "@vitest/coverage-istanbul": "4.1.9", "@vitest/coverage-v8": "4.1.9", "@vitest/ui": "4.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ=="],
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -226,13 +226,13 @@ inspecting MotherDuck Flights through Drizzle SQL templates:
 import {
   mdAccessTokens,
   mdCreateFlight,
-  mdFlightRuns,
-  mdFlights,
+  mdListFlightRuns,
+  mdListFlights,
 } from '@duckdbfan/drizzle-duckdb';
 
 const flights = await db.execute(sql`
   select flight_id, flight_name, current_version
-  from ${mdFlights({ limit: 25 })}
+  from ${mdListFlights({ limit: 25 })}
 `);
 
 const activeTokens = await db.execute(sql`
@@ -252,23 +252,26 @@ const [flight] = await db.execute(sql`
 
 const runs = await db.execute(sql`
   select run_number, status, created_at
-  from ${mdFlightRuns(String(flight.flight_id))}
+  from ${mdListFlightRuns(String(flight.flight_id))}
 `);
 ```
 
 The older Job helper names are still exported for older MotherDuck deployments,
-but new code should use the Flight helpers.
+and the earlier `mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, and
+`mdFlightVersions()` TypeScript helper names remain as deprecated aliases. New
+code should use the verb-style Flight helpers.
 For optional Flight fields, `undefined` omits the named parameter and `null`
 emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,
 and `flightSecretNames`.
 
 `config` entries are exposed to Flight code as environment variables using the
-config key. Config keys must not be empty and cannot contain `=` or NULL bytes;
-config values cannot contain NULL bytes. `flightSecretNames` references
-MotherDuck `TYPE flights` secrets; each secret param is exposed as
-`<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with param `API_KEY`
-becomes `API_SECRET_API_KEY`.
+config key. Config keys must not be empty, cannot contain `=` or NULL bytes, and
+cannot use reserved runtime names such as `MOTHERDUCK_TOKEN` or
+`MOTHERDUCK_FLIGHTS_RUN`. Config values cannot contain NULL bytes.
+`flightSecretNames` references MotherDuck `TYPE flights` secrets; each secret
+param is exposed as `<SECRET_NAME>_<KEY>`, so a secret named `api_secret` with
+param `API_KEY` becomes `API_SECRET_API_KEY`.
 
 ## OLAP builder (grouped measures)
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,8 +42,8 @@ const allUsers = await db.select().from(users);
 - MotherDuck cloud support
 - DuckLake catalog attach support
 - MotherDuck metadata and Dives table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives(), mdGetDive(), mdCreateDive(), mdUpdateDiveMetadata(), mdUpdateDiveContent(), mdDeleteDive(), mdListDiveVersions(), mdGetDiveVersion(). Dive listing and version rows may include required_resources.
-- MotherDuck Flight table function helpers: mdFlights(), mdCreateFlight(), mdGetFlight(), mdUpdateFlight(), mdDeleteFlight(), mdRunFlight(), mdCancelFlightRun(), mdFlightRuns(), mdFlightLogs(), mdFlightVersions(), mdGetFlightVersion()
-- Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty and cannot contain = or NULL bytes. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
+- MotherDuck Flight table function helpers: mdListFlights(), mdCreateFlight(), mdGetFlight(), mdUpdateFlight(), mdDeleteFlight(), mdRunFlight(), mdCancelFlightRun(), mdListFlightRuns(), mdGetFlightLogs(), mdListFlightVersions(), mdGetFlightVersion(). Deprecated aliases mdFlights(), mdFlightRuns(), mdFlightLogs(), and mdFlightVersions() emit the same supported SQL names.
+- Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty, cannot contain = or NULL bytes, and cannot use reserved names MOTHERDUCK_TOKEN or MOTHERDUCK_FLIGHTS_RUN. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 
 ## Important Notes
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4",
+  "version": "1.5.5",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {
@@ -31,13 +31,13 @@
     "@duckdb/node-api": "1.5.4-r.1",
     "@types/bun": "1.3.14",
     "@types/node": "26.1.0",
-    "@vitest/ui": "4.1.9",
+    "@vitest/ui": "4.1.10",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",
     "tinybench": "6.0.2",
     "typescript": "6.0.3",
     "uuid": "14.0.1",
-    "vitest": "4.1.9"
+    "vitest": "4.1.10"
   },
   "repository": {
     "type": "git",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -273,6 +273,11 @@ type NamedParameter = {
   value: MotherDuckSqlArgument | undefined;
 };
 
+const motherDuckFlightReservedConfigKeys = new Set([
+  'MOTHERDUCK_TOKEN',
+  'MOTHERDUCK_FLIGHTS_RUN',
+]);
+
 const motherDuckTableFunctionNameList = [
   'read_parquet',
   'parquet_scan',
@@ -363,6 +368,12 @@ function validateMotherDuckConfigMap(
   for (const [key, configValue] of Object.entries(value)) {
     if (key === '') {
       throw new Error('MotherDuck Flight config keys must not be empty');
+    }
+
+    if (motherDuckFlightReservedConfigKeys.has(key)) {
+      throw new Error(
+        `MotherDuck Flight config key "${key}" is reserved and cannot be set`
+      );
     }
 
     if (key.includes('=')) {
@@ -624,8 +635,16 @@ export const motherDuckReadJsonAuto = (
   options?: MotherDuckTableFunctionOptions
 ) => motherDuckTableFunction('read_json_auto', [path], options);
 
+export function mdListFlights(options: MotherDuckPaginationOptions = {}): SQL {
+  return motherDuckNamedFunction(
+    'md_list_flights',
+    motherDuckPagedParams(options)
+  );
+}
+
+/** @deprecated Use mdListFlights. */
 export function mdFlights(options: MotherDuckPaginationOptions = {}): SQL {
-  return motherDuckNamedFunction('md_flights', motherDuckPagedParams(options));
+  return mdListFlights(options);
 }
 
 export function mdCreateFlight(options: MotherDuckCreateFlightOptions): SQL {
@@ -687,34 +706,58 @@ export function mdCancelFlightRun(
   );
 }
 
+export function mdListFlightRuns(
+  flightId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return motherDuckNamedFunction(
+    'md_list_flight_runs',
+    motherDuckIdPagedParams('flight_id', flightId, options)
+  );
+}
+
+/** @deprecated Use mdListFlightRuns. */
 export function mdFlightRuns(
   flightId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_flight_runs',
-    motherDuckIdPagedParams('flight_id', flightId, options)
-  );
+  return mdListFlightRuns(flightId, options);
 }
 
-export function mdFlightLogs(
+export function mdGetFlightLogs(
   flightId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
 ): SQL {
   return motherDuckNamedFunction(
-    'md_flight_logs',
+    'md_get_flight_logs',
     motherDuckIdRunParams('flight_id', flightId, runNumber)
   );
 }
 
-export function mdFlightVersions(
+/** @deprecated Use mdGetFlightLogs. */
+export function mdFlightLogs(
+  flightId: string | SQLWrapper,
+  runNumber: number | bigint | SQLWrapper
+): SQL {
+  return mdGetFlightLogs(flightId, runNumber);
+}
+
+export function mdListFlightVersions(
   flightId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
 ): SQL {
   return motherDuckNamedFunction(
-    'md_flight_versions',
+    'md_list_flight_versions',
     motherDuckIdPagedParams('flight_id', flightId, options)
   );
+}
+
+/** @deprecated Use mdListFlightVersions. */
+export function mdFlightVersions(
+  flightId: string | SQLWrapper,
+  options: MotherDuckPaginationOptions = {}
+): SQL {
+  return mdListFlightVersions(flightId, options);
 }
 
 export function mdGetFlightVersion(
@@ -727,7 +770,7 @@ export function mdGetFlightVersion(
   );
 }
 
-/** @deprecated Use mdFlights. */
+/** @deprecated Use mdListFlights. */
 export function mdJobs(options: MotherDuckPaginationOptions = {}): SQL {
   return motherDuckNamedFunction('md_jobs', motherDuckPagedParams(options));
 }
@@ -794,7 +837,7 @@ export function mdCancelJobRun(
   );
 }
 
-/** @deprecated Use mdFlightRuns. */
+/** @deprecated Use mdListFlightRuns. */
 export function mdJobRuns(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
@@ -805,7 +848,7 @@ export function mdJobRuns(
   );
 }
 
-/** @deprecated Use mdFlightLogs. */
+/** @deprecated Use mdGetFlightLogs. */
 export function mdJobRunLogs(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
@@ -816,7 +859,7 @@ export function mdJobRunLogs(
   );
 }
 
-/** @deprecated Use mdFlightVersions. */
+/** @deprecated Use mdListFlightVersions. */
 export function mdJobVersions(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -24,8 +24,12 @@ import {
   mdJobRuns,
   mdJobs,
   mdJobVersions,
+  mdGetFlightLogs,
   mdListDiveVersions,
   mdListDives,
+  mdListFlightRuns,
+  mdListFlights,
+  mdListFlightVersions,
   mdRunFlight,
   mdRunJob,
   mdUpdateDiveContent,
@@ -242,10 +246,12 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
 
   const flights = dialect.sqlToQuery(sql`
     select flight_name
-    from ${mdFlights({ limit: 10, offset: 20 })}
+    from ${mdListFlights({ limit: 10, offset: 20 })}
   `);
 
-  expect(flights.sql).toContain('from md_flights("LIMIT" = $1, "OFFSET" = $2)');
+  expect(flights.sql).toContain(
+    'from md_list_flights("LIMIT" = $1, "OFFSET" = $2)'
+  );
   expect(flights.params).toEqual([10, 20]);
 
   const updateFlight = dialect.sqlToQuery(sql`
@@ -288,20 +294,41 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
     dialect.sqlToQuery(sql`from ${mdCancelFlightRun(flightId, 2)}`).sql
   ).toContain('from md_cancel_flight_run(flight_id = $1, run_number = $2)');
   expect(
-    dialect.sqlToQuery(sql`from ${mdFlightRuns(flightId, { limit: 1 })}`).sql
-  ).toContain('from md_flight_runs(flight_id = $1, "LIMIT" = $2)');
-  expect(
-    dialect.sqlToQuery(sql`from ${mdFlightLogs(flightId, 1)}`).sql
-  ).toContain('from md_flight_logs(flight_id = $1, run_number = $2)');
-  expect(
-    dialect.sqlToQuery(sql`from ${mdFlightVersions(flightId, { offset: 2 })}`)
+    dialect.sqlToQuery(sql`from ${mdListFlightRuns(flightId, { limit: 1 })}`)
       .sql
-  ).toContain('from md_flight_versions(flight_id = $1, "OFFSET" = $2)');
+  ).toContain('from md_list_flight_runs(flight_id = $1, "LIMIT" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdGetFlightLogs(flightId, 1)}`).sql
+  ).toContain('from md_get_flight_logs(flight_id = $1, run_number = $2)');
+  expect(
+    dialect.sqlToQuery(
+      sql`from ${mdListFlightVersions(flightId, { offset: 2 })}`
+    ).sql
+  ).toContain('from md_list_flight_versions(flight_id = $1, "OFFSET" = $2)');
   expect(
     dialect.sqlToQuery(sql`from ${mdGetFlightVersion(flightId, 1)}`).sql
   ).toContain(
     'from md_get_flight_version(flight_id = $1, version_number = $2)'
   );
+});
+
+test('deprecated MotherDuck flight helper aliases emit supported table functions', () => {
+  const dialect = new DuckDBDialect();
+  const flightId = '80000000-0000-0000-0000-000000000001';
+
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlights({ limit: 1 })}`).sql
+  ).toContain('from md_list_flights("LIMIT" = $1)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightRuns(flightId, { limit: 1 })}`).sql
+  ).toContain('from md_list_flight_runs(flight_id = $1, "LIMIT" = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightLogs(flightId, 1)}`).sql
+  ).toContain('from md_get_flight_logs(flight_id = $1, run_number = $2)');
+  expect(
+    dialect.sqlToQuery(sql`from ${mdFlightVersions(flightId, { offset: 2 })}`)
+      .sql
+  ).toContain('from md_list_flight_versions(flight_id = $1, "OFFSET" = $2)');
 });
 
 test('MotherDuck flight helpers emit explicit null optional parameters', () => {
@@ -393,6 +420,24 @@ test('MotherDuck flight config helpers reject invalid environment keys', () => {
       })}
     `)
   ).toThrow(/value for key "GOOD_KEY" must not contain a NULL byte/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdCreateFlight({
+        name: 'reserved-config',
+        sourceCode: 'print("hello")',
+        config: { MOTHERDUCK_TOKEN: 'not-allowed' },
+      })}
+    `)
+  ).toThrow(/config key "MOTHERDUCK_TOKEN" is reserved/i);
+
+  expect(() =>
+    dialect.sqlToQuery(sql`
+      from ${mdRunFlight(flightId, {
+        config: { MOTHERDUCK_FLIGHTS_RUN: '1' },
+      })}
+    `)
+  ).toThrow(/config key "MOTHERDUCK_FLIGHTS_RUN" is reserved/i);
 });
 
 test('MotherDuck config validation preserves nulls and SQL wrapper escape hatches', () => {


### PR DESCRIPTION
## Summary

This fixes the MotherDuck Flight helper SQL emitted by drizzle-duckdb. The current helpers for listing Flights, listing runs, fetching run logs, and listing versions were still emitting the older noun-style table function names, which are not available on the current public MotherDuck SQL surface.

Users calling helpers such as `mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, or `mdFlightVersions()` could receive catalog errors from MotherDuck even though the higher-level TypeScript helper existed. The root cause was stale SQL function names in `src/motherduck.ts`.

The fix adds preferred verb-style helper exports (`mdListFlights()`, `mdListFlightRuns()`, `mdGetFlightLogs()`, and `mdListFlightVersions()`) and keeps the older TypeScript helper names as deprecated aliases that emit the supported SQL. It also rejects reserved Flight config keys locally so users get a clear Drizzle-side error before a backend validation failure.

Because this is a public package bugfix, the package version is bumped to `1.5.5`. I also updated Vitest and `@vitest/ui` from `4.1.9` to `4.1.10`; Prettier was checked but left pinned because the newer formatter required unrelated formatting churn.

## Validation

- `bun install --frozen-lockfile`
- `bun test test/motherduck-functions.test.ts`
- `bunx prettier --check .`
- `bunx tsc --noEmit --project tsconfig.check.json`
- `bun run build`
- `CI=1 bun run test`
- `npm pack --dry-run`
- Live MotherDuck smoke: `mdFlights()` alias resolves successfully through the updated SQL name; `mdListFlightRuns()`, `mdGetFlightLogs()`, and `mdListFlightVersions()` resolve to real functions and fail only on the intentionally fake Flight id.
