### PR TITLE
[codex] Release v1.5.4-1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.6",
+  "version": "1.5.4-1",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

This corrects the package version for the MotherDuck Job helper compatibility release to `1.5.4-1`.

The runtime fix already landed in #113. This PR only changes `package.json` so the GitHub release and npm package version match the requested minor release line.

## Validation

- `bun install --lockfile-only`
- `bun install --frozen-lockfile`
- `git diff --check`
- `bunx prettier --check package.json`
- `bun run build`
- `CI=1 bun run test`
- `npm pack --dry-run`, confirmed tarball version `@duckdbfan/drizzle-duckdb@1.5.4-1`
