### PR TITLE
fix(introspection): disambiguate table exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-4",
+  "version": "1.5.4-5",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/introspect.ts
+++ b/src/introspect.ts
@@ -440,12 +440,17 @@ function emitSchema(
       ? a.name.localeCompare(b.name)
       : a.schema.localeCompare(b.schema)
   );
+  const schemaIdentifiers = buildSchemaIdentifiers(sorted);
+  const tableIdentifiers = buildTableIdentifiers(
+    sorted,
+    new Set(schemaIdentifiers.values())
+  );
 
   const lines: string[] = [];
 
   for (const schema of uniqueSchemas(sorted)) {
     imports.pgCore.add('pgSchema');
-    const schemaVar = toSchemaIdentifier(schema);
+    const schemaVar = schemaIdentifiers.get(schema)!;
     lines.push(
       `export const ${schemaVar} = pgSchema(${JSON.stringify(schema)});`,
       ''
@@ -453,7 +458,16 @@ function emitSchema(
 
     const tables = sorted.filter((table) => table.schema === schema);
     for (const table of tables) {
-      lines.push(...emitTable(schemaVar, table, imports, options));
+      lines.push(
+        ...emitTable(
+          schemaVar,
+          tableIdentifiers.get(tableKey(table.schema, table.name))!,
+          table,
+          tableIdentifiers,
+          imports,
+          options
+        )
+      );
       lines.push('');
     }
   }
@@ -464,11 +478,12 @@ function emitSchema(
 
 function emitTable(
   schemaVar: string,
+  tableVar: string,
   table: IntrospectedTable,
+  tableIdentifiers: ReadonlyMap<string, string>,
   imports: ImportBuckets,
   options: EmitOptions
 ): string[] {
-  const tableVar = toIdentifier(table.name);
   const columnLines: string[] = [];
   for (const column of table.columns) {
     columnLines.push(
@@ -480,7 +495,7 @@ function emitTable(
     );
   }
 
-  const constraintBlock = emitConstraints(table, imports);
+  const constraintBlock = emitConstraints(table, tableIdentifiers, imports);
 
   const tableLines: string[] = [];
   tableLines.push(
@@ -498,6 +513,7 @@ function emitTable(
 
 function emitConstraints(
   table: IntrospectedTable,
+  tableIdentifiers: ReadonlyMap<string, string>,
   imports: ImportBuckets
 ): string {
   const constraints = table.constraints.filter((constraint) =>
@@ -530,7 +546,13 @@ function emitConstraints(
       constraint.referencedTable
     ) {
       imports.pgCore.add('foreignKey');
-      const targetTable = toIdentifier(constraint.referencedTable.name);
+      const targetTable =
+        tableIdentifiers.get(
+          tableKey(
+            constraint.referencedTable.schema,
+            constraint.referencedTable.name
+          )
+        ) ?? toIdentifier(constraint.referencedTable.name);
       entries.push(
         `${key}: foreignKey({ columns: [${constraint.columns
           .map((col) => `t.${toIdentifier(col)}`)
@@ -561,6 +583,62 @@ function emitConstraints(
   }
   lines.push('})');
   return lines.join('\n');
+}
+
+function buildSchemaIdentifiers(
+  tables: IntrospectedTable[]
+): Map<string, string> {
+  const identifiers = new Map<string, string>();
+  const used = new Set<string>();
+
+  for (const schema of uniqueSchemas(tables)) {
+    identifiers.set(
+      schema,
+      allocateIdentifier(toSchemaIdentifier(schema), used)
+    );
+  }
+
+  return identifiers;
+}
+
+function buildTableIdentifiers(
+  tables: IntrospectedTable[],
+  reserved: Set<string>
+): Map<string, string> {
+  const identifiers = new Map<string, string>();
+  const baseCounts = new Map<string, number>();
+
+  for (const table of tables) {
+    const base = toIdentifier(table.name);
+    baseCounts.set(base, (baseCounts.get(base) ?? 0) + 1);
+  }
+
+  for (const table of tables) {
+    const base = toIdentifier(table.name);
+    const preferred =
+      (baseCounts.get(base) ?? 0) > 1
+        ? `${toIdentifier(table.schema)}${capitalize(base)}`
+        : base;
+    identifiers.set(
+      tableKey(table.schema, table.name),
+      allocateIdentifier(preferred, reserved)
+    );
+  }
+
+  return identifiers;
+}
+
+function allocateIdentifier(preferred: string, used: Set<string>): string {
+  let candidate = preferred;
+  let suffix = 2;
+
+  while (used.has(candidate)) {
+    candidate = `${preferred}${suffix}`;
+    suffix += 1;
+  }
+
+  used.add(candidate);
+  return candidate;
 }
 
 interface ColumnEmitOptions extends EmitOptions {}

--- a/test/introspect.typecheck.test.ts
+++ b/test/introspect.typecheck.test.ts
@@ -17,6 +17,8 @@ beforeAll(async () => {
   const db = drizzle(connection);
 
   await db.execute(sql`create schema if not exists tc`);
+  await db.execute(sql`create schema if not exists tc_sales`);
+  await db.execute(sql`create schema if not exists tc_support`);
   await db.execute(sql`
     create table tc.metrics (
       id integer primary key,
@@ -25,6 +27,18 @@ beforeAll(async () => {
       created_at timestamp with time zone
     )
   `);
+  await db.execute(
+    sql`create table tc_sales.customers (id integer primary key)`
+  );
+  await db.execute(sql`
+    create table tc_sales.orders (
+      id integer primary key,
+      customer_id integer references tc_sales.customers(id)
+    )
+  `);
+  await db.execute(
+    sql`create table tc_support.customers (id integer primary key)`
+  );
 });
 
 afterAll(() => {
@@ -40,11 +54,23 @@ test('generated schema type-checks with tsc', async () => {
   const importBasePath = '@duckdbfan/drizzle-duckdb';
 
   const result = await introspect(db, {
-    schemas: ['tc'],
+    schemas: ['tc', 'tc_sales', 'tc_support'],
     importBasePath,
   });
 
   fs.writeFileSync(schemaPath, result.files.schemaTs, 'utf8');
+  expect(result.files.schemaTs).toContain(
+    'export const tcSalesCustomers = tcSalesSchema.table("customers"'
+  );
+  expect(result.files.schemaTs).toContain(
+    'export const tcSupportCustomers = tcSupportSchema.table("customers"'
+  );
+  expect(result.files.schemaTs).toContain(
+    'export const metrics = tcSchema.table("metrics"'
+  );
+  expect(result.files.schemaTs).toContain(
+    'foreignColumns: [tcSalesCustomers.id]'
+  );
 
   const tsconfigPath = path.join(tmpDir, 'tsconfig.generated.json');
   const tsconfig = {


### PR DESCRIPTION
Multi-schema introspection currently emits duplicate TypeScript exports when schemas contain same-named tables. This makes generated schemas fail to compile. This change assigns deterministic schema-qualified identifiers only when needed and preserves foreign-key references.

### Codex description

- disambiguate colliding schema and table identifiers while preserving existing non-colliding names
- resolve generated foreign keys through the final table identifier map
- add a real DuckDB multi-schema type-check regression and bump to 1.5.4-5