### PR TITLE
refactor(ast): deduplicate generate series ordering

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,7 +39,7 @@ repos:
       # Tests (run on push for faster commits)
       - id: bun-test
         name: Bun test suite
-        entry: bun run test -- run
+        entry: bun run test
         language: system
         pass_filenames: false
         stages: [pre-push]

--- a/src/sql/visitors/generate-series-alias.ts
+++ b/src/sql/visitors/generate-series-alias.ts
@@ -177,6 +177,24 @@ function walkFrom(from: Select['from'], aliases: Set<string>): boolean {
   return transformed;
 }
 
+function walkOrderBy(
+  orderBy: OrderBy[] | null | undefined,
+  aliases: Set<string>
+): boolean {
+  if (!Array.isArray(orderBy)) return false;
+
+  let transformed = false;
+
+  for (const order of orderBy) {
+    if (order.expr) {
+      transformed =
+        walkExpression(order.expr as ExpressionValue, aliases) || transformed;
+    }
+  }
+
+  return transformed;
+}
+
 function walkSelect(select: Select): boolean {
   let transformed = false;
   const aliases = getGenerateSeriesAliases(select.from);
@@ -222,23 +240,8 @@ function walkSelect(select: Select): boolean {
     }
   }
 
-  if (Array.isArray(select.orderby)) {
-    for (const order of select.orderby as OrderBy[]) {
-      if (order.expr) {
-        transformed =
-          walkExpression(order.expr as ExpressionValue, aliases) || transformed;
-      }
-    }
-  }
-
-  if (select._orderby) {
-    for (const order of select._orderby as OrderBy[]) {
-      if (order.expr) {
-        transformed =
-          walkExpression(order.expr as ExpressionValue, aliases) || transformed;
-      }
-    }
-  }
+  transformed = walkOrderBy(select.orderby, aliases) || transformed;
+  transformed = walkOrderBy(select._orderby, aliases) || transformed;
 
   if (select._next) {
     transformed = walkSelect(select._next) || transformed;

--- a/test/generate-series-alias.test.ts
+++ b/test/generate-series-alias.test.ts
@@ -2,6 +2,7 @@ import { DuckDBInstance } from '@duckdb/node-api';
 import { sql } from 'drizzle-orm';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { drizzle, type DuckDBDatabase } from '../src/index.ts';
+import { transformSQL } from '../src/sql/ast-transformer.ts';
 
 let db: DuckDBDatabase;
 let instance: DuckDBInstance;
@@ -23,6 +24,23 @@ afterAll(async () => {
 });
 
 describe('generate_series alias compatibility', () => {
+  test.each([
+    {
+      name: 'ordinary queries',
+      query: 'select gs from generate_series(1, 3) as gs order by gs',
+    },
+    {
+      name: 'compound queries',
+      query:
+        '(select gs from generate_series(1, 3) as gs) union all (select gs from generate_series(1, 3) as gs) order by gs',
+    },
+  ])('rewrites ORDER BY aliases in $name', ({ query }) => {
+    const result = transformSQL(query);
+
+    expect(result.transformed).toBe(true);
+    expect(result.sql).toMatch(/ORDER BY "gs"\.generate_series ASC$/);
+  });
+
   test('rewrites gs::date to gs.generate_series::date', async () => {
     const result = await db
       .select({


### PR DESCRIPTION
The generate_series AST visitor now shares ORDER BY traversal across ordinary and compound queries, with the repository pre-push test gate corrected to run the full suite.

### Codex description

- extract one helper for orderby and _orderby AST fields
- cover ordinary and UNION ALL alias rewriting
- remove the stale duplicate run argument from the pre-push test hook