### PR TITLE
fix(pool): retry queued acquires after connection failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-1",
+  "version": "1.5.4-2",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -141,6 +141,14 @@ export function createDuckDBConnectionPool(
     waiter.reject(error);
   };
 
+  const takeWaiter = (): WaitingRequest | undefined => {
+    const waiter = waiting.shift();
+    if (waiter) {
+      clearTimeout(waiter.timeoutId);
+    }
+    return waiter;
+  };
+
   const toError = (error: unknown): Error =>
     error instanceof Error ? error : new Error(String(error));
 
@@ -175,6 +183,18 @@ export function createDuckDBConnectionPool(
     createdAt: meta.createdAt,
     lastUsedAt: meta.lastUsedAt,
   });
+
+  const retryNextWaiter = (): void => {
+    if (closed) return;
+
+    const waiter = takeWaiter();
+    if (!waiter) return;
+
+    void acquire().then(
+      (connection) => resolveWaiter(waiter, connection),
+      (error) => rejectWaiter(waiter, toError(error))
+    );
+  };
 
   const acquire = async (): Promise<DuckDBConnection> => {
     if (closed) {
@@ -220,6 +240,7 @@ export function createDuckDBConnectionPool(
       } catch (error) {
         if (!slotReleased) {
           decrementTotal();
+          retryNextWaiter();
         }
         throw error;
       } finally {
@@ -257,7 +278,7 @@ export function createDuckDBConnectionPool(
       return;
     }
 
-    const waiter = waiting.shift();
+    const waiter = takeWaiter();
     if (waiter) {
       const now = Date.now();
       const meta = readMetadata(connection, now);

--- a/test/pool.recycle.test.ts
+++ b/test/pool.recycle.test.ts
@@ -30,7 +30,36 @@ describe('Pool recycling and resilience', () => {
     expect(createSpy).toHaveBeenCalledTimes(2);
   });
 
-  test('setup failure does not reduce capacity', async () => {
+  test('failed connection creation retries the next queued acquire', async () => {
+    const fakeConn = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+    let rejectFirstCreate: (error: Error) => void = () => undefined;
+    const firstCreate = new Promise<DuckDBConnection>((_, reject) => {
+      rejectFirstCreate = reject;
+    });
+    const createSpy = vi
+      .spyOn(DuckDBConnection, 'create')
+      .mockReturnValueOnce(firstCreate)
+      .mockResolvedValueOnce(fakeConn);
+
+    const pool = createDuckDBConnectionPool({} as any, {
+      size: 1,
+      acquireTimeout: 50,
+    });
+
+    const failedAcquire = pool.acquire();
+    const queuedAcquire = pool.acquire();
+    rejectFirstCreate(new Error('boom'));
+
+    await expect(failedAcquire).rejects.toThrow(/boom/);
+    await expect(queuedAcquire).resolves.toBe(fakeConn);
+
+    await pool.release(fakeConn);
+    await pool.close();
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('setup failure retries the next queued acquire', async () => {
     const conn1 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
     const conn2 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
 
@@ -48,10 +77,13 @@ describe('Pool recycling and resilience', () => {
       setup,
     });
 
-    await expect(pool.acquire()).rejects.toThrow(/setup failed/);
+    const failedAcquire = pool.acquire();
+    const queuedAcquire = pool.acquire();
+
+    await expect(failedAcquire).rejects.toThrow(/setup failed/);
     expect(conn1.closeSync).toHaveBeenCalled();
 
-    const conn = await pool.acquire();
+    const conn = await queuedAcquire;
     expect(conn).toBe(conn2);
 
     await pool.release(conn);


### PR DESCRIPTION
Queued pool acquires could time out after an in-flight connection or setup failure freed capacity. This change immediately retries the next queued request and bumps the package for a bug-fix release.

### Codex description

- retry queued acquires when connection creation or setup fails
- cover concurrent failure recovery and release version 1.5.4-2