### PR TITLE
Fix pool recycling after close failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-2",
+  "version": "1.5.4-3",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/pool.ts
+++ b/src/pool.ts
@@ -123,9 +123,12 @@ export function createDuckDBConnectionPool(
   const dropConnection = async (
     connection: DuckDBConnection
   ): Promise<void> => {
-    await closeClientConnection(connection);
-    decrementTotal();
-    metadata.delete(connection);
+    try {
+      await closeClientConnection(connection);
+    } finally {
+      decrementTotal();
+      metadata.delete(connection);
+    }
   };
 
   const resolveWaiter = (
@@ -205,7 +208,12 @@ export function createDuckDBConnectionPool(
       const pooled = idle.pop() as PooledConnection;
       const now = Date.now();
       if (shouldRecycleIdleConnection(pooled, now)) {
-        await dropConnection(pooled.connection);
+        try {
+          await dropConnection(pooled.connection);
+        } catch (error) {
+          retryNextWaiter();
+          throw error;
+        }
         continue;
       }
       markConnectionUsed(pooled.connection, pooled, now);
@@ -278,51 +286,43 @@ export function createDuckDBConnectionPool(
       return;
     }
 
-    const waiter = takeWaiter();
-    if (waiter) {
-      const now = Date.now();
-      const meta = readMetadata(connection, now);
-
-      if (closed) {
-        await dropConnection(connection);
-        rejectWaiter(waiter, new Error(POOL_CLOSED_MESSAGE));
-        return;
-      }
-
-      if (hasExceededMaxLifetime(meta, now)) {
-        await dropConnection(connection);
-        try {
-          const replacement = await acquire();
-          resolveWaiter(waiter, replacement);
-        } catch (error) {
-          rejectWaiter(waiter, toError(error));
-        }
-        return;
-      }
-
-      markConnectionUsed(connection, meta, now);
-      leased.add(connection);
-      resolveWaiter(waiter, connection);
-      return;
-    }
+    const now = Date.now();
+    const meta = readMetadata(connection, now);
 
     if (closed) {
       await dropConnection(connection);
       return;
     }
 
-    const now = Date.now();
-    const existingMeta = markConnectionUsed(
-      connection,
-      readMetadata(connection, now),
-      now
-    );
+    if (hasExceededMaxLifetime(meta, now)) {
+      try {
+        await dropConnection(connection);
+      } catch (error) {
+        retryNextWaiter();
+        throw error;
+      }
 
-    if (hasExceededMaxLifetime(existingMeta, now)) {
-      await dropConnection(connection);
+      const waiter = takeWaiter();
+      if (waiter) {
+        try {
+          const replacement = await acquire();
+          resolveWaiter(waiter, replacement);
+        } catch (error) {
+          rejectWaiter(waiter, toError(error));
+        }
+      }
       return;
     }
 
+    const waiter = takeWaiter();
+    if (waiter) {
+      markConnectionUsed(connection, meta, now);
+      leased.add(connection);
+      resolveWaiter(waiter, connection);
+      return;
+    }
+
+    const existingMeta = markConnectionUsed(connection, meta, now);
     idle.push(toPooledConnection(connection, existingMeta));
   };
 

--- a/test/pool.recycle.test.ts
+++ b/test/pool.recycle.test.ts
@@ -1,4 +1,4 @@
-import { DuckDBConnection } from '@duckdb/node-api';
+import { DuckDBConnection, type DuckDBInstance } from '@duckdb/node-api';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import { createDuckDBConnectionPool } from '../src/pool.ts';
 
@@ -146,6 +146,69 @@ describe('Pool recycling and resilience', () => {
     expect(conn1.closeSync).toHaveBeenCalled();
 
     await pool.release(second);
+    await pool.close();
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('close failure while replacing an expired connection retries the waiter', async () => {
+    const conn1 = {
+      closeSync: vi.fn(() => {
+        throw new Error('close failed');
+      }),
+    } as unknown as DuckDBConnection;
+    const conn2 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+
+    const createSpy = vi
+      .spyOn(DuckDBConnection, 'create')
+      .mockResolvedValueOnce(conn1)
+      .mockResolvedValueOnce(conn2);
+
+    const pool = createDuckDBConnectionPool({} as DuckDBInstance, {
+      size: 1,
+      acquireTimeout: 50,
+      maxLifetimeMs: 0,
+    });
+
+    const first = await pool.acquire();
+    const pendingAcquire = pool.acquire();
+
+    await expect(pool.release(first)).rejects.toThrow('close failed');
+    const replacement = await pendingAcquire;
+    expect(replacement).toBe(conn2);
+
+    await pool.release(replacement);
+    await pool.close();
+
+    expect(createSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('close failure while discarding an idle connection preserves capacity', async () => {
+    const conn1 = {
+      closeSync: vi.fn(() => {
+        throw new Error('close failed');
+      }),
+    } as unknown as DuckDBConnection;
+    const conn2 = { closeSync: vi.fn() } as unknown as DuckDBConnection;
+
+    const createSpy = vi
+      .spyOn(DuckDBConnection, 'create')
+      .mockResolvedValueOnce(conn1)
+      .mockResolvedValueOnce(conn2);
+
+    const pool = createDuckDBConnectionPool({} as DuckDBInstance, {
+      size: 1,
+      idleTimeoutMs: 0,
+    });
+
+    const first = await pool.acquire();
+    await pool.release(first);
+
+    await expect(pool.acquire()).rejects.toThrow('close failed');
+    const replacement = await pool.acquire();
+    expect(replacement).toBe(conn2);
+
+    await pool.release(replacement);
     await pool.close();
 
     expect(createSpy).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
## Summary

- preserve pool capacity accounting when closing an expired connection fails
- retry queued acquires instead of leaving them pending after a recycle failure
- add regression coverage for queued and idle recycling paths
- bump the package version to `1.5.4-3`

## Verification

- `pre-commit run --all-files`
- `bun x prettier --check .`
- `bun x tsc --noEmit --project tsconfig.check.json`
- `CI=1 bun test` (638 passed, 8 skipped)
- `bun run build`
- `npm pack --dry-run --json`
- `bun run bench`
- live MotherDuck integration tests and NYC example
- failure PoC confirms queued acquire resolves with a replacement
- real DuckDB pool recycle smoke query returned 42

## Compatibility

No breaking changes are expected.