### PR TITLE
Fix MotherDuck Flight log compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,10 @@ the older `job_*` result column names where the Flight result uses `flight_*`.
 The earlier `mdFlights()`, `mdFlightRuns()`, `mdFlightLogs()`, and
 `mdFlightVersions()` TypeScript helper names also remain as deprecated aliases,
 but new code should use the verb-style Flight helpers.
+`mdGetFlightLogs()` returns one `MotherDuckFlightLogLineRow` per log line with
+`line_number`, `reported_at`, and `line` fields. The old blob-shaped
+`MotherDuckFlightLogsRow` type remains exported for the deprecated
+`mdFlightLogs()` and `mdJobRunLogs()` compatibility views.
 For optional Flight fields, `undefined` omits the named parameter and `null`
 emits an explicit SQL `NULL`. MotherDuck treats explicit `NULL` values as clear
 or empty values for nullable Flight options such as `requirementsTxt`, `config`,

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.5-r.4",
         "@types/bun": "1.4.0",
-        "@types/node": "26.2.0",
+        "@types/node": "26.3.0",
         "@vitest/ui": "4.1.11",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
@@ -113,7 +113,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
+    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 
@@ -240,6 +240,8 @@
     "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "bun-types/@types/node": ["@types/node@26.2.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg=="],
 
     "vitest/tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-8",
+  "version": "1.5.4-9",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.5-r.4",
     "@types/bun": "1.4.0",
-    "@types/node": "26.2.0",
+    "@types/node": "26.3.0",
     "@vitest/ui": "4.1.11",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",

--- a/src/motherduck.ts
+++ b/src/motherduck.ts
@@ -107,6 +107,16 @@ export interface MotherDuckFlightRunRow {
   exit_code: number | null;
 }
 
+export interface MotherDuckFlightLogLineRow {
+  line_number: number | bigint | null;
+  reported_at: Date | string | null;
+  line: string | null;
+}
+
+/**
+ * @deprecated Flight logs are returned one line per row. Use
+ * MotherDuckFlightLogLineRow.
+ */
 export interface MotherDuckFlightLogsRow {
   logs: string;
 }
@@ -495,6 +505,10 @@ function motherDuckJobVersionView(source: SQL): SQL {
   ]);
 }
 
+function motherDuckLegacyFlightLogsView(source: SQL): SQL {
+  return sql`(select coalesce(string_agg(coalesce(line, ''), chr(10)), '') as logs from ${source}) as md_flight_logs`;
+}
+
 function motherDuckPagedParams(
   options: MotherDuckPaginationOptions = {}
 ): NamedParameter[] {
@@ -800,6 +814,7 @@ export function mdFlightRuns(
   return mdListFlightRuns(flightId, options);
 }
 
+/** Return the run log as oldest-first line rows. */
 export function mdGetFlightLogs(
   flightId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
@@ -810,12 +825,15 @@ export function mdGetFlightLogs(
   );
 }
 
-/** @deprecated Use mdGetFlightLogs. */
+/**
+ * @deprecated Use mdGetFlightLogs for line-oriented log rows. This alias keeps
+ * returning the earlier single-row logs blob.
+ */
 export function mdFlightLogs(
   flightId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
 ): SQL {
-  return mdGetFlightLogs(flightId, runNumber);
+  return motherDuckLegacyFlightLogsView(mdGetFlightLogs(flightId, runNumber));
 }
 
 export function mdListFlightVersions(
@@ -915,12 +933,15 @@ export function mdJobRuns(
   return motherDuckJobRunView(mdListFlightRuns(jobId, options));
 }
 
-/** @deprecated Use mdGetFlightLogs. */
+/**
+ * @deprecated Use mdGetFlightLogs for line-oriented log rows. This alias keeps
+ * returning the earlier single-row logs blob.
+ */
 export function mdJobRunLogs(
   jobId: string | SQLWrapper,
   runNumber: number | bigint | SQLWrapper
 ): SQL {
-  return mdGetFlightLogs(jobId, runNumber);
+  return motherDuckLegacyFlightLogsView(mdGetFlightLogs(jobId, runNumber));
 }
 
 /** @deprecated Use mdListFlightVersions. */

--- a/test/motherduck-functions.test.ts
+++ b/test/motherduck-functions.test.ts
@@ -37,6 +37,8 @@ import {
   mdUpdateFlight,
   mdUpdateJob,
   type MotherDuckDiveVersionSummaryRow,
+  type MotherDuckFlightLogLineRow,
+  type MotherDuckFlightLogsRow,
 } from '../src/motherduck.ts';
 import { DuckDBDialect } from '../src/dialect.ts';
 
@@ -315,6 +317,20 @@ test('MotherDuck flight helpers emit named-parameter table functions', () => {
   );
 });
 
+test('MotherDuck flight log row types preserve line results and legacy imports', () => {
+  const line: MotherDuckFlightLogLineRow = {
+    line_number: 3n,
+    reported_at: '2026-08-26T12:00:00Z',
+    line: 'refresh complete',
+  };
+  const legacy: MotherDuckFlightLogsRow = {
+    logs: 'refresh complete\n',
+  };
+
+  expect(line.line).toBe('refresh complete');
+  expect(legacy.logs).toBe('refresh complete\n');
+});
+
 test('deprecated MotherDuck flight helper aliases emit supported table functions', () => {
   const dialect = new DuckDBDialect();
   const flightId = '80000000-0000-0000-0000-000000000001';
@@ -327,7 +343,9 @@ test('deprecated MotherDuck flight helper aliases emit supported table functions
   ).toContain('from md_list_flight_runs(flight_id = $1, "LIMIT" = $2)');
   expect(
     dialect.sqlToQuery(sql`from ${mdFlightLogs(flightId, 1)}`).sql
-  ).toContain('from md_get_flight_logs(flight_id = $1, run_number = $2)');
+  ).toContain(
+    "from (select coalesce(string_agg(coalesce(line, ''), chr(10)), '') as logs from md_get_flight_logs(flight_id = $1, run_number = $2)) as md_flight_logs"
+  );
   expect(
     dialect.sqlToQuery(sql`from ${mdFlightVersions(flightId, { offset: 2 })}`)
       .sql
@@ -548,7 +566,7 @@ test('deprecated MotherDuck job helpers emit supported Flight functions', () => 
     'from (select run_id, flight_id as job_id, flight_name as job_name, flight_version as job_version, run_number, is_scheduled, status, created_at, started_at, ended_at, scheduled_at, cancelled_at, exit_code from md_list_flight_runs(flight_id = $1, "LIMIT" = $2)) as md_job_runs'
   );
   expect(dialect.sqlToQuery(sql`from ${mdJobRunLogs(jobId, 1)}`).sql).toContain(
-    'from md_get_flight_logs(flight_id = $1, run_number = $2)'
+    "from (select coalesce(string_agg(coalesce(line, ''), chr(10)), '') as logs from md_get_flight_logs(flight_id = $1, run_number = $2)) as md_flight_logs"
   );
   expect(
     dialect.sqlToQuery(sql`from ${mdJobVersions(jobId, { offset: 2 })}`).sql

--- a/test/motherduck.integration.test.ts
+++ b/test/motherduck.integration.test.ts
@@ -9,6 +9,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { drizzle } from '../src';
 import { introspect } from '../src/introspect';
+import { mdFlightLogs, mdGetFlightLogs } from '../src/motherduck.ts';
 import { expect, test } from 'vitest';
 
 const motherduckToken = process.env.MOTHERDUCK_TOKEN;
@@ -203,6 +204,44 @@ if (skipMotherduck) {
 
         // The generated schema should not reference sample_data
         expect(result.files.schemaTs).not.toContain('sample_data');
+      } finally {
+        connection.closeSync();
+        instance.closeSync();
+      }
+    });
+
+    if (completed === undefined) {
+      return;
+    }
+  }, 120_000);
+
+  test('Flight logs expose line-oriented result columns', async () => {
+    const completed = await runWithMotherDuckAccess(async () => {
+      const instance = await DuckDBInstance.create('md:', {
+        motherduck_token: motherduckToken,
+      });
+      const connection: DuckDBConnection = await instance.connect();
+      const db = drizzle(connection);
+
+      try {
+        const columns = await db.execute<{ column_name: string }>(sql`
+          describe select *
+          from ${mdGetFlightLogs(sql`uuid()`, sql`0::ubigint`)}
+        `);
+
+        expect(columns.map((column) => column.column_name)).toEqual([
+          'line_number',
+          'reported_at',
+          'line',
+        ]);
+
+        const legacyColumns = await db.execute<{ column_name: string }>(sql`
+          describe select *
+          from ${mdFlightLogs(sql`uuid()`, sql`0::ubigint`)}
+        `);
+        expect(legacyColumns.map((column) => column.column_name)).toEqual([
+          'logs',
+        ]);
       } finally {
         connection.closeSync();
         instance.closeSync();


### PR DESCRIPTION
## Summary

Align the public Flight log helper types with the current line-oriented result and preserve the deprecated blob-shaped aliases through compatibility views. Prepare package version 1.5.4-9 and update @types/node to 26.3.0.

## What changed and why

- Add `MotherDuckFlightLogLineRow` for `line_number`, `reported_at`, and `line`.
- Keep `MotherDuckFlightLogsRow`, `mdFlightLogs()`, and `mdJobRunLogs()` backward compatible and deprecated.
- Add generated-SQL coverage and live MotherDuck schema checks for both result shapes.
- Document the migration path and bump the release version.

## Validation

- 658 tests passed, 8 skipped
- Build and TypeScript declarations passed
- Prettier, typecheck, pre-commit, and audit passed
- 17 performance benchmarks completed
- Live MotherDuck integration passed
- npm pack dry-run passed
- Isolated packed-package install and live schema smoke passed