### PR TITLE
refactor(ducklake): reuse normalized setup

### DIFF
--- a/src/ducklake.ts
+++ b/src/ducklake.ts
@@ -126,14 +126,13 @@ function buildDuckLakeAttachOptionsSql(
   return options;
 }
 
-export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
-  const normalized = normalizeDuckLakeConfig(config);
-  const options = buildDuckLakeAttachOptionsSql(normalized.attachOptions);
+function buildNormalizedDuckLakeAttachSql(
+  config: NormalizedDuckLakeConfig
+): string {
+  const options = buildDuckLakeAttachOptionsSql(config.attachOptions);
 
   const attachSql = [
-    `ATTACH ${quoteString(normalized.catalog)} AS ${quoteIdentifier(
-      normalized.alias
-    )}`,
+    `ATTACH ${quoteString(config.catalog)} AS ${quoteIdentifier(config.alias)}`,
   ];
 
   if (options.length > 0) {
@@ -143,26 +142,37 @@ export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
   return attachSql.join(' ');
 }
 
+export function buildDuckLakeAttachSql(config: DuckLakeConfig): string {
+  return buildNormalizedDuckLakeAttachSql(normalizeDuckLakeConfig(config));
+}
+
+async function configureNormalizedDuckLake(
+  connection: DuckDBConnection,
+  config: NormalizedDuckLakeConfig
+): Promise<void> {
+  if (config.install) {
+    await connection.run('INSTALL ducklake');
+  }
+
+  if (config.load) {
+    await connection.run('LOAD ducklake');
+  }
+
+  await connection.run(buildNormalizedDuckLakeAttachSql(config));
+
+  if (config.use) {
+    await connection.run(`USE ${quoteIdentifier(config.alias)}`);
+  }
+}
+
 export async function configureDuckLake(
   connection: DuckDBConnection,
   config: DuckLakeConfig
 ): Promise<void> {
-  const normalized = normalizeDuckLakeConfig(config);
-
-  if (normalized.install) {
-    await connection.run('INSTALL ducklake');
-  }
-
-  if (normalized.load) {
-    await connection.run('LOAD ducklake');
-  }
-
-  const attachSql = buildDuckLakeAttachSql(normalized);
-  await connection.run(attachSql);
-
-  if (normalized.use) {
-    await connection.run(`USE ${quoteIdentifier(normalized.alias)}`);
-  }
+  await configureNormalizedDuckLake(
+    connection,
+    normalizeDuckLakeConfig(config)
+  );
 }
 
 function isDuckDBConnection(

--- a/test/ducklake.helpers.test.ts
+++ b/test/ducklake.helpers.test.ts
@@ -2,6 +2,7 @@ import type { DuckDBConnection } from '@duckdb/node-api';
 import { describe, expect, test, vi } from 'vitest';
 import {
   buildDuckLakeAttachSql,
+  configureDuckLake,
   isDuckDbFileCatalog,
   normalizeDuckLakeConfig,
   resolveDuckLakePoolSize,
@@ -46,6 +47,28 @@ describe('DuckLake helpers', () => {
     expect(sql).toBe(
       `ATTACH 'ducklake:md:meta''db' AS "lake""name" (METADATA_CATALOG='cat''alog', READ_ONLY=false)`
     );
+  });
+
+  test('configureDuckLake runs normalized setup in order', async () => {
+    const connection = {
+      run: vi.fn(async () => undefined),
+    } as unknown as DuckDBConnection;
+
+    await configureDuckLake(connection, {
+      catalog: 'md:meta_db',
+      alias: 'lake',
+      install: true,
+      load: true,
+    });
+
+    expect(connection.run).toHaveBeenCalledTimes(4);
+    expect(connection.run).toHaveBeenNthCalledWith(1, 'INSTALL ducklake');
+    expect(connection.run).toHaveBeenNthCalledWith(2, 'LOAD ducklake');
+    expect(connection.run).toHaveBeenNthCalledWith(
+      3,
+      `ATTACH 'ducklake:md:meta_db' AS "lake"`
+    );
+    expect(connection.run).toHaveBeenNthCalledWith(4, 'USE "lake"');
   });
 
   test('isDuckDbFileCatalog detects local file catalogs', () => {


### PR DESCRIPTION
Reuse a normalized DuckLake configuration path so setup no longer normalizes the same config again while building ATTACH SQL.

### Codex description

- extract normalized ATTACH SQL and setup helpers
- cover ordered install, load, attach, and use execution