### PR TITLE
Fix unsafe result object assignments

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       "devDependencies": {
         "@duckdb/node-api": "1.5.5-r.4",
         "@types/bun": "1.4.0",
-        "@types/node": "26.3.0",
+        "@types/node": "26.4.0",
         "@vitest/ui": "4.1.11",
         "drizzle-orm": "0.45.2",
         "prettier": "3.8.4",
@@ -113,7 +113,7 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
-    "@types/node": ["@types/node@26.3.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-L3fgrnchriRC2ExBflb8j4uZZURHZfQsmQeyVzhjcHW4kkwVyo8/0h1B2MVzMTrYUJYu6G7EWs14hW/L9putqw=="],
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
 
     "@types/pegjs": ["@types/pegjs@0.10.6", "", {}, "sha512-eLYXDbZWXh2uxf+w8sXS8d6KSoXTswfps6fvCUuVAGN8eRpfe7h9eSRydxiSJvo9Bf+GzifsDOr9TMQlmJdmkw=="],
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
-  "version": "1.5.4-9",
+  "version": "1.5.4-10",
   "description": "A drizzle ORM client for use with DuckDB. Based on drizzle's Postgres client.",
   "type": "module",
   "scripts": {
@@ -30,7 +30,7 @@
   "devDependencies": {
     "@duckdb/node-api": "1.5.5-r.4",
     "@types/bun": "1.4.0",
-    "@types/node": "26.3.0",
+    "@types/node": "26.4.0",
     "@vitest/ui": "4.1.11",
     "drizzle-orm": "0.45.2",
     "prettier": "3.8.4",

--- a/src/client.ts
+++ b/src/client.ts
@@ -21,6 +21,7 @@ import {
   clearPreparedStatementCache,
   getPreparedStatementCache,
 } from './prepared-statement-cache.ts';
+import { assignOwnProperty } from './own-property.ts';
 
 export type DuckDBExecutionClient = DuckDBConnection | PgDuckClient;
 export type DuckDBClientLike = DuckDBExecutionClient | DuckDBConnectionPool;
@@ -602,7 +603,11 @@ function mapRowsToObjects(columns: string[], rows: unknown[][]): RowData[] {
     const row: RowData = {};
 
     for (let columnIndex = 0; columnIndex < columns.length; columnIndex += 1) {
-      row[columns[columnIndex] as string] = values[columnIndex];
+      assignOwnProperty(
+        row,
+        columns[columnIndex] as string,
+        values[columnIndex]
+      );
     }
 
     mappedRows[rowIndex] = row;
@@ -616,14 +621,17 @@ function mapRowsToColumnData(
   rows: unknown[][]
 ): Record<string, unknown[]> {
   const columnData: Record<string, unknown[]> = {};
+  const valuesByColumn: unknown[][] = [];
 
   for (const column of columns) {
-    columnData[column] = [];
+    const values: unknown[] = [];
+    assignOwnProperty(columnData, column, values);
+    valuesByColumn.push(values);
   }
 
   for (const row of rows) {
     for (let index = 0; index < columns.length; index += 1) {
-      columnData[columns[index] as string]?.push(row[index]);
+      valuesByColumn[index]?.push(row[index]);
     }
   }
 

--- a/src/own-property.ts
+++ b/src/own-property.ts
@@ -1,0 +1,17 @@
+export function assignOwnProperty(
+  target: Record<string, unknown>,
+  key: string,
+  value: unknown
+): void {
+  if (key === '__proto__') {
+    Object.defineProperty(target, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    });
+    return;
+  }
+
+  target[key] = value;
+}

--- a/src/sql/result-mapper.ts
+++ b/src/sql/result-mapper.ts
@@ -16,6 +16,7 @@ import {
   PgTimestamp,
   PgTimestampString,
 } from 'drizzle-orm/pg-core';
+import { assignOwnProperty } from '../own-property.ts';
 
 type SQLInternal<T = unknown> = SQL<T> & {
   decoder: DriverValueDecoder<T, any>;
@@ -92,8 +93,12 @@ function trackNullifyTarget(
   tableName: string,
   value: unknown
 ): void {
-  if (!(objectName in nullifyMap)) {
-    nullifyMap[objectName] = value === null ? tableName : false;
+  if (!Object.hasOwn(nullifyMap, objectName)) {
+    assignOwnProperty(
+      nullifyMap,
+      objectName,
+      value === null ? tableName : false
+    );
     return;
   }
 
@@ -341,14 +346,14 @@ function assignResultPath(
   ) {
     const pathChunk = path[pathChunkIndex] as string;
 
-    if (!(pathChunk in node)) {
-      node[pathChunk] = {};
+    if (!Object.hasOwn(node, pathChunk)) {
+      assignOwnProperty(node, pathChunk, {});
     }
 
     node = node[pathChunk] as ResultRow;
   }
 
-  node[path[path.length - 1] as string] = value;
+  assignOwnProperty(node, path[path.length - 1] as string, value);
 }
 
 export function mapResultRow<TResult>(
@@ -356,7 +361,7 @@ export function mapResultRow<TResult>(
   row: unknown[],
   joinsNotNullableMap: Record<string, boolean> | undefined
 ): TResult {
-  const nullifyMap: NullifyMap = {};
+  const nullifyMap = Object.create(null) as NullifyMap;
   const result: ResultRow = {};
 
   for (const [columnIndex, { path, field }] of columns.entries()) {
@@ -373,7 +378,7 @@ export function mapResultRow<TResult>(
   if (joinsNotNullableMap && Object.keys(nullifyMap).length > 0) {
     for (const [objectName, tableName] of Object.entries(nullifyMap)) {
       if (typeof tableName === 'string' && !joinsNotNullableMap[tableName]) {
-        result[objectName] = null;
+        assignOwnProperty(result, objectName, null);
       }
     }
   }

--- a/test/client-execute.test.ts
+++ b/test/client-execute.test.ts
@@ -226,6 +226,26 @@ describe('executeArrowOnClient', () => {
     expect(data).toEqual({ id: [1], name: ['Ada'] });
     expect(calls[0]).toMatchObject({ text: 'select', rowMode: 'array' });
   });
+
+  test('preserves pg_duckdb __proto__ columns as own data properties', async () => {
+    const client: PgDuckClient = {
+      async query() {
+        return {
+          fields: [{ name: '__proto__' }],
+          rows: [[42]],
+        };
+      },
+    };
+
+    const data = (await executeArrowOnClient(client, 'select', [])) as Record<
+      string,
+      unknown[]
+    >;
+
+    expect(Object.getPrototypeOf(data)).toBe(Object.prototype);
+    expect(Object.hasOwn(data, '__proto__')).toBe(true);
+    expect(data['__proto__']).toEqual([42]);
+  });
 });
 
 describe('executeInBatches', () => {

--- a/test/result-object-safety.test.ts
+++ b/test/result-object-safety.test.ts
@@ -1,0 +1,69 @@
+import { DuckDBInstance } from '@duckdb/node-api';
+import { sql } from 'drizzle-orm';
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
+import { drizzle, type DuckDBDatabase } from '../src/driver.ts';
+
+const pollutionMarker = 'drizzleDuckdbPollutionProbe';
+
+let db: DuckDBDatabase;
+let instance: DuckDBInstance;
+
+beforeAll(async () => {
+  instance = await DuckDBInstance.create(':memory:');
+  const connection = await instance.connect();
+  db = drizzle(connection);
+});
+
+afterEach(() => {
+  delete (Object.prototype as Record<string, unknown>)[pollutionMarker];
+});
+
+afterAll(async () => {
+  await db.close();
+  instance.closeSync?.();
+});
+
+test('raw result rows preserve __proto__ as an own data property', async () => {
+  const [row] = await db.execute(
+    sql.raw('select 42 as "__proto__", 7 as "constructor", 9 as normal')
+  );
+
+  expect(Object.getPrototypeOf(row)).toBe(Object.prototype);
+  expect(Object.hasOwn(row, '__proto__')).toBe(true);
+  expect(row?.['__proto__']).toBe(42);
+  expect(row?.constructor).toBe(7);
+  expect(row?.normal).toBe(9);
+});
+
+test('nested selection paths cannot mutate Object.prototype', async () => {
+  const fields = Object.fromEntries([
+    ['__proto__', Object.fromEntries([[pollutionMarker, sql<number>`123`]])],
+    [
+      'constructor',
+      Object.fromEntries([
+        ['prototype', Object.fromEntries([['safe', sql<number>`456`]])],
+      ]),
+    ],
+  ]);
+
+  const [row] = await db.select(fields).from(sql`(select 1) as source`);
+
+  expect(Object.prototype).not.toHaveProperty(pollutionMarker);
+  expect(Object.hasOwn(row, '__proto__')).toBe(true);
+  expect(row?.['__proto__']).toEqual({ [pollutionMarker]: 123 });
+  expect(row?.constructor).toEqual({ prototype: { safe: 456 } });
+});
+
+test('streamed object rows preserve __proto__ columns', async () => {
+  const chunks = [];
+
+  for await (const chunk of db.executeBatches(
+    sql.raw('select 42 as "__proto__"'),
+    { rowsPerChunk: 1 }
+  )) {
+    chunks.push(chunk);
+  }
+
+  expect(Object.hasOwn(chunks[0]?.[0], '__proto__')).toBe(true);
+  expect(chunks[0]?.[0]?.['__proto__']).toBe(42);
+});


### PR DESCRIPTION
## Summary

- preserve `__proto__` result columns as own data properties across materialized, streamed, and pg_duckdb columnar results
- prevent nested selection paths such as `__proto__.value` and `constructor.prototype.value` from traversing inherited objects
- update `@types/node` to 26.4.0 and prepare `1.5.4-10`

## Why

Normal object assignment treats `__proto__` specially. Raw columns with that name were silently lost, while nested selection paths could write through inherited properties into `Object.prototype`.

The fix keeps plain object results for compatibility and uses own-property assignment for special names.

## Validation

- `CI=1 bun test` (662 passed, 8 skipped)
- `bun x tsc --noEmit --project tsconfig.check.json`
- `bun run build`
- `bun x prettier --check .`
- `pre-commit run --all-files`
- `bun audit`
- `bun run bench` (17 benchmarks)
- `npm pack --dry-run`
- isolated install of the `1.5.4-10` tarball with the real DuckDB Node API
- live MotherDuck integration suite and result-safety smoke
