### PR TITLE
[codex] Fix deprecated Job helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,10 +270,12 @@ reading, creating, updating, deleting, and versioning Dives: `mdListDives()`,
 `mdGetDiveVersion()`. Dive listing and version rows include
 `required_resources` on supported MotherDuck deployments.
 
-The older `mdJobs()` helper family is still exported for deployments that have
-not moved to Flights yet. The earlier `mdFlights()`, `mdFlightRuns()`,
-`mdFlightLogs()`, and `mdFlightVersions()` TypeScript helper names remain as
-deprecated aliases, but new code should use the verb-style Flight helpers.
+The older `mdJobs()` helper family remains exported as deprecated compatibility
+aliases. Those helpers call the supported Flight table functions and preserve
+the older `job_*` result column names where the Flight result uses `flight_*`.
+The earlier `mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, and
+`mdFlightVersions()` TypeScript helper names also remain as deprecated aliases,
+but new code should use the verb-style Flight helpers.
 For optional Flight fields, `undefined` omits the named parameter and `null`
 emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,

--- a/docs/api/olap-helpers.md
+++ b/docs/api/olap-helpers.md
@@ -256,10 +256,12 @@ const runs = await db.execute(sql`
 `);
 ```
 
-The older Job helper names are still exported for older MotherDuck deployments,
-and the earlier `mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, and
-`mdFlightVersions()` TypeScript helper names remain as deprecated aliases. New
-code should use the verb-style Flight helpers.
+The older Job helper names remain exported as deprecated compatibility aliases.
+They call the supported Flight table functions and preserve the older `job_*`
+result column names where the Flight result uses `flight_*`. The earlier
+`mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, and `mdFlightVersions()`
+TypeScript helper names remain as deprecated aliases too. New code should use
+the verb-style Flight helpers.
 For optional Flight fields, `undefined` omits the named parameter and `null`
 emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -42,7 +42,7 @@ const allUsers = await db.select().from(users);
 - MotherDuck cloud support
 - DuckLake catalog attach support
 - MotherDuck metadata and Dives table function helpers: mdAccessTokens(), mdAccessTokens({ activeOnly: true }), mdListDives(), mdGetDive(), mdCreateDive(), mdUpdateDiveMetadata(), mdUpdateDiveContent(), mdDeleteDive(), mdListDiveVersions(), mdGetDiveVersion(). Dive listing and version rows may include required_resources.
-- MotherDuck Flight table function helpers: mdListFlights(), mdCreateFlight(), mdGetFlight(), mdUpdateFlight(), mdDeleteFlight(), mdRunFlight(), mdCancelFlightRun(), mdListFlightRuns(), mdGetFlightLogs(), mdListFlightVersions(), mdGetFlightVersion(). Deprecated aliases mdFlights(), mdFlightRuns(), mdFlightLogs(), and mdFlightVersions() emit the same supported SQL names.
+- MotherDuck Flight table function helpers: mdListFlights(), mdCreateFlight(), mdGetFlight(), mdUpdateFlight(), mdDeleteFlight(), mdRunFlight(), mdCancelFlightRun(), mdListFlightRuns(), mdGetFlightLogs(), mdListFlightVersions(), mdGetFlightVersion(). Deprecated aliases mdFlights(), mdFlightRuns(), mdFlightLogs(), and mdFlightVersions() emit the same supported SQL names. Deprecated mdJobs() helpers call the supported Flight table functions and preserve older job_* result column names where Flight returns flight_* columns.
 - Flight helper optional fields use undefined to omit a parameter and null to emit SQL NULL. Config keys must not be empty, cannot contain = or NULL bytes, and cannot use reserved names MOTHERDUCK_TOKEN or MOTHERDUCK_FLIGHTS_RUN. Flight secret params are exposed as <SECRET_NAME>_<KEY> environment variables.
 
 ## Important Notes

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.5",
+  "version": "1.5.6",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -421,6 +421,75 @@ function motherDuckNamedFunction(
   return sql`${sql.raw(name)}(${motherDuckNamedParams(parameters)})`;
 }
 
+type MotherDuckColumnAlias = readonly [sourceName: string, targetName: string];
+
+function motherDuckColumnProjection(
+  column: string | MotherDuckColumnAlias
+): SQL {
+  if (typeof column === 'string') {
+    return sql.raw(column);
+  }
+
+  const [sourceName, targetName] = column;
+  return sql`${sql.raw(sourceName)} as ${sql.raw(targetName)}`;
+}
+
+function motherDuckCompatibilityView(
+  source: SQL,
+  alias: string,
+  columns: readonly (string | MotherDuckColumnAlias)[]
+): SQL {
+  return sql`(select ${sql.join(
+    columns.map((column) => motherDuckColumnProjection(column)),
+    sql`, `
+  )} from ${source}) as ${sql.raw(alias)}`;
+}
+
+function motherDuckJobSummaryView(source: SQL): SQL {
+  return motherDuckCompatibilityView(source, 'md_jobs', [
+    ['flight_id', 'job_id'],
+    ['flight_name', 'job_name'],
+    'schedule_cron',
+    'schedule_status',
+    'status',
+    'current_version',
+    'created_at',
+    'updated_at',
+  ]);
+}
+
+function motherDuckJobRunView(source: SQL): SQL {
+  return motherDuckCompatibilityView(source, 'md_job_runs', [
+    'run_id',
+    ['flight_id', 'job_id'],
+    ['flight_name', 'job_name'],
+    ['flight_version', 'job_version'],
+    'run_number',
+    'is_scheduled',
+    'status',
+    'created_at',
+    'started_at',
+    'ended_at',
+    'scheduled_at',
+    'cancelled_at',
+    'exit_code',
+  ]);
+}
+
+function motherDuckJobVersionView(source: SQL): SQL {
+  return motherDuckCompatibilityView(source, 'md_job_versions', [
+    'version_id',
+    ['flight_id', 'job_id'],
+    ['flight_version', 'version'],
+    'created_at',
+    ['access_token_name', 'md_token_name'],
+    ['flight_secret_names', 'md_secret_names'],
+    'config',
+    'source_code',
+    'requirements_txt',
+  ]);
+}
+
 function motherDuckPagedParams(
   options: MotherDuckPaginationOptions = {}
 ): NamedParameter[] {
@@ -772,58 +841,53 @@ export function mdGetFlightVersion(
 
 /** @deprecated Use mdListFlights. */
 export function mdJobs(options: MotherDuckPaginationOptions = {}): SQL {
-  return motherDuckNamedFunction('md_jobs', motherDuckPagedParams(options));
+  return motherDuckJobSummaryView(mdListFlights(options));
 }
 
 /** @deprecated Use mdCreateFlight. */
 export function mdCreateJob(options: MotherDuckCreateJobOptions): SQL {
-  return motherDuckNamedFunction('md_create_job', [
-    { name: 'name', value: options.name },
-    { name: 'md_token_name', value: options.mdTokenName },
-    { name: 'source_code', value: options.sourceCode },
-    { name: 'md_secret_names', value: options.mdSecretNames },
-    { name: 'schedule_cron', value: options.scheduleCron },
-    { name: 'config', value: motherDuckOptionalMapArg(options.config) },
-    { name: 'requirements_txt', value: options.requirementsTxt },
-  ]);
+  return motherDuckJobSummaryView(
+    mdCreateFlight({
+      name: options.name,
+      accessTokenName: options.mdTokenName,
+      sourceCode: options.sourceCode,
+      flightSecretNames: options.mdSecretNames,
+      scheduleCron: options.scheduleCron,
+      config: options.config,
+      requirementsTxt: options.requirementsTxt,
+    })
+  );
 }
 
 /** @deprecated Use mdGetFlight. */
 export function mdGetJob(jobId: string | SQLWrapper): SQL {
-  return motherDuckNamedFunction(
-    'md_get_job',
-    motherDuckIdParams('job_id', jobId)
-  );
+  return motherDuckJobSummaryView(mdGetFlight(jobId));
 }
 
 /** @deprecated Use mdUpdateFlight. */
 export function mdUpdateJob(options: MotherDuckUpdateJobOptions): SQL {
-  return motherDuckNamedFunction('md_update_job', [
-    { name: 'job_id', value: options.jobId },
-    { name: 'name', value: options.name },
-    { name: 'schedule_cron', value: options.scheduleCron },
-    { name: 'config', value: motherDuckOptionalMapArg(options.config) },
-    { name: 'source_code', value: options.sourceCode },
-    { name: 'requirements_txt', value: options.requirementsTxt },
-    { name: 'md_token_name', value: options.mdTokenName },
-    { name: 'md_secret_names', value: options.mdSecretNames },
-  ]);
+  return motherDuckJobSummaryView(
+    mdUpdateFlight({
+      flightId: options.jobId,
+      name: options.name,
+      scheduleCron: options.scheduleCron,
+      config: options.config,
+      sourceCode: options.sourceCode,
+      requirementsTxt: options.requirementsTxt,
+      accessTokenName: options.mdTokenName,
+      flightSecretNames: options.mdSecretNames,
+    })
+  );
 }
 
 /** @deprecated Use mdDeleteFlight. */
 export function mdDeleteJob(jobId: string | SQLWrapper): SQL {
-  return motherDuckNamedFunction(
-    'md_delete_job',
-    motherDuckIdParams('job_id', jobId)
-  );
+  return mdDeleteFlight(jobId);
 }
 
 /** @deprecated Use mdRunFlight. */
 export function mdRunJob(jobId: string | SQLWrapper): SQL {
-  return motherDuckNamedFunction(
-    'md_run_job',
-    motherDuckIdParams('job_id', jobId)
-  );
+  return motherDuckJobRunView(mdRunFlight(jobId));
 }
 
 /** @deprecated Use mdCancelFlightRun. */
@@ -831,10 +895,7 @@ export function mdCancelJobRun(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_cancel_job_run',
-    motherDuckIdRunParams('job_id', jobId, runNumber)
-  );
+  return mdCancelFlightRun(jobId, runNumber);
 }
 
 /** @deprecated Use mdListFlightRuns. */
@@ -842,10 +903,7 @@ export function mdJobRuns(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_job_runs',
-    motherDuckIdPagedParams('job_id', jobId, options)
-  );
+  return motherDuckJobRunView(mdListFlightRuns(jobId, options));
 }
 
 /** @deprecated Use mdGetFlightLogs. */
@@ -853,10 +911,7 @@ export function mdJobRunLogs(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_job_run_logs',
-    motherDuckIdRunParams('job_id', jobId, runNumber)
-  );
+  return mdGetFlightLogs(jobId, runNumber);
 }
 
 /** @deprecated Use mdListFlightVersions. */
@@ -864,10 +919,7 @@ export function mdJobVersions(
   jobId: string | SQLWrapper,
   options: MotherDuckPaginationOptions = {}
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_job_versions',
-    motherDuckIdPagedParams('job_id', jobId, options)
-  );
+  return motherDuckJobVersionView(mdListFlightVersions(jobId, options));
 }
 
 /** @deprecated Use mdGetFlightVersion. */
@@ -875,8 +927,5 @@ export function mdGetJobVersion(
   jobId: string | SQLWrapper,
   versionNumber: number | SQLWrapper
 ): SQL {
-  return motherDuckNamedFunction(
-    'md_get_job_version',
-    motherDuckIdVersionParams('job_id', jobId, versionNumber)
-  );
+  return motherDuckJobVersionView(mdGetFlightVersion(jobId, versionNumber));
 }

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -470,7 +470,7 @@ test('MotherDuck config validation preserves nulls and SQL wrapper escape hatche
   expect(sqlWrapperConfig.params).toEqual([flightId]);
 });
 
-test('MotherDuck job helpers emit named-parameter table functions', () => {
+test('deprecated MotherDuck job helpers emit supported Flight functions', () => {
   const dialect = new DuckDBDialect();
   const jobId = '80000000-0000-0000-0000-000000000001';
 
@@ -488,7 +488,7 @@ test('MotherDuck job helpers emit named-parameter table functions', () => {
   `);
 
   expect(createJob.sql).toContain(
-    'from md_create_job(name = $1, md_token_name = $2, source_code = $3, md_secret_names = $4, schedule_cron = $5, config = MAP($6, $7), requirements_txt = $8)'
+    'from (select flight_id as job_id, flight_name as job_name, schedule_cron, schedule_status, status, current_version, created_at, updated_at from md_create_flight(name = $1, access_token_name = $2, source_code = $3, flight_secret_names = $4, schedule_cron = $5, config = MAP($6, $7), requirements_txt = $8)) as md_jobs'
   );
   expect(createJob.params).toEqual([
     'daily-refresh',
@@ -506,7 +506,9 @@ test('MotherDuck job helpers emit named-parameter table functions', () => {
     from ${mdJobs({ limit: 10, offset: 20 })}
   `);
 
-  expect(jobs.sql).toContain('from md_jobs("LIMIT" = $1, "OFFSET" = $2)');
+  expect(jobs.sql).toContain(
+    'from (select flight_id as job_id, flight_name as job_name, schedule_cron, schedule_status, status, current_version, created_at, updated_at from md_list_flights("LIMIT" = $1, "OFFSET" = $2)) as md_jobs'
+  );
   expect(jobs.params).toEqual([10, 20]);
 
   const updateJob = dialect.sqlToQuery(sql`
@@ -519,34 +521,40 @@ test('MotherDuck job helpers emit named-parameter table functions', () => {
   `);
 
   expect(updateJob.sql).toContain(
-    'from md_update_job(job_id = $1, source_code = source_code || $2, md_secret_names = $3)'
+    'from (select flight_id as job_id, flight_name as job_name, schedule_cron, schedule_status, status, current_version, created_at, updated_at from md_update_flight(flight_id = $1, source_code = source_code || $2, flight_secret_names = $3)) as md_jobs'
   );
   expect(updateJob.params).toEqual([jobId, '\n# patched', []]);
 
   expect(dialect.sqlToQuery(sql`from ${mdGetJob(jobId)}`).sql).toContain(
-    'from md_get_job(job_id = $1)'
+    'from (select flight_id as job_id, flight_name as job_name, schedule_cron, schedule_status, status, current_version, created_at, updated_at from md_get_flight(flight_id = $1)) as md_jobs'
   );
   expect(dialect.sqlToQuery(sql`from ${mdDeleteJob(jobId)}`).sql).toContain(
-    'from md_delete_job(job_id = $1)'
+    'from md_delete_flight(flight_id = $1)'
   );
   expect(dialect.sqlToQuery(sql`from ${mdRunJob(jobId)}`).sql).toContain(
-    'from md_run_job(job_id = $1)'
+    'from (select run_id, flight_id as job_id, flight_name as job_name, flight_version as job_version, run_number, is_scheduled, status, created_at, started_at, ended_at, scheduled_at, cancelled_at, exit_code from md_run_flight(flight_id = $1)) as md_job_runs'
   );
   expect(
     dialect.sqlToQuery(sql`from ${mdCancelJobRun(jobId, 2)}`).sql
-  ).toContain('from md_cancel_job_run(job_id = $1, run_number = $2)');
+  ).toContain('from md_cancel_flight_run(flight_id = $1, run_number = $2)');
   expect(
     dialect.sqlToQuery(sql`from ${mdJobRuns(jobId, { limit: 1 })}`).sql
-  ).toContain('from md_job_runs(job_id = $1, "LIMIT" = $2)');
+  ).toContain(
+    'from (select run_id, flight_id as job_id, flight_name as job_name, flight_version as job_version, run_number, is_scheduled, status, created_at, started_at, ended_at, scheduled_at, cancelled_at, exit_code from md_list_flight_runs(flight_id = $1, "LIMIT" = $2)) as md_job_runs'
+  );
   expect(dialect.sqlToQuery(sql`from ${mdJobRunLogs(jobId, 1)}`).sql).toContain(
-    'from md_job_run_logs(job_id = $1, run_number = $2)'
+    'from md_get_flight_logs(flight_id = $1, run_number = $2)'
   );
   expect(
     dialect.sqlToQuery(sql`from ${mdJobVersions(jobId, { offset: 2 })}`).sql
-  ).toContain('from md_job_versions(job_id = $1, "OFFSET" = $2)');
+  ).toContain(
+    'from (select version_id, flight_id as job_id, flight_version as version, created_at, access_token_name as md_token_name, flight_secret_names as md_secret_names, config, source_code, requirements_txt from md_list_flight_versions(flight_id = $1, "OFFSET" = $2)) as md_job_versions'
+  );
   expect(
     dialect.sqlToQuery(sql`from ${mdGetJobVersion(jobId, 1)}`).sql
-  ).toContain('from md_get_job_version(job_id = $1, version_number = $2)');
+  ).toContain(
+    'from (select version_id, flight_id as job_id, flight_version as version, created_at, access_token_name as md_token_name, flight_secret_names as md_secret_names, config, source_code, requirements_txt from md_get_flight_version(flight_id = $1, version_number = $2)) as md_job_versions'
+  );
 });
 
 test('deprecated MotherDuck job config helpers share Flight validation', () => {


### PR DESCRIPTION
## Summary

This fixes the deprecated MotherDuck Job helper family so it no longer emits obsolete server-side Job table function names. Current MotherDuck accepts the Flight table functions, while live smoke testing showed `md_jobs` and `md_job_runs` are rejected as missing table functions.

The deprecated TypeScript helper names remain exported for source compatibility. They now route through the supported Flight helper functions and wrap the results with compatibility projections so existing `job_*` column selections keep working where Flight returns `flight_*` columns.

## User impact

Users calling helpers such as `mdJobs()`, `mdCreateJob()`, `mdJobRuns()`, or `mdJobVersions()` against current MotherDuck could get catalog errors before their query ran. After this change those helpers generate supported Flight SQL while preserving the older helper names and old-style result columns.

## Changes

- Added a small compatibility view builder in `src/motherduck.ts` for deprecated Job helpers.
- Routed deprecated Job helpers through the current Flight table functions.
- Preserved old result aliases such as `job_id`, `job_name`, `job_version`, `version`, `md_token_name`, and `md_secret_names`.
- Updated MotherDuck helper tests and docs.
- Bumped the package version to `1.5.6` because this is a public SQL-emission bug fix.

## Validation

- Live MotherDuck probe: `md_list_flights` works, while old `md_jobs` and `md_job_runs` are missing.
- Live MotherDuck smoke with patched `mdJobs()` returned rows and patched `mdJobRuns()` reached the Flight function before failing on the intentionally fake ID.
- `bun test test/motherduck-functions.test.ts`
- `git diff --check`
- `bunx prettier --check .`
- `bunx tsc --noEmit --project tsconfig.check.json`
- `bun run build`
- `CI=1 bun run test`
- `bun install --frozen-lockfile`
- `npm pack --dry-run`
- `bun outdated --json`

## Dependency review

`bun outdated --json` only reports `prettier` `3.8.4` behind latest `3.9.4`. I tested `prettier@3.9.4 --check .`; it would require formatting churn across existing source files, so this PR leaves it pinned.
