### PR TITLE
refactor: deduplicate array predicate helpers

### DIFF
--- a/src/columns.ts
+++ b/src/columns.ts
@@ -584,25 +584,25 @@ export const duckDbTime = (name: string, options: TimeOptions = {}) =>
     },
   })(name);
 
-export function duckDbArrayContains(
+export function duckDbArrayContains<T>(
   column: SQLWrapper,
-  values: ArrayPredicateValue<unknown>
+  values: ArrayPredicateValue<T>
 ): SQL {
   const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_all(${column}, ${rhs})`;
 }
 
-export function duckDbArrayContained(
+export function duckDbArrayContained<T>(
   column: SQLWrapper,
-  values: ArrayPredicateValue<unknown>
+  values: ArrayPredicateValue<T>
 ): SQL {
   const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_all(${rhs}, ${column})`;
 }
 
-export function duckDbArrayOverlaps(
+export function duckDbArrayOverlaps<T>(
   column: SQLWrapper,
-  values: ArrayPredicateValue<unknown>
+  values: ArrayPredicateValue<T>
 ): SQL {
   const rhs = normalizeArrayPredicateValue(values);
   return sql`array_has_any(${column}, ${rhs})`;

--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,34 +1,8 @@
 /**
- * DuckDB-native array operators. Generate DuckDB-compatible SQL directly
- * without query rewriting.
+ * DuckDB-native names for the array predicate helpers.
  */
-
-import { sql, type SQL, type SQLWrapper } from 'drizzle-orm';
-import {
-  normalizeArrayPredicateValue,
-  type ArrayPredicateValue,
+export {
+  duckDbArrayContains as arrayHasAll,
+  duckDbArrayOverlaps as arrayHasAny,
+  duckDbArrayContained as arrayContainedBy,
 } from './columns.ts';
-
-export function arrayHasAll<T>(
-  column: SQLWrapper,
-  values: ArrayPredicateValue<T>
-): SQL {
-  const rhs = normalizeArrayPredicateValue(values);
-  return sql`array_has_all(${column}, ${rhs})`;
-}
-
-export function arrayHasAny<T>(
-  column: SQLWrapper,
-  values: ArrayPredicateValue<T>
-): SQL {
-  const rhs = normalizeArrayPredicateValue(values);
-  return sql`array_has_any(${column}, ${rhs})`;
-}
-
-export function arrayContainedBy<T>(
-  column: SQLWrapper,
-  values: ArrayPredicateValue<T>
-): SQL {
-  const lhs = normalizeArrayPredicateValue(values);
-  return sql`array_has_all(${lhs}, ${column})`;
-}

--- a/test/arrays.test.ts
+++ b/test/arrays.test.ts
@@ -2,6 +2,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import type { DuckDBConnection } from '@duckdb/node-api';
 import {
   duckDbArray,
+  duckDbArrayContained,
   duckDbArrayContains,
   duckDbArrayOverlaps,
   duckDbList,
@@ -29,6 +30,12 @@ interface Context {
 }
 
 let ctx: Context;
+
+test('array predicate names share their implementations', () => {
+  expect(arrayHasAll).toBe(duckDbArrayContains);
+  expect(arrayHasAny).toBe(duckDbArrayOverlaps);
+  expect(arrayContainedBy).toBe(duckDbArrayContained);
+});
 
 beforeAll(async () => {
   const instance = await DuckDBInstance.create(':memory:');


### PR DESCRIPTION
Consolidates the two public array predicate naming families so they share one implementation and cannot drift apart.

### Codex description

- re-export native array helper names from the canonical DuckDB helper implementations
- preserve generic value inference and add identity coverage for every alias