### PR TITLE
refactor(client): extract prepared statement cache

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -3,7 +3,6 @@ import {
   timestampValue,
   type DuckDBConnection,
   type DuckDBInstance,
-  type DuckDBPreparedStatement,
   type DuckDBValue,
 } from '@duckdb/node-api';
 import {
@@ -17,6 +16,11 @@ import {
 } from './options.ts';
 import { isPgArrayLiteral, parsePgArrayLiteral } from './array-literals.ts';
 import type { PgDuckClient, PgDuckField, PgDuckQueryResult } from './pgduck.ts';
+import {
+  bindPreparedStatement,
+  clearPreparedStatementCache,
+  getPreparedStatementCache,
+} from './prepared-statement-cache.ts';
 
 export type DuckDBExecutionClient = DuckDBConnection | PgDuckClient;
 export type DuckDBClientLike = DuckDBExecutionClient | DuckDBConnectionPool;
@@ -41,15 +45,6 @@ export interface ExecuteClientOptions {
 export type ExecuteArraysResult = { columns: string[]; rows: unknown[][] };
 
 type MaterializedRows = ExecuteArraysResult;
-
-type PreparedCacheEntry = {
-  statement: DuckDBPreparedStatement;
-};
-
-type PreparedStatementCache = {
-  size: number;
-  entries: Map<string, PreparedCacheEntry>;
-};
 
 type ResultColumnsLike = {
   columnNames: () => string[];
@@ -76,8 +71,6 @@ type ClosableResource = {
 type DisconnectableResource = ClosableResource & {
   disconnectSync?: () => void;
 };
-
-const PREPARED_CACHE = Symbol.for('drizzle-duckdb:prepared-cache');
 
 interface PreferredResultReader<T> {
   readDefault: () => Promise<T>;
@@ -348,93 +341,6 @@ function normalizeDeduplicatedColumns(
   return changed ? normalized : deduplicatedColumns;
 }
 
-function destroyPreparedStatement(entry: PreparedCacheEntry | undefined): void {
-  if (!entry) return;
-  try {
-    entry.statement.destroySync();
-  } catch {
-    // Ignore cleanup errors
-  }
-}
-
-function getPreparedCache(
-  connection: DuckDBConnection,
-  size: number
-): PreparedStatementCache {
-  const store = connection as unknown as Record<
-    symbol,
-    PreparedStatementCache | undefined
-  >;
-  const existing = store[PREPARED_CACHE];
-  if (existing) {
-    existing.size = size;
-    return existing;
-  }
-
-  const cache: PreparedStatementCache = { size, entries: new Map() };
-  store[PREPARED_CACHE] = cache;
-  return cache;
-}
-
-function evictOldest(cache: PreparedStatementCache): void {
-  const oldest = cache.entries.keys().next();
-  if (!oldest.done) {
-    const key = oldest.value as string;
-    const entry = cache.entries.get(key);
-    cache.entries.delete(key);
-    destroyPreparedStatement(entry);
-  }
-}
-
-function evictCacheEntry(cache: PreparedStatementCache, key: string): void {
-  const entry = cache.entries.get(key);
-  cache.entries.delete(key);
-  destroyPreparedStatement(entry);
-}
-
-function rememberPreparedStatement(
-  cache: PreparedStatementCache,
-  query: string,
-  statement: DuckDBPreparedStatement
-): DuckDBPreparedStatement {
-  cache.entries.delete(query);
-  cache.entries.set(query, { statement });
-  return statement;
-}
-
-async function getOrPrepareStatement(
-  connection: DuckDBConnection,
-  query: string,
-  cacheConfig: PreparedStatementCacheConfig
-): Promise<DuckDBPreparedStatement> {
-  const cache = getPreparedCache(connection, cacheConfig.size);
-  const cached = cache.entries.get(query);
-  if (cached) {
-    return rememberPreparedStatement(cache, query, cached.statement);
-  }
-
-  const statement = await connection.prepare(query);
-  rememberPreparedStatement(cache, query, statement);
-
-  while (cache.entries.size > cache.size) {
-    evictOldest(cache);
-  }
-
-  return statement;
-}
-
-function bindPreparedStatement(
-  statement: DuckDBPreparedStatement,
-  values: DuckDBValue[] | undefined
-): void {
-  if (values) {
-    statement.bind(values);
-    return;
-  }
-
-  statement.clearBindings?.();
-}
-
 function resolveResultColumns(result: ResultColumnsLike): string[] {
   const columns = result.columnNames();
 
@@ -555,20 +461,16 @@ async function executePreparedQuery(
   values: DuckDBValue[] | undefined,
   cacheConfig: PreparedStatementCacheConfig
 ): Promise<MaterializedRows> {
-  const cache = getPreparedCache(connection, cacheConfig.size);
+  const cache = getPreparedStatementCache(connection, cacheConfig.size);
 
   try {
-    const statement = await getOrPrepareStatement(
-      connection,
-      query,
-      cacheConfig
-    );
+    const statement = await cache.getOrPrepare(query);
     bindPreparedStatement(statement, values);
     const result = await statement.run();
-    rememberPreparedStatement(cache, query, statement);
+    cache.remember(query, statement);
     return await materializeResultRows(result);
   } catch (error) {
-    evictCacheEntry(cache, query);
+    cache.evict(query);
     throw error;
   }
 }
@@ -692,19 +594,6 @@ async function materializePgDuckRows(
   );
 }
 
-function clearPreparedCache(connection: DuckDBConnection): void {
-  const store = connection as unknown as Record<
-    symbol,
-    PreparedStatementCache | undefined
-  >;
-  const cache = store[PREPARED_CACHE];
-  if (!cache) return;
-  for (const entry of cache.entries.values()) {
-    destroyPreparedStatement(entry);
-  }
-  cache.entries.clear();
-}
-
 function mapRowsToObjects(columns: string[], rows: unknown[][]): RowData[] {
   const mappedRows: RowData[] = new Array(rows.length);
 
@@ -745,7 +634,7 @@ export async function closeClientConnection(
   connection: DuckDBExecutionClient
 ): Promise<void> {
   if (isNodeApiConnection(connection)) {
-    clearPreparedCache(connection);
+    clearPreparedStatementCache(connection);
   }
 
   await closeDuckDbResource(connection as DisconnectableResource, true);

--- a/src/prepared-statement-cache.ts
+++ b/src/prepared-statement-cache.ts
@@ -1,0 +1,120 @@
+import type {
+  DuckDBConnection,
+  DuckDBPreparedStatement,
+  DuckDBValue,
+} from '@duckdb/node-api';
+
+type PreparedCacheEntry = {
+  statement: DuckDBPreparedStatement;
+};
+
+const PREPARED_CACHE = Symbol.for('drizzle-duckdb:prepared-cache');
+
+function destroyPreparedStatement(entry: PreparedCacheEntry | undefined): void {
+  if (!entry) return;
+
+  try {
+    entry.statement.destroySync();
+  } catch {
+    // Ignore cleanup errors
+  }
+}
+
+export class PreparedStatementCache {
+  private entries = new Map<string, PreparedCacheEntry>();
+
+  constructor(
+    private connection: DuckDBConnection,
+    private size: number
+  ) {}
+
+  resize(size: number): void {
+    this.size = size;
+  }
+
+  async getOrPrepare(query: string): Promise<DuckDBPreparedStatement> {
+    const cached = this.entries.get(query);
+    if (cached) {
+      return this.remember(query, cached.statement);
+    }
+
+    const statement = await this.connection.prepare(query);
+    this.remember(query, statement);
+
+    while (this.entries.size > this.size) {
+      this.evictOldest();
+    }
+
+    return statement;
+  }
+
+  remember(
+    query: string,
+    statement: DuckDBPreparedStatement
+  ): DuckDBPreparedStatement {
+    this.entries.delete(query);
+    this.entries.set(query, { statement });
+    return statement;
+  }
+
+  evict(query: string): void {
+    const entry = this.entries.get(query);
+    this.entries.delete(query);
+    destroyPreparedStatement(entry);
+  }
+
+  clear(): void {
+    for (const entry of this.entries.values()) {
+      destroyPreparedStatement(entry);
+    }
+    this.entries.clear();
+  }
+
+  private evictOldest(): void {
+    const oldest = this.entries.keys().next();
+    if (!oldest.done) {
+      this.evict(oldest.value);
+    }
+  }
+}
+
+export function getPreparedStatementCache(
+  connection: DuckDBConnection,
+  size: number
+): PreparedStatementCache {
+  const store = connection as unknown as Record<
+    symbol,
+    PreparedStatementCache | undefined
+  >;
+  const existing = store[PREPARED_CACHE];
+  if (existing) {
+    existing.resize(size);
+    return existing;
+  }
+
+  const cache = new PreparedStatementCache(connection, size);
+  store[PREPARED_CACHE] = cache;
+  return cache;
+}
+
+export function clearPreparedStatementCache(
+  connection: DuckDBConnection
+): void {
+  const store = connection as unknown as Record<
+    symbol,
+    PreparedStatementCache | undefined
+  >;
+  store[PREPARED_CACHE]?.clear();
+}
+
+export function bindPreparedStatement(
+  statement: DuckDBPreparedStatement,
+  values: DuckDBValue[] | undefined
+): void {
+  if (values) {
+    statement.bind(values);
+    return;
+  }
+
+  statement.clearBindings?.();
+}

--- a/test/prepared-statement-cache.test.ts
+++ b/test/prepared-statement-cache.test.ts
@@ -1,0 +1,67 @@
+import type {
+  DuckDBConnection,
+  DuckDBPreparedStatement,
+} from '@duckdb/node-api';
+import { expect, test, vi } from 'vitest';
+import {
+  bindPreparedStatement,
+  clearPreparedStatementCache,
+  getPreparedStatementCache,
+} from '../src/prepared-statement-cache.ts';
+
+function createStatement() {
+  return {
+    bind: vi.fn(),
+    clearBindings: vi.fn(),
+    destroySync: vi.fn(),
+  } as unknown as DuckDBPreparedStatement;
+}
+
+test('reuses statements and evicts the least recently used entry', async () => {
+  const statements = [createStatement(), createStatement(), createStatement()];
+  const connection = {
+    prepare: vi
+      .fn()
+      .mockResolvedValueOnce(statements[0])
+      .mockResolvedValueOnce(statements[1])
+      .mockResolvedValueOnce(statements[2]),
+  } as unknown as DuckDBConnection;
+  const cache = getPreparedStatementCache(connection, 2);
+
+  expect(await cache.getOrPrepare('select 1')).toBe(statements[0]);
+  expect(await cache.getOrPrepare('select 2')).toBe(statements[1]);
+  expect(await cache.getOrPrepare('select 1')).toBe(statements[0]);
+  expect(await cache.getOrPrepare('select 3')).toBe(statements[2]);
+
+  expect(connection.prepare).toHaveBeenCalledTimes(3);
+  expect(statements[0]?.destroySync).not.toHaveBeenCalled();
+  expect(statements[1]?.destroySync).toHaveBeenCalledTimes(1);
+  expect(statements[2]?.destroySync).not.toHaveBeenCalled();
+});
+
+test('clears cached statements and preserves the cache instance', async () => {
+  const statement = createStatement();
+  const connection = {
+    prepare: vi.fn().mockResolvedValue(statement),
+  } as unknown as DuckDBConnection;
+  const cache = getPreparedStatementCache(connection, 1);
+
+  await cache.getOrPrepare('select 1');
+  clearPreparedStatementCache(connection);
+
+  expect(statement.destroySync).toHaveBeenCalledTimes(1);
+  expect(getPreparedStatementCache(connection, 1)).toBe(cache);
+  expect(await cache.getOrPrepare('select 1')).toBe(statement);
+  expect(connection.prepare).toHaveBeenCalledTimes(2);
+});
+
+test('binds values and clears stale bindings when values are absent', () => {
+  const statement = createStatement();
+  const values = [42];
+
+  bindPreparedStatement(statement, values);
+  bindPreparedStatement(statement, undefined);
+
+  expect(statement.bind).toHaveBeenCalledWith(values);
+  expect(statement.clearBindings).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
Prepared-statement cache ownership was embedded in the client execution module. This extracts the cache lifecycle into a focused internal module without changing the public API or query behavior.\n\n### Codex description\n\n- centralize prepared statement reuse, LRU eviction, binding reset, and cleanup\n- add focused tests for cache lifecycle behavior