### PR TITLE
Fix prepared cache downsizing

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-5",
+  "version": "1.5.4-6",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {

--- a/src/prepared-statement-cache.ts
+++ b/src/prepared-statement-cache.ts
@@ -30,6 +30,7 @@ export class PreparedStatementCache {
 
   resize(size: number): void {
     this.size = size;
+    this.trimToSize();
   }
 
   async getOrPrepare(query: string): Promise<DuckDBPreparedStatement> {
@@ -41,10 +42,6 @@ export class PreparedStatementCache {
     const statement = await this.connection.prepare(query);
     this.remember(query, statement);
 
-    while (this.entries.size > this.size) {
-      this.evictOldest();
-    }
-
     return statement;
   }
 
@@ -54,6 +51,7 @@ export class PreparedStatementCache {
   ): DuckDBPreparedStatement {
     this.entries.delete(query);
     this.entries.set(query, { statement });
+    this.trimToSize();
     return statement;
   }
 
@@ -74,6 +72,12 @@ export class PreparedStatementCache {
     const oldest = this.entries.keys().next();
     if (!oldest.done) {
       this.evict(oldest.value);
+    }
+  }
+
+  private trimToSize(): void {
+    while (this.entries.size > this.size) {
+      this.evictOldest();
     }
   }
 }

--- a/test/prepared-statement-cache.test.ts
+++ b/test/prepared-statement-cache.test.ts
@@ -39,6 +39,29 @@ test('reuses statements and evicts the least recently used entry', async () => {
   expect(statements[2]?.destroySync).not.toHaveBeenCalled();
 });
 
+test('evicts excess statements immediately when resized', async () => {
+  const statements = [createStatement(), createStatement(), createStatement()];
+  const connection = {
+    prepare: vi
+      .fn()
+      .mockResolvedValueOnce(statements[0])
+      .mockResolvedValueOnce(statements[1])
+      .mockResolvedValueOnce(statements[2]),
+  } as unknown as DuckDBConnection;
+  const cache = getPreparedStatementCache(connection, 3);
+
+  await cache.getOrPrepare('select 1');
+  await cache.getOrPrepare('select 2');
+  await cache.getOrPrepare('select 3');
+  getPreparedStatementCache(connection, 1);
+
+  expect(statements[0]?.destroySync).toHaveBeenCalledTimes(1);
+  expect(statements[1]?.destroySync).toHaveBeenCalledTimes(1);
+  expect(statements[2]?.destroySync).not.toHaveBeenCalled();
+  expect(await cache.getOrPrepare('select 3')).toBe(statements[2]);
+  expect(connection.prepare).toHaveBeenCalledTimes(3);
+});
+
 test('clears cached statements and preserves the cache instance', async () => {
   const statement = createStatement();
   const connection = {


### PR DESCRIPTION
## Summary

- enforce the prepared-statement cache size immediately when a shared connection is reconfigured with a smaller limit
- centralize trimming so both inserts and resizes release least-recently-used native statements
- bump the package version to 1.5.4-6 for the public bug fix

## Verification

- real DuckDB smoke confirms excess native statements are destroyed after downsizing
- 652 tests passed, 6 skipped
- formatting, TypeScript, build, declarations, npm pack dry-run, audit, pre-commit, and benchmarks passed
- live MotherDuck integration passed