### PR TITLE
Fix duplicate result column collisions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,14 +9,14 @@
       },
       "devDependencies": {
         "@duckdb/node-api": "1.5.5-r.4",
-        "@types/bun": "1.3.14",
+        "@types/bun": "1.4.0",
         "@types/node": "26.2.0",
         "@vitest/ui": "4.1.11",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
         "tinybench": "6.1.3",
         "typescript": "6.0.3",
-        "uuid": "14.0.1",
+        "uuid": "14.0.2",
         "vitest": "4.1.11",
       },
       "peerDependencies": {
@@ -105,7 +105,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
 
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
@@ -137,7 +137,7 @@
 
     "big-integer": ["big-integer@1.6.52", "", {}, "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg=="],
 
-    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -233,7 +233,7 @@
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
-    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+    "uuid": ["uuid@14.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ=="],
 
     "vite": ["vite@8.1.4", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.16", "rolldown": "~1.1.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ=="],
 
@@ -241,10 +241,6 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
-    "bun-types/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
-
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
-
-    "bun-types/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-7",
+  "version": "1.5.4-8",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {
@@ -29,14 +29,14 @@
   },
   "devDependencies": {
     "@duckdb/node-api": "1.5.5-r.4",
-    "@types/bun": "1.3.14",
+    "@types/bun": "1.4.0",
     "@types/node": "26.2.0",
     "@vitest/ui": "4.1.11",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",
     "tinybench": "6.1.3",
     "typescript": "6.0.3",
-    "uuid": "14.0.1",
+    "uuid": "14.0.2",
     "vitest": "4.1.11"
   },
   "repository": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -287,28 +287,30 @@ function toPgDuckValues(params: unknown[]): unknown[] {
 }
 
 function deduplicateColumns(columns: string[]): string[] {
-  const counts = new Map<string, number>();
-  let hasDuplicates = false;
+  const used = new Set<string>();
+  const nextSuffix = new Map<string, number>();
+  let deduplicated: string[] | undefined;
 
-  for (const column of columns) {
-    const next = (counts.get(column) ?? 0) + 1;
-    counts.set(column, next);
-    if (next > 1) {
-      hasDuplicates = true;
-      break;
+  for (let index = 0; index < columns.length; index += 1) {
+    const column = columns[index] as string;
+    let candidate = column;
+
+    if (used.has(candidate)) {
+      let suffix = nextSuffix.get(column) ?? 1;
+      do {
+        candidate = `${column}_${suffix}`;
+        suffix += 1;
+      } while (used.has(candidate));
+
+      nextSuffix.set(column, suffix);
+      deduplicated ??= columns.slice();
+      deduplicated[index] = candidate;
     }
+
+    used.add(candidate);
   }
 
-  if (!hasDuplicates) {
-    return columns;
-  }
-
-  counts.clear();
-  return columns.map((column) => {
-    const count = counts.get(column) ?? 0;
-    counts.set(column, count + 1);
-    return count === 0 ? column : `${column}_${count}`;
-  });
+  return deduplicated ?? columns;
 }
 
 function normalizeDeduplicatedColumns(
@@ -316,10 +318,9 @@ function normalizeDeduplicatedColumns(
   deduplicatedColumns: string[]
 ): string[] {
   if (columns.length !== deduplicatedColumns.length) {
-    return deduplicatedColumns;
+    return deduplicateColumns(deduplicatedColumns);
   }
 
-  let changed = false;
   const normalized = deduplicatedColumns.map((column, index) => {
     const original = columns[index];
     if (column === original) {
@@ -330,7 +331,6 @@ function normalizeDeduplicatedColumns(
     if (column.startsWith(duplicatePrefix)) {
       const suffix = column.slice(duplicatePrefix.length);
       if (/^\d+$/.test(suffix)) {
-        changed = true;
         return `${original}_${suffix}`;
       }
     }
@@ -338,7 +338,7 @@ function normalizeDeduplicatedColumns(
     return column;
   });
 
-  return changed ? normalized : deduplicatedColumns;
+  return deduplicateColumns(normalized);
 }
 
 function resolveResultColumns(result: ResultColumnsLike): string[] {

--- a/test/aliasing.test.ts
+++ b/test/aliasing.test.ts
@@ -109,3 +109,9 @@ test('duplicate column aliases preserve ordering', async () => {
 
   expect(rows).toEqual([{ first: 1, second: 2 }]);
 });
+
+test('raw duplicate aliases avoid generated name collisions', async () => {
+  const rows = await ctx.db.execute(sql`select 1 as a, 2 as a, 3 as a_1`);
+
+  expect(rows).toEqual([{ a: 1, a_1: 2, a_1_1: 3 }]);
+});

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -383,6 +383,18 @@ describe('executeOnClient', () => {
     expect(rows).toEqual([{ id: 1, id_1: 2 }]);
   });
 
+  test('keeps normalized duplicate column names unique', async () => {
+    const client = makeClient({
+      rows: [[1, 2, 3]],
+      columns: ['id', 'id', 'id_1'],
+      deduplicatedColumns: ['id', 'id:1', 'id_1'],
+    });
+
+    const rows = await executeOnClient(client, 'select', []);
+
+    expect(rows).toEqual([{ id: 1, id_1: 2, id_1_1: 3 }]);
+  });
+
   test('uses JSON materialization for precise time families', async () => {
     const client = makeClient({
       rows: [[new Date('2024-03-01T12:34:56.123Z')]],
@@ -537,6 +549,23 @@ describe('executeInBatchesRaw', () => {
     }
 
     expect(chunks).toEqual([{ columns: ['id', 'id_1'], rows: [[1, 2]] }]);
+  });
+
+  test('keeps fallback duplicate column names unique', async () => {
+    const client = makeClient({
+      rows: [[1, 2, 3]],
+      columns: ['id', 'id', 'id_1'],
+      deduplicatedColumns: undefined,
+    });
+    const chunks: Array<{ columns: string[]; rows: unknown[][] }> = [];
+
+    for await (const chunk of executeInBatchesRaw(client, 'select', [])) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([
+      { columns: ['id', 'id_1', 'id_1_1'], rows: [[1, 2, 3]] },
+    ]);
   });
 
   test('closes stream when consumer exits early', async () => {


### PR DESCRIPTION
## Summary

Fix result materialization when DuckDB returns duplicate aliases that collide with an existing suffixed column name. Every value now receives a stable unique key instead of silently overwriting an earlier result.

Also updates the safe maintenance dependencies `@types/bun` to 1.4.0 and `uuid` to 14.0.2, and bumps the package to 1.5.4-8.

## Verification

- `CI=1 bun test` (656 passed, 8 skipped)
- `bun run build`
- `bun run bench`
- `pre-commit run --all-files`
- `bun x prettier --check .`
- `bun audit`
- `npm pack --dry-run`
- live MotherDuck integration (2 passed)
- built-package smoke: `select 1 as a, 2 as a, 3 as a_1` preserves all three values