### PR TITLE
fix: publish prereleases with npm tag

### DIFF
--- a/.github/workflows/motherduck-integration.yml
+++ b/.github/workflows/motherduck-integration.yml
@@ -26,10 +26,22 @@ jobs:
       - name: Build package
         run: bun run build
 
+      - name: Check MotherDuck token
+        id: motherduck-token
+        run: |
+          if [ -n "${MOTHERDUCK_TOKEN:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "MOTHERDUCK_TOKEN is unavailable; skipping cloud integration steps."
+          fi
+
       - name: Run nyc taxi example
+        if: steps.motherduck-token.outputs.available == 'true'
         run: bun example/motherduck-nyc.ts
 
       - name: Seed MotherDuck CI schema
+        if: steps.motherduck-token.outputs.available == 'true'
         run: |
           bun - <<'EOF'
           import { DuckDBInstance } from '@duckdb/node-api';
@@ -57,6 +69,7 @@ jobs:
           EOF
 
       - name: Introspect seeded schema
+        if: steps.motherduck-token.outputs.available == 'true'
         run: |
           mkdir -p /tmp/motherduck
           bun ./dist/duckdb-introspect.mjs --url md: --schemas ci_extension --out /tmp/motherduck/schema.ts
@@ -65,9 +78,11 @@ jobs:
           grep -q "ci_orders" /tmp/motherduck/schema.ts
 
       - name: MotherDuck integration tests
+        if: steps.motherduck-token.outputs.available == 'true'
         run: bun test test/motherduck.integration.test.ts
 
       - name: Complex join & aggregation smoke test
+        if: steps.motherduck-token.outputs.available == 'true'
         run: |
           bun - <<'EOF'
           import { DuckDBInstance } from '@duckdb/node-api';

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,13 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false # never use caching in release builds
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
@@ -37,4 +30,4 @@ jobs:
         run: bun run build
 
       - name: Publish to npm (@duckdbfan/drizzle-duckdb)
-        run: npm publish --access public
+        run: bun publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false # never use caching in release builds
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
 
@@ -30,4 +37,4 @@ jobs:
         run: bun run build
 
       - name: Publish to npm (@duckdbfan/drizzle-duckdb)
-        run: bun publish --access public
+        run: npm publish --access public --tag latest


### PR DESCRIPTION
Fix the release publish workflow by keeping npm trusted publishing and passing an explicit latest dist-tag. npm requires a tag for prerelease versions, and setup-node is still needed to configure the registry for npm publish in GitHub Actions.

Also make the MotherDuck integration workflow skip its cloud-only steps when MOTHERDUCK_TOKEN is unavailable, which is the expected state for forked pull request runs. The workflow still installs and builds before the gated cloud checks.

Verified locally:
- bunx prettier --check .github/workflows/publish.yml .github/workflows/motherduck-integration.yml
- pre-commit run --files .github/workflows/publish.yml .github/workflows/motherduck-integration.yml
- CI=1 bun run test
- bun run build
- npm publish --dry-run --access public --tag latest